### PR TITLE
refactor: 배포 파이프라인 개선 (Docker 네트워크 DNS 기반 blue/green)

### DIFF
--- a/.github/workflows/cicd-deploy.yml
+++ b/.github/workflows/cicd-deploy.yml
@@ -1,16 +1,25 @@
 name: CI/CD - Deploy
 
 on:
-  push:
-    branches: [ main ]
+  workflow_run:
+    workflows: ["Create Release"]
+    types:
+      - completed
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Repository 접근
         uses: actions/checkout@v4
+
+      - name: 최신 릴리즈 태그 가져오기
+        id: release
+        run: echo "tag=$(gh release view --json tagName -q '.tagName')" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Hub 로그인
         uses: docker/login-action@v3
@@ -21,7 +30,7 @@ jobs:
       - name: Docker 이미지 빌드 & 푸시
         run: |
           IMAGE=${{ secrets.DOCKER_HUB_USERNAME }}/vs-server
-          TAG=${{ github.sha }}
+          TAG=${{ steps.release.outputs.tag }}
 
           docker build -t $IMAGE:$TAG .
           docker tag $IMAGE:$TAG $IMAGE:latest
@@ -36,4 +45,4 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             curl -fsSL https://raw.githubusercontent.com/JECT-Study/JECT2-4th-Server/main/scripts/deploy.sh \
-              | bash -s ${{ secrets.DOCKER_HUB_USERNAME }}/vs-server:${{ github.sha }}
+              | bash -s ${{ secrets.DOCKER_HUB_USERNAME }}/vs-server:${{ steps.release.outputs.tag }}

--- a/.github/workflows/cicd-deploy.yml
+++ b/.github/workflows/cicd-deploy.yml
@@ -12,28 +12,6 @@ jobs:
       - name: Repository 접근
         uses: actions/checkout@v4
 
-      - name: JDK 25 셋팅
-        uses: actions/setup-java@v4
-        with:
-          java-version: '25'
-          distribution: 'temurin'
-
-      - name: Gradle 의존성 캐싱
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: 프로젝트 빌드
-        run: ./gradlew build
-
       - name: Docker Hub 로그인
         uses: docker/login-action@v3
         with:
@@ -46,7 +24,7 @@ jobs:
           TAG=${{ github.sha }}
 
           docker build -t $IMAGE:$TAG .
-          docker build -t $IMAGE:latest .
+          docker tag $IMAGE:$TAG $IMAGE:latest
           docker push $IMAGE:$TAG
           docker push $IMAGE:latest
 
@@ -57,5 +35,5 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            cd /home/ubuntu/app
-            ./deploy.sh ${{ secrets.DOCKER_HUB_USERNAME }}/vs-server:${{ github.sha }}
+            curl -fsSL https://raw.githubusercontent.com/JECT-Study/JECT2-4th-Server/main/scripts/deploy.sh \
+              | bash -s ${{ secrets.DOCKER_HUB_USERNAME }}/vs-server:${{ github.sha }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+services:
+  nginx:
+    image: nginx:latest
+    container_name: nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/app.conf:/etc/nginx/conf.d/default.conf
+    networks:
+      - app-network
+    restart: unless-stopped
+
+networks:
+  app-network:
+    name: app-network
+    driver: bridge

--- a/nginx/app.conf
+++ b/nginx/app.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+
+    location / {
+        proxy_pass http://app:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+IMAGE=$1
+BLUE_PORT=8080
+GREEN_PORT=8081
+
+# 현재 활성 포트 확인
+CURRENT_PORT=$(cat /home/ubuntu/app/current_port 2>/dev/null || echo $BLUE_PORT)
+
+if [ "$CURRENT_PORT" == "$BLUE_PORT" ]; then
+    NEW_PORT=$GREEN_PORT
+    NEW_CONTAINER="green"
+    OLD_CONTAINER="blue"
+else
+    NEW_PORT=$BLUE_PORT
+    NEW_CONTAINER="blue"
+    OLD_CONTAINER="green"
+fi
+
+echo ">>> 현재: $CURRENT_PORT → 새로운: $NEW_PORT"
+
+# 새 이미지 pull
+echo ">>> 이미지 pull 중..."
+docker pull $IMAGE
+
+# 새 컨테이너 실행
+echo ">>> 새 컨테이너($NEW_CONTAINER) 실행 중..."
+docker run -d --name $NEW_CONTAINER \
+    -p $NEW_PORT:8080 \
+    -e SPRING_PROFILES_ACTIVE=prod \
+    $IMAGE
+
+# Docker 헬스체크 상태 확인 방식
+echo ">>> 헬스체크 시작..."
+for i in {1..60}; do
+    STATUS=$(docker inspect --format='{{.State.Health.Status}}' $NEW_CONTAINER 2>/dev/null || echo "starting")
+    if [ "$STATUS" == "healthy" ]; then
+        echo ">>> 헬스체크 통과! (${i}초)"
+        break
+    fi
+    if [ $i -eq 60 ]; then
+        echo ">>> 헬스체크 실패! 롤백합니다."
+        docker stop $NEW_CONTAINER && docker rm $NEW_CONTAINER
+        exit 1
+    fi
+    sleep 1
+done
+
+# Nginx 트래픽 전환
+echo ">>> Nginx 트래픽 전환 중..."
+sudo sed -i "s/server 127.0.0.1:[0-9]*/server 127.0.0.1:$NEW_PORT/" /etc/nginx/conf.d/app.conf
+sudo nginx -s reload
+
+# 이전 컨테이너 정리
+echo ">>> 이전 컨테이너($OLD_CONTAINER) 정리 중..."
+docker stop $OLD_CONTAINER 2>/dev/null && docker rm $OLD_CONTAINER 2>/dev/null
+
+# 현재 포트 기록
+echo $NEW_PORT > /home/ubuntu/app/current_port
+
+# 오래된 Docker 이미지 정리
+docker image prune -f
+
+echo ">>> 배포 완료! 활성 포트: $NEW_PORT"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,63 +1,75 @@
 #!/bin/bash
 IMAGE=$1
-BLUE_PORT=8080
-GREEN_PORT=8081
 
-# 현재 활성 포트 확인
-CURRENT_PORT=$(cat /home/ubuntu/app/current_port 2>/dev/null || echo $BLUE_PORT)
-
-if [ "$CURRENT_PORT" == "$BLUE_PORT" ]; then
-    NEW_PORT=$GREEN_PORT
-    NEW_CONTAINER="green"
-    OLD_CONTAINER="blue"
-else
-    NEW_PORT=$BLUE_PORT
-    NEW_CONTAINER="blue"
-    OLD_CONTAINER="green"
+if [ -z "$IMAGE" ]; then
+  echo ">>> 사용법: ./deploy.sh <이미지명:태그>"
+  exit 1
 fi
 
-echo ">>> 현재: $CURRENT_PORT → 새로운: $NEW_PORT"
+NETWORK="app-network"
+
+# 현재 활성 컨테이너 확인
+CURRENT=$(cat /home/ubuntu/app/current_container 2>/dev/null || echo "")
+
+if [ "$CURRENT" == "app-blue" ]; then
+  NEW_CONTAINER="app-green"
+  OLD_CONTAINER="app-blue"
+else
+  NEW_CONTAINER="app-blue"
+  OLD_CONTAINER="app-green"
+fi
+
+echo ">>> 현재: ${OLD_CONTAINER:-없음} → 새로운: $NEW_CONTAINER"
 
 # 새 이미지 pull
 echo ">>> 이미지 pull 중..."
 docker pull $IMAGE
 
-# 새 컨테이너 실행
+# 혹시 남아있는 동일 이름 컨테이너 정리
+docker stop $NEW_CONTAINER 2>/dev/null && docker rm $NEW_CONTAINER 2>/dev/null
+
+# 새 컨테이너 실행 (네트워크 연결 없이)
 echo ">>> 새 컨테이너($NEW_CONTAINER) 실행 중..."
 docker run -d --name $NEW_CONTAINER \
-    -p $NEW_PORT:8080 \
-    -e SPRING_PROFILES_ACTIVE=prod \
-    $IMAGE
+  -e SPRING_PROFILES_ACTIVE=prod \
+  --health-cmd="curl -f http://localhost:8080/actuator/health || exit 1" \
+  --health-interval=5s \
+  --health-timeout=3s \
+  --health-start-period=30s \
+  --health-retries=10 \
+  $IMAGE
 
-# Docker 헬스체크 상태 확인 방식
+# 헬스체크 (docker inspect로 healthy 상태 확인)
 echo ">>> 헬스체크 시작..."
-for i in {1..60}; do
-    STATUS=$(docker inspect --format='{{.State.Health.Status}}' $NEW_CONTAINER 2>/dev/null || echo "starting")
-    if [ "$STATUS" == "healthy" ]; then
-        echo ">>> 헬스체크 통과! (${i}초)"
-        break
-    fi
-    if [ $i -eq 60 ]; then
-        echo ">>> 헬스체크 실패! 롤백합니다."
-        docker stop $NEW_CONTAINER && docker rm $NEW_CONTAINER
-        exit 1
-    fi
-    sleep 1
+for i in $(seq 1 60); do
+  STATUS=$(docker inspect --format='{{.State.Health.Status}}' $NEW_CONTAINER 2>/dev/null)
+  if [ "$STATUS" == "healthy" ]; then
+    echo ">>> 헬스체크 통과! (${i}초)"
+    break
+  fi
+  if [ $i -eq 60 ]; then
+    echo ">>> 헬스체크 실패! 롤백합니다."
+    docker stop $NEW_CONTAINER && docker rm $NEW_CONTAINER
+    exit 1
+  fi
+  sleep 1
 done
 
-# Nginx 트래픽 전환
-echo ">>> Nginx 트래픽 전환 중..."
-sudo sed -i "s/server 127.0.0.1:[0-9]*/server 127.0.0.1:$NEW_PORT/" /etc/nginx/conf.d/app.conf
-sudo nginx -s reload
+# 새 컨테이너를 네트워크에 연결 (app alias 부여 → 이 순간 트래픽 전환)
+echo ">>> 트래픽 전환 중..."
+docker network connect --alias app $NETWORK $NEW_CONTAINER
 
-# 이전 컨테이너 정리
-echo ">>> 이전 컨테이너($OLD_CONTAINER) 정리 중..."
-docker stop $OLD_CONTAINER 2>/dev/null && docker rm $OLD_CONTAINER 2>/dev/null
+# 이전 컨테이너 네트워크에서 분리 + 정리
+if [ -n "$CURRENT" ]; then
+  echo ">>> 이전 컨테이너($OLD_CONTAINER) 정리 중..."
+  docker network disconnect $NETWORK $OLD_CONTAINER 2>/dev/null
+  docker stop $OLD_CONTAINER 2>/dev/null && docker rm $OLD_CONTAINER 2>/dev/null
+fi
 
-# 현재 포트 기록
-echo $NEW_PORT > /home/ubuntu/app/current_port
+# 현재 컨테이너 기록
+echo $NEW_CONTAINER > /home/ubuntu/app/current_container
 
 # 오래된 Docker 이미지 정리
 docker image prune -f
 
-echo ">>> 배포 완료! 활성 포트: $NEW_PORT"
+echo ">>> 배포 완료! 활성 컨테이너: $NEW_CONTAINER"


### PR DESCRIPTION
📌 관련 이슈
* 배포 파이프라인 개선 피드백 반영

🔍 작업 내용
팀원 피드백을 반영하여 배포 구조를 전면 개선합니다.
- Nginx를 호스트 설치에서 Docker 컨테이너로 전환
- 포트 스위칭(8080/8081) 방식에서 Docker 네트워크 DNS 기반 blue/green으로 전환
- 서버에만 존재하던 deploy.sh를 GitHub 레포로 이동하여 Git 관리
- GitHub Actions 중복 빌드 제거 및 curl | bash 배포 방식 적용
- 배포 트리거를 릴리즈 기반(workflow_run)으로 변경

📝 변경 사항
커밋 히스토리를 순서대로 확인해주세요.

1. 기존 deploy.sh를 레포에 추가 (현재 상태 스냅샷)
2. docker-compose.yaml + nginx 설정 추가 (Nginx 컨테이너화)
3. deploy.sh를 Docker 네트워크 DNS 기반 blue/green으로 리팩토링
4. GitHub Actions 중복 빌드 제거 및 curl | bash 배포 전환
5. 배포 트리거를 Create Release workflow_run 기반으로 변경

💬 리뷰어에게
이전 방식은 Nginx 호스트 직접 설치 + sed로 포트 교체 + deploy.sh가 서버에만 존재하는 구조였습니다.
개선 후에는 Nginx도 Docker 컨테이너로 띄우고, Docker 네트워크 DNS alias(app)를 활용하여 Nginx 설정 변경 없이 컨테이너 교체만으로 무중단 배포가 가능합니다.
또한 배포 트리거를 main push에서 릴리즈 기반으로 변경하여, 릴리즈 태그(v1.0.0)가 Docker 이미지 태그로 사용됩니다.
커밋 단위로 변경 과정을 남겨두었으니 순서대로 확인 부탁드립니다.