### PR TITLE
chore: Push CI 워크플로우 추가

### DIFF
--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - chore/ci-push
 
 jobs:
   build:

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -1,0 +1,38 @@
+name: CI - Push
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - chore/ci-push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Repository 접근
+        uses: actions/checkout@v4
+
+      - name: JDK 25 셋팅
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Gradle 의존성 캐싱
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: 프로젝트 빌드
+        run: ./gradlew build


### PR DESCRIPTION
## 📌 관련 이슈
- 프로젝트 초기 셋팅 (CI 파이프라인)

## 🔍 작업 내용
main 및 develop 브랜치에 push 시 자동으로 빌드를 실행하는 CI 워크플로우를 추가합니다.

---

## 🗂️ 추가된 파일 설명

### CI - Push (`.github/workflows/ci-push.yml`)
main 또는 develop 브랜치에 push(merge 포함)되면 자동으로 빌드가 실행됩니다.

**실행 조건**: main, develop 브랜치에 push 시
**실행 내용**:
1. Repository checkout
2. JDK 25 (Temurin) 세팅
3. Gradle 의존성 캐싱 (빌드 속도 향상)
4. `./gradlew build` 실행

**왜 필요한가?**
- PR을 통과하고 merge됐더라도, 다른 PR과 합쳐지면서 충돌이 생길 수 있음
- merge 후 빌드가 깨지면 바로 감지 가능
- develop/main 브랜치가 항상 빌드 가능한 상태를 유지하도록 보장

---

## 📝 변경 사항
- `.github/workflows/ci-push.yml` 추가

## 💬 리뷰어에게
이 PR이 develop에 merge되면, develop에 push될 때마다 자동으로 빌드 검증이 실행됩니다. main은 develop → main merge 후부터 동작합니다.