### PR TITLE
feat: develop 머지 시 소스 브랜치 자동 삭제 워크플로우 추가

### DIFF
--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -1,0 +1,25 @@
+name: Delete merged branch
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+
+jobs:
+  delete-branch:
+    if: github.event.pull_request.merged == true
+      && github.event.pull_request.head.ref != 'develop'
+      && github.event.pull_request.head.ref != 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete head branch
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `heads/${context.payload.pull_request.head.ref}`
+            });


### PR DESCRIPTION
## 📌 관련 이슈
-

## 🔍 작업 내용
develop에 PR이 머지되면 소스 브랜치를 자동으로 삭제하는 워크플로우 추가

## 📝 변경 사항
- `.github/workflows/delete-merged-branch.yml` 추가
- develop으로 머지된 PR의 head 브랜치를 자동 삭제
- develop, main 브랜치는 삭제 대상에서 제외

## 💬 리뷰어에게
머지 후 브랜치가 쌓이는 것을 방지하기 위한 워크플로우입니다.