### PR TITLE
feat: API 클라이언트 배포 시 Discord 알림 추가

### DIFF
--- a/.github/actions/publish-api-client/action.yml
+++ b/.github/actions/publish-api-client/action.yml
@@ -47,7 +47,7 @@ runs:
           -d "{
             \"embeds\": [{
               \"title\": \"🚀 v${{ inputs.version }} 배포 완료\",
-              \"description\": \"API 클라이언트가 npm에 배포되었습니다.\",
+              \"description\": \"API 클라이언트가 npm에 배포되었습니다.\\n\\n\`\`\`\\nnpm install @ject-4-vs-team/api-client@${{ inputs.version }}\\n\`\`\`\",
               \"color\": 5763719,
               \"fields\": [
                 { \"name\": \"Version\", \"value\": \"\`v${{ inputs.version }}\`\", \"inline\": true },

--- a/.github/actions/publish-api-client/action.yml
+++ b/.github/actions/publish-api-client/action.yml
@@ -8,6 +8,12 @@ inputs:
   node-auth-token:
     description: "NPM 토큰"
     required: true
+  discord-webhook-url:
+    description: "Discord Webhook URL"
+    required: true
+  github-repository:
+    description: "GitHub 리포지토리 (owner/repo)"
+    required: true
 
 runs:
   using: composite
@@ -33,3 +39,21 @@ runs:
       run: ./gradlew publishApiClient -PapiClientVersion=${{ inputs.version }}
       env:
         NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+
+    - name: Notify Discord
+      shell: bash
+      run: |
+        curl -H "Content-Type: application/json" \
+          -d "{
+            \"embeds\": [{
+              \"title\": \"🚀 v${{ inputs.version }} 배포 완료\",
+              \"description\": \"API 클라이언트가 npm에 배포되었습니다.\",
+              \"color\": 5763719,
+              \"fields\": [
+                { \"name\": \"Version\", \"value\": \"\`v${{ inputs.version }}\`\", \"inline\": true },
+                { \"name\": \"Package\", \"value\": \"[@ject-4-vs-team/api-client](https://www.npmjs.com/package/@ject-4-vs-team/api-client)\", \"inline\": true },
+                { \"name\": \"Release\", \"value\": \"[GitHub Release](https://github.com/${{ inputs.github-repository }}/releases/tag/v${{ inputs.version }})\", \"inline\": true }
+              ]
+            }]
+          }" \
+          ${{ inputs.discord-webhook-url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,5 @@ jobs:
         with:
           version: ${{ steps.version.outputs.version }}
           node-auth-token: ${{ secrets.NPM_TOKEN }}
+          discord-webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          github-repository: ${{ github.repository }}


### PR DESCRIPTION
## 📌 관련 이슈
-

## 🔍 작업 내용
API 클라이언트가 npm에 배포되면 Discord로 알림을 전송하도록 추가

## 📝 변경 사항
- `publish-api-client` composite action에 Discord 알림 step 추가
- 알림 내용: 버전 정보, npm install 커맨드, npm 패키지 링크, GitHub Release 링크
- `release.yml`에서 Discord webhook URL과 repository 정보를 action에 전달하도록 수정

## 💬 리뷰어에게
Discord webhook URL은 GitHub Secret(`DISCORD_WEBHOOK_URL`)으로 등록되어 있습니다.