### PR TITLE
chore: Docker 빌드 환경 및 Actuator 설정 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# ===== 빌드 스테이지 =====
+FROM gradle:8.14-jdk25 AS build
+WORKDIR /app
+
+# 의존성 먼저 복사 (캐싱 활용)
+COPY build.gradle.kts settings.gradle.kts ./
+COPY buildSrc ./buildSrc
+COPY gradle ./gradle
+RUN gradle dependencies --no-daemon || true
+
+# 소스 코드 복사 & 빌드
+COPY src ./src
+RUN gradle bootJar --no-daemon
+
+# ===== 실행 스테이지 =====
+FROM eclipse-temurin:25-jre
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 	implementation(Dependencies.SpringBoot.SECURITY)
 	implementation(Dependencies.SpringBoot.VALIDATION)
 	implementation(Dependencies.SpringBoot.WEB)
+	implementation(Dependencies.SpringBoot.ACTUATOR)
 
 	// Database
 	runtimeOnly(Dependencies.Database.H2)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,6 +1,7 @@
 object Dependencies {
 
     object SpringBoot {
+        const val ACTUATOR = "org.springframework.boot:spring-boot-starter-actuator"
         const val DATA_JPA = "org.springframework.boot:spring-boot-starter-data-jpa"
         const val SECURITY = "org.springframework.boot:spring-boot-starter-security"
         const val VALIDATION = "org.springframework.boot:spring-boot-starter-validation"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,8 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never


### PR DESCRIPTION
## 📌 관련 이슈
- CD 서버 배포 환경 구축

## 🔍 작업 내용
EC2 Blue-Green 무중단 배포를 위한 Spring Boot 프로젝트 설정을 추가합니다.

## 📝 변경 사항
- `build.gradle.kts`에 Actuator 의존성 추가 (헬스체크 엔드포인트 `/actuator/health` 활성화)
- `application-prod.yml` 생성 (운영 환경 프로필 설정, health 엔드포인트만 노출)
- `Dockerfile` 생성 (멀티 스테이지 빌드: Gradle 빌드 → JRE 실행 이미지)

## 💬 리뷰어에게
배포 스크립트(`deploy.sh`)가 `/actuator/health`로 헬스체크를 하기 때문에 Actuator가 필수입니다. Dockerfile은 `buildSrc` 폴더도 복사하도록 구성했고, `SPRING_PROFILES_ACTIVE=prod`를 기본값으로 설정해뒀습니다. GitHub Secrets(Docker Hub, EC2 접속 정보) 등록은 따로 진행해 두었습니다.