### PR TITLE
chore: 버전 계산 job 추가 및 워크플로우 의존성 개선

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,10 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  calculate-version:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - uses: actions/checkout@v4
@@ -20,15 +22,33 @@ jobs:
         id: version
         uses: ./.github/actions/calculate-version
 
+  release:
+    needs: calculate-version
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Create GitHub Release
-        run: gh release create "v${{ steps.version.outputs.version }}" --generate-notes
+        run: gh release create "v${{ needs.calculate-version.outputs.version }}" --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-api-client:
+    needs: calculate-version
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Publish API Client
         uses: ./.github/actions/publish-api-client
         with:
-          version: ${{ steps.version.outputs.version }}
+          version: ${{ needs.calculate-version.outputs.version }}
           node-auth-token: ${{ secrets.NPM_TOKEN }}
           discord-webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           github-repository: ${{ github.repository }}


### PR DESCRIPTION
## 📌 관련 이슈


## 🔍 작업 내용
Release 워크플로우 최적화 - 버전 계산을 별도 job으로 분리하고 배포 작업을 병렬화

## 📝 변경 사항
- **버전 계산 job 분리**: `calculate-version` job을 추가하여 버전을 한 번만 계산하고 outputs로 공유
- **배포 작업 병렬화**: `release`와 `publish-api-client` job을 분리하여 GitHub Release 생성과 API Client 배포가 동시에 진행되도록 개선
- **워크플로우 의존성 설정**: `needs: calculate-version`을 통해 버전 계산 후 배포 작업들이 병렬로 실행되도록 구성

## 💬 리뷰어에게
워크플로우 실행 순서는 `calculate-version` → (`release` + `publish-api-client` 병렬 실행) 입니다.