### PR TITLE
chore: PR 자동 Assignee 할당, 자동 라벨링 추가

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+feature:
+  - head-branch: ['^feat', 'feat']
+
+bug:
+  - head-branch: ['^fix', 'fix', '^hotfix', 'hotfix']
+
+refactor:
+  - head-branch: ['^refactor', 'refactor']
+
+chore:
+  - head-branch: ['^chore', 'chore', '^docs', 'docs']

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,28 @@
+name: 자동 PR 작성자 할당
+
+on:
+  pull_request:
+    types: [ opened, reopened ]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: 작성자를 할당자에 추가
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                assignees: [context.payload.pull_request.user.login]
+              });
+            } catch (error) {
+              core.setFailed(error.message);
+            }

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,16 @@
+name: 자동 PR 라벨 할당
+
+on:
+  pull_request:
+    types: [ opened, reopened]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>📌 관련 이슈</h2>
<ul>
<li>프로젝트 초기 셋팅 (GitHub Actions 자동화)</li>
</ul>
<h2>🔍 작업 내용</h2>
<p>PR 생성 시 자동으로 Assignee 할당 및 라벨 부착이 되도록 GitHub Actions 워크플로우를 추가합니다.</p>
<hr>
<h2>🗂️ 추가된 파일 설명</h2>
<h3>1. 자동 Assignee 할당 (<code>.github/workflows/auto-assign.yml</code>)</h3>
<p>PR이 열리면(opened) 또는 다시 열리면(reopened) <strong>PR 작성자가 자동으로 Assignee에 등록</strong>됩니다.</p>
<ul>
<li><code>actions/github-script@v7</code>을 사용해서 GitHub API를 직접 호출</li>
<li>수동으로 Assignee 등록하는 걸 까먹을 일이 없어짐</li>
</ul>
<h3>2. 자동 라벨링 (<code>.github/workflows/auto-label.yml</code> + <code>.github/labeler.yml</code>)</h3>
<p>PR이 열리면 <strong>브랜치 이름을 보고 자동으로 라벨을 부착</strong>합니다.</p>

브랜치 이름 | 붙는 라벨 | 예시
-- | -- | --
feat/*, feature/* | feature | feat/login, feature/user-api
fix/*, hotfix/* | bug | fix/jwt-expired, hotfix/payment
refactor/* | refactor | refactor/user-service
chore/*, config/* | chore | chore/docker-compose, config/db


<ul>
<li><code>actions/labeler@v5</code> 사용</li>
<li>라벨 매핑 규칙은 <code>.github/labeler.yml</code>에서 관리</li>
</ul>
<h3>파일 위치</h3>
<pre><code>.github/
├── labeler.yml              ← 라벨 매핑 규칙
└── workflows/
    ├── auto-assign.yml      ← PR 자동 할당
    └── auto-label.yml       ← 자동 라벨링
</code></pre>
<hr>
<h2>📝 변경 사항</h2>
<ul>
<li><code>.github/workflows/auto-assign.yml</code> 추가</li>
<li><code>.github/workflows/auto-label.yml</code> 추가</li>
<li><code>.github/labeler.yml</code> 추가</li>
</ul>

</ul>
<h2>💬 리뷰어에게</h2>
<p>이 PR이 develop에 merge되면, 그 이후부터 모든 PR에서 자동 할당 + 자동 라벨링이 동작합니다.</p></body></html><!--EndFragment-->
</body>
</html>