### PR TITLE
fix: Dockerfile 빌드 이미지 수정 및 HEALTHCHECK 추가

### DIFF
--- a/.github/workflows/cicd-deploy.yml
+++ b/.github/workflows/cicd-deploy.yml
@@ -2,7 +2,7 @@ name: CI/CD - Deploy
 
 on:
   push:
-    branches: [ main, fix/dockerfile]
+    branches: [ main ]
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/cicd-deploy.yml
+++ b/.github/workflows/cicd-deploy.yml
@@ -2,7 +2,7 @@ name: CI/CD - Deploy
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, fix/dockerfile]
 
 jobs:
   build-and-deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,8 @@ FROM eclipse-temurin:25-jre
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 
+HEALTHCHECK --interval=5s --timeout=3s --start-period=30s --retries=10 \
+  CMD curl -f http://localhost:8080/actuator/health || exit 1
+
 EXPOSE 8080
 ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ===== 빌드 스테이지 =====
-FROM gradle:8.14-jdk25 AS build
+FROM gradle:jdk25 AS build
 WORKDIR /app
 
 # 의존성 먼저 복사 (캐싱 활용)

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ FROM eclipse-temurin:25-jre
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
 HEALTHCHECK --interval=5s --timeout=3s --start-period=30s --retries=10 \
   CMD curl -f http://localhost:8080/actuator/health || exit 1
 

--- a/src/main/java/com/ject/vs/config/SecurityConfig.java
+++ b/src/main/java/com/ject/vs/config/SecurityConfig.java
@@ -18,7 +18,8 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
-                                "/api/**"
+                                "/api/**",
+                                "/actuator/health"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 📌 관련 이슈
- CD 배포 파이프라인 안정화

## 🔍 작업 내용
Dockerfile 빌드 실패 수정 및 Docker HEALTHCHECK를 추가하고, SecurityConfig에 헬스체크 엔드포인트를 허용했습니다.

## 📝 변경 사항
- Dockerfile: `gradle:8.14-jdk25` → `gradle:jdk25`로 변경 (기존 이미지가 Docker Hub에 존재하지 않아 빌드 실패)
- Dockerfile: curl 설치 및 HEALTHCHECK 추가 (deploy.sh에서 컨테이너 상태 기반으로 헬스체크하기 위함)
- SecurityConfig: `/actuator/health` 엔드포인트 permitAll 추가 (HEALTHCHECK가 인증 없이 접근 가능하도록)

## 💬 리뷰어에게
기존에는 deploy.sh가 직접 curl로 헬스체크했는데, Dockerfile에 HEALTHCHECK를 넣고 deploy.sh에서는 Docker 컨테이너 상태만 확인하는 방식으로 변경했습니다. 이렇게 하면 배포 시점뿐 아니라 운영 중에도 Docker가 계속 헬스체크를 수행하고, `docker ps`에서 healthy/unhealthy 상태를 바로 확인할 수 있습니다.