### PR TITLE
chore: PR 댓글/라벨 CI, main push 배포 워크플로우 수정

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -3,12 +3,15 @@ name: CI - Pull Request
 on:
   issue_comment:
     types: [ created ]
+  pull_request:
+    types: [ labeled ]
 
 jobs:
-  build:
-    name: PR 빌드 검증
+  # 댓글 트리거 빌드
+  build-on-comment:
+    name: PR 빌드 검증 (댓글)
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '빌드 시작') }}
+    if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '빌드 시작') }}
     permissions:
       contents: read
       pull-requests: write
@@ -65,3 +68,70 @@ jobs:
               issue_number: context.issue.number,
               body: message
             });
+
+  # 라벨 트리거 빌드
+  build-on-label:
+    name: PR 빌드 검증 (라벨)
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.label.name == 'ready-to-build' }}
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Repository 접근
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: JDK 25 셋팅
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Gradle 의존성 캐싱
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: 프로젝트 빌드
+        run: ./gradlew build
+
+      - name: 빌드 결과 댓글
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const status = '${{ job.status }}';
+            const message = status === 'success'
+              ? ' **빌드 성공** \n배포 준비 완료!'
+              : ' **빌드 실패** \n코드를 확인해주세요.';
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: message
+            });
+
+      - name: 라벨 제거
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'ready-to-build'
+              });
+            } catch (e) {}

--- a/.github/workflows/cicd-deploy.yml
+++ b/.github/workflows/cicd-deploy.yml
@@ -1,9 +1,8 @@
-name: CI/CD - Release
+name: CI/CD - Deploy
 
 on:
-  release:
-    types:
-      - published
+  push:
+    branches: [ main ]
 
 jobs:
   build-and-deploy:
@@ -44,7 +43,7 @@ jobs:
       - name: Docker 이미지 빌드 & 푸시
         run: |
           IMAGE=${{ secrets.DOCKER_HUB_USERNAME }}/vs-server
-          TAG=${{ github.event.release.tag_name }}
+          TAG=${{ github.sha }}
 
           docker build -t $IMAGE:$TAG .
           docker build -t $IMAGE:latest .
@@ -59,4 +58,4 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             cd /home/ubuntu/app
-            ./deploy.sh ${{ secrets.DOCKER_HUB_USERNAME }}/vs-server:${{ github.event.release.tag_name }}
+            ./deploy.sh ${{ secrets.DOCKER_HUB_USERNAME }}/vs-server:${{ github.sha }}


### PR DESCRIPTION
## 📌 관련 이슈
- 프로젝트 초기 셋팅 (CI/CD 파이프라인)
 
## 🔍 작업 내용
PR 빌드 검증 CI (댓글 + 라벨 트리거)와 main push 시 자동 배포 CD 워크플로우를 추가합니다.
 
---
 
## 🗂️ 추가된 파일 설명
 
### 1. PR 빌드 CI (`.github/workflows/ci-pr.yml`)
PR에서 빌드 검증을 **두 가지 방법**으로 트리거할 수 있습니다.
 
| 방법 | 사용법 | 트리거 이벤트 |
|------|--------|---------------|
| 댓글 | PR 댓글에 **"빌드 시작"** 입력 | `issue_comment` (main 필요) |
| 라벨 | PR에 **`ready-to-build`** 라벨 부착 | `pull_request: labeled` (바로 동작) |
 
**댓글 방식**: main에 워크플로우가 올라간 후부터 동작합니다.
**라벨 방식**: `pull_request` 이벤트이므로 develop에 merge된 후부터 바로 동작합니다.
 
두 방식 모두:
- 해당 PR 브랜치의 코드만 빌드합니다
- 빌드 결과가 PR 댓글로 자동 피드백됩니다
- 라벨 방식은 빌드 완료 후 **라벨이 자동 제거**되어, 다시 붙이면 재실행 가능합니다
 
### 2. 배포 CD (`.github/workflows/cicd-deploy.yml`)
main 브랜치에 push(merge)되면 자동으로 배포가 실행됩니다.
 
**실행 조건**: main 브랜치에 push 시
**배포 흐름**:
```
main에 merge
  ↓
Gradle 빌드
  ↓
Docker 이미지 빌드 & Docker Hub push (커밋 해시 + latest 태그)
  ↓
EC2 SSH 접속 → deploy.sh 실행
  ↓
Blue-Green 무중단 배포 (새 컨테이너 → 헬스체크 → Nginx 전환)
```
 
> **⚠️ 트리거 변경 이유 (release → main push)**
>
> 원래는 GitHub Release가 publish되면 배포가 실행되도록 `on: release: [published]` 트리거를 사용하려 했습니다.
> 하지만 팀원의 `release.yml`이 `GITHUB_TOKEN`으로 Release를 자동 생성하는 구조이기 때문에 문제가 발생합니다.
>
> GitHub Actions에는 **`GITHUB_TOKEN`으로 만든 이벤트는 다른 워크플로우를 트리거하지 않는다**는 보안 정책이 있습니다.
> 이는 워크플로우 간 무한 루프를 방지하기 위한 것입니다.
>
> 따라서 Release 트리거 대신 **main push 트리거**로 변경하여,
> main에 merge되는 시점에 배포가 자동 실행되도록 했습니다.
 
**main push 시 동시 실행되는 워크플로우**:
| 워크플로우 | 역할 | 병렬 실행 |
|---|---|---|
| `release.yml` (팀원) | GitHub Release 생성 + npm 배포 | ✅ |
| `cicd-deploy.yml` (이 PR) | Docker 빌드 + EC2 서버 배포 | ✅ |
 
**필요한 GitHub Secrets** (서버 세팅 후 등록):
| Secret | 설명 |
|--------|------|
| `DOCKER_HUB_USERNAME` | Docker Hub 아이디 |
| `DOCKER_HUB_PASSWORD` | Docker Hub Access Token |
| `EC2_HOST` | EC2 퍼블릭 IP |
| `EC2_USERNAME` | EC2 접속 유저명 |
| `EC2_SSH_KEY` | EC2 SSH 키 (.pem 내용) |
 
---
 
## ⚠️ 참고 사항
- `ci-pr.yml`의 댓글 트리거(`issue_comment`)는 **main에 merge되어야 동작**합니다
- `ci-pr.yml`의 라벨 트리거(`pull_request: labeled`)는 **develop에 merge되면 바로 동작**합니다
- `cicd-deploy.yml`은 main push 트리거이므로 **main에 merge되어야 동작**합니다
- 배포는 GitHub Secrets + EC2 서버 세팅이 완료되어야 정상 동작합니다
- GitHub Labels에 **`ready-to-build`** 라벨을 추가해야 합니다
 
---
 
## 📝 변경 사항
- `.github/workflows/ci-pr.yml` 추가
- `.github/workflows/cicd-deploy.yml` 추가
 
## 🧪 테스트 결과
- [ ] 라벨 CI: develop merge 후 PR에 `ready-to-build` 라벨 부착하여 테스트 예정
- [ ] 댓글 CI: main merge 후 "빌드 시작" 댓글로 테스트 예정
- [ ] 배포: 서버 세팅 완료 후 테스트 예정