### PR TITLE
Restore user subject assignment for OAuth sign-in

### DIFF
--- a/src/main/java/com/ject/vs/domain/User.java
+++ b/src/main/java/com/ject/vs/domain/User.java
@@ -2,7 +2,6 @@ package com.ject.vs.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.Setter;
 
 @Entity
 @Getter
@@ -10,6 +9,13 @@ import lombok.Setter;
 public class User {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private String sub;
     // 아직 유저에 대한 정보 확정 아님
+
+    public static User createWithSub(String sub) {
+        User user = new User();
+        user.sub = sub;
+        return user;
+    }
 }

--- a/src/main/java/com/ject/vs/service/UserService.java
+++ b/src/main/java/com/ject/vs/service/UserService.java
@@ -14,11 +14,7 @@ public class UserService {
 
     public User findOrCreate(String sub) {
         return userRepository.findBySub(sub)
-                .orElseGet(() -> {
-                    User user = new User();
-                    user.setSub(sub);
-                    return userRepository.save(user);
-                });
+                .orElseGet(() -> userRepository.save(User.createWithSub(sub)));
     }
 
     public User getBySub(String sub) {      // 추후에 예외처리 통합


### PR DESCRIPTION
## 요약
- `UserService.findOrCreate()`에서 신규 사용자 생성 시 OAuth subject를 저장해야 하는데, `User` 엔티티가 해당 생성 경로를 제공하지 않아 CI 컴파일이 실패하던 문제를 수정했습니다.
- setter/update 메서드가 아니라 `User.createWithSub(sub)` 정적 팩토리로 신규 사용자를 생성하도록 변경했습니다.

## 원인
- GitHub Actions `build-and-deploy`와 `publish-api-client` 모두 `compileJava` 단계에서 아래 에러로 실패했습니다.

```text
UserService.java:19: error: cannot find symbol
user.setSub(sub);
symbol: method setSub(String)
```

## 변경 사항
- `User.createWithSub(String sub)` 정적 팩토리 추가
- `UserService`에서 `new User()` 후 setter/update 호출 대신 `User.createWithSub(sub)` 사용

## 검증
- `./gradlew compileJava --no-daemon`
- `./gradlew bootJar --no-daemon`

## 참고
- setter 방식은 generic mutation을 열기 때문에 제외했습니다.
- `updateSub` 방식도 신규 생성 책임이 서비스에 남기 때문에 정적 팩토리로 대체했습니다.
- `publishApiClient`는 이전 로컬 실행에서 컴파일 단계는 통과했지만 `extractSwagger` 서버 기동 대기 60초 타임아웃이 있었습니다. 이번 PR은 액션 로그상 직접 실패 원인이었던 컴파일 에러를 해결합니다.