### PR TITLE
배포 헬스 체크 대기 시간을 완화한다

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,15 @@ jobs:
 
       - name: 서버 배포
         uses: appleboy/ssh-action@v1.0.3
+        env:
+          APP_JWT_SECRET: ${{ secrets.APP_JWT_SECRET }}
+          APP_JWT_ACCESS_TOKEN_EXPIRATION_SECONDS: 3600
+          APP_JWT_REFRESH_TOKEN_EXPIRATION_SECONDS: 1209600
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          envs: APP_JWT_SECRET,APP_JWT_ACCESS_TOKEN_EXPIRATION_SECONDS,APP_JWT_REFRESH_TOKEN_EXPIRATION_SECONDS
           script: |
             curl -fsSL https://raw.githubusercontent.com/JECT-Study/JECT2-4th-Server/main/scripts/setup-docker-nginx.sh \
               | bash

--- a/scripts/app.env.example
+++ b/scripts/app.env.example
@@ -1,7 +1,11 @@
-# 서버의 /home/ubuntu/app/.env 로 복사해서 실제 운영 값을 채워 넣으세요.
-# 이 파일에는 실제 secret 값을 커밋하지 않습니다.
+# 배포 시 GitHub Actions secrets으로 주입되는 값 목록입니다.
+# 아래 두 값은 GitHub repository secrets에 등록해야 합니다:
+#   APP_JWT_SECRET                  — Settings > Secrets and variables > Actions
+#   APP_OAUTH2_REDIRECT_SUCCESS_URL — Settings > Secrets and variables > Actions
+#
+# 아래 두 값은 release.yml에 하드코딩되어 있습니다 (secrets 불필요):
+#   APP_JWT_ACCESS_TOKEN_EXPIRATION_SECONDS=3600
+#   APP_JWT_REFRESH_TOKEN_EXPIRATION_SECONDS=1209600
 
 APP_JWT_SECRET=<base64-encoded-hmac-secret>
-APP_JWT_ACCESS_TOKEN_EXPIRATION_SECONDS=3600
-APP_JWT_REFRESH_TOKEN_EXPIRATION_SECONDS=1209600
 APP_OAUTH2_REDIRECT_SUCCESS_URL=https://example.com/oauth2/redirect

--- a/scripts/app.env.example
+++ b/scripts/app.env.example
@@ -1,0 +1,7 @@
+# 서버의 /home/ubuntu/app/.env 로 복사해서 실제 운영 값을 채워 넣으세요.
+# 이 파일에는 실제 secret 값을 커밋하지 않습니다.
+
+APP_JWT_SECRET=<base64-encoded-hmac-secret>
+APP_JWT_ACCESS_TOKEN_EXPIRATION_SECONDS=3600
+APP_JWT_REFRESH_TOKEN_EXPIRATION_SECONDS=1209600
+APP_OAUTH2_REDIRECT_SUCCESS_URL=https://example.com/oauth2/redirect

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,7 +11,6 @@ fi
 APP_DIR="${APP_DIR:-/home/ubuntu/app}"
 NETWORK="${NETWORK:-app-network}"
 NGINX_CONTAINER="${NGINX_CONTAINER:-nginx}"
-ENV_FILE="${ENV_FILE:-$APP_DIR/.env}"
 HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-180}"
 HEALTH_LOG_INTERVAL_SECONDS="${HEALTH_LOG_INTERVAL_SECONDS:-10}"
 
@@ -28,19 +27,10 @@ cleanup_new_container() {
 
 mkdir -p "$APP_DIR"
 
-if [ -f "$ENV_FILE" ]; then
-  log "환경 변수 파일 로드: $ENV_FILE"
-  set -a
-  # shellcheck disable=SC1090
-  . "$ENV_FILE"
-  set +a
-fi
-
 REQUIRED_ENV_VARS=(
   APP_JWT_SECRET
   APP_JWT_ACCESS_TOKEN_EXPIRATION_SECONDS
   APP_JWT_REFRESH_TOKEN_EXPIRATION_SECONDS
-  APP_OAUTH2_REDIRECT_SUCCESS_URL
 )
 
 MISSING_ENV_VARS=()
@@ -52,7 +42,7 @@ done
 
 if [ "${#MISSING_ENV_VARS[@]}" -gt 0 ]; then
   echo ">>> 필수 운영 환경 변수가 없습니다: ${MISSING_ENV_VARS[*]}" >&2
-  echo ">>> $ENV_FILE 파일에 값을 설정한 뒤 다시 배포하세요." >&2
+  echo ">>> GitHub Actions secrets 또는 환경 변수로 값을 설정한 뒤 다시 배포하세요." >&2
   exit 1
 fi
 
@@ -100,7 +90,6 @@ docker run -d --name "$NEW_CONTAINER" \
   -e APP_JWT_SECRET \
   -e APP_JWT_ACCESS_TOKEN_EXPIRATION_SECONDS \
   -e APP_JWT_REFRESH_TOKEN_EXPIRATION_SECONDS \
-  -e APP_OAUTH2_REDIRECT_SUCCESS_URL \
   --health-cmd="curl -f http://localhost:8080/actuator/health || exit 1" \
   --health-interval=10s \
   --health-timeout=5s \

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,6 +11,9 @@ fi
 APP_DIR="${APP_DIR:-/home/ubuntu/app}"
 NETWORK="${NETWORK:-app-network}"
 NGINX_CONTAINER="${NGINX_CONTAINER:-nginx}"
+ENV_FILE="${ENV_FILE:-$APP_DIR/.env}"
+HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-180}"
+HEALTH_LOG_INTERVAL_SECONDS="${HEALTH_LOG_INTERVAL_SECONDS:-10}"
 
 log() {
   echo ">>> $*"
@@ -24,6 +27,34 @@ cleanup_new_container() {
 }
 
 mkdir -p "$APP_DIR"
+
+if [ -f "$ENV_FILE" ]; then
+  log "환경 변수 파일 로드: $ENV_FILE"
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+fi
+
+REQUIRED_ENV_VARS=(
+  APP_JWT_SECRET
+  APP_JWT_ACCESS_TOKEN_EXPIRATION_SECONDS
+  APP_JWT_REFRESH_TOKEN_EXPIRATION_SECONDS
+  APP_OAUTH2_REDIRECT_SUCCESS_URL
+)
+
+MISSING_ENV_VARS=()
+for ENV_VAR in "${REQUIRED_ENV_VARS[@]}"; do
+  if [ -z "${!ENV_VAR:-}" ]; then
+    MISSING_ENV_VARS+=("$ENV_VAR")
+  fi
+done
+
+if [ "${#MISSING_ENV_VARS[@]}" -gt 0 ]; then
+  echo ">>> 필수 운영 환경 변수가 없습니다: ${MISSING_ENV_VARS[*]}" >&2
+  echo ">>> $ENV_FILE 파일에 값을 설정한 뒤 다시 배포하세요." >&2
+  exit 1
+fi
 
 docker network inspect "$NETWORK" >/dev/null 2>&1 || docker network create "$NETWORK" >/dev/null
 
@@ -66,35 +97,52 @@ fi
 log "새 컨테이너($NEW_CONTAINER) 실행 중"
 docker run -d --name "$NEW_CONTAINER" \
   -e SPRING_PROFILES_ACTIVE=prod \
+  -e APP_JWT_SECRET \
+  -e APP_JWT_ACCESS_TOKEN_EXPIRATION_SECONDS \
+  -e APP_JWT_REFRESH_TOKEN_EXPIRATION_SECONDS \
+  -e APP_OAUTH2_REDIRECT_SUCCESS_URL \
   --health-cmd="curl -f http://localhost:8080/actuator/health || exit 1" \
-  --health-interval=5s \
-  --health-timeout=3s \
-  --health-start-period=30s \
-  --health-retries=10 \
+  --health-interval=10s \
+  --health-timeout=5s \
+  --health-start-period=90s \
+  --health-retries=18 \
   "$IMAGE" >/dev/null
 
 # 헬스체크 (docker inspect로 healthy 상태 확인)
-log "헬스체크 시작"
-for i in $(seq 1 60); do
-  STATUS=$(docker inspect --format='{{.State.Health.Status}}' "$NEW_CONTAINER" 2>/dev/null || echo "missing")
+# Docker health status가 start-period 직후 일시적으로 unhealthy가 될 수 있어
+# unhealthy 즉시 실패 대신 전체 타임아웃까지 여유 있게 대기한다.
+log "헬스체크 시작 (최대 ${HEALTH_TIMEOUT_SECONDS}초)"
+HEALTH_PASSED=false
+for i in $(seq 1 "$HEALTH_TIMEOUT_SECONDS"); do
+  RUNNING=$(docker inspect --format='{{.State.Running}}' "$NEW_CONTAINER" 2>/dev/null || echo "false")
+  STATUS=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}unknown{{end}}' "$NEW_CONTAINER" 2>/dev/null || echo "missing")
+
+  if [ "$RUNNING" != "true" ]; then
+    echo ">>> 새 컨테이너가 실행 중이 아닙니다. 롤백합니다." >&2
+    docker logs --tail=100 "$NEW_CONTAINER" >&2 || true
+    cleanup_new_container
+    exit 1
+  fi
+
   if [ "$STATUS" = "healthy" ]; then
     log "헬스체크 통과! (${i}초)"
+    HEALTH_PASSED=true
     break
   fi
-  if [ "$STATUS" = "unhealthy" ]; then
-    echo ">>> 헬스체크 unhealthy. 롤백합니다." >&2
-    docker logs --tail=100 "$NEW_CONTAINER" >&2 || true
-    cleanup_new_container
-    exit 1
+
+  if [ $((i % HEALTH_LOG_INTERVAL_SECONDS)) -eq 0 ]; then
+    log "헬스체크 대기 중... status=$STATUS (${i}/${HEALTH_TIMEOUT_SECONDS}초)"
   fi
-  if [ "$i" -eq 60 ]; then
-    echo ">>> 헬스체크 타임아웃. 롤백합니다." >&2
-    docker logs --tail=100 "$NEW_CONTAINER" >&2 || true
-    cleanup_new_container
-    exit 1
-  fi
+
   sleep 1
 done
+
+if [ "$HEALTH_PASSED" != "true" ]; then
+  echo ">>> 헬스체크 타임아웃. 롤백합니다." >&2
+  docker logs --tail=100 "$NEW_CONTAINER" >&2 || true
+  cleanup_new_container
+  exit 1
+fi
 
 # 새 컨테이너를 네트워크에 연결 (app alias 부여 → 이 순간 트래픽 전환)
 log "트래픽 전환 중"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,3 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:proddb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: false
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  flyway:
+    enabled: true
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## 변경 사항
- Docker 헬스 체크 start-period를 90초로 늘리고 전체 대기 시간을 기본 180초로 확장했습니다.
- 컨테이너가 일시적으로 `unhealthy`가 되어도 즉시 롤백하지 않고 타임아웃까지 계속 대기하도록 변경했습니다.
- 다만 컨테이너 프로세스가 종료되면 기존처럼 즉시 로그를 출력하고 롤백합니다.
- 서버의 `/home/ubuntu/app/.env` 파일을 로드해 운영 환경 변수를 컨테이너에 주입하도록 했습니다.
- JWT/OAuth 리다이렉트 필수 값이 없으면 애플리케이션 크래시 전에 배포 스크립트가 명확히 실패하도록 했습니다.
- 운영 환경 변수 예시 파일 `scripts/app.env.example`을 추가했습니다.

## 확인한 내용
- 이번 액션 실패는 헬스 체크가 너무 빨라서가 아니라, prod 컨테이너에서 `APP_JWT_SECRET` 값이 없어 `JwtProvider` 초기화가 실패한 것이 직접 원인이었습니다.
- 현재 서버는 기존 `app-blue` 컨테이너가 계속 살아 있고 `/actuator/health` 응답도 `UP`입니다.

## 검증
- `bash -n scripts/deploy.sh`
- `SPRING_PROFILES_ACTIVE=prod` 및 필수 env 주입 상태에서 `./gradlew test --tests com.ject.vs.VsServerApplicationTests.contextLoads --no-daemon` 통과

## 배포 전 필요한 서버 설정
서버에 `/home/ubuntu/app/.env` 파일을 만들고 아래 값을 실제 운영 값으로 채워야 합니다.

```env
APP_JWT_SECRET=...
APP_JWT_ACCESS_TOKEN_EXPIRATION_SECONDS=3600
APP_JWT_REFRESH_TOKEN_EXPIRATION_SECONDS=1209600
APP_OAUTH2_REDIRECT_SUCCESS_URL=...
```