### PR TITLE
운영 환경 OAuth2 리다이렉트 URL 임시값 설정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,6 +13,13 @@ spring:
   flyway:
     enabled: true
 
+app:
+  oauth2:
+    # 운영 도메인 확정 후 실제 URL로 교체 필요 (관련 이슈: #43)
+    redirect-success-url: https://example.com/oauth2/redirect
+  cookie:
+    secure: true
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## 변경 사항

`app.oauth2.redirect-success-url` 값이 `prod` 프로파일에 없어 `OAuth2LoginSuccessHandler` 빈 생성이 실패하는 문제를 수정합니다.

## 원인

`@Value("${app.oauth2.redirect-success-url}")` 주입 시 `prod` 프로파일에 해당 키가 없어 컨텍스트 로드 실패

## 해결

`application-prod.yml`에 placeholder URL을 하드코딩하여 빈 생성 오류 방지

## 남은 작업

- 운영 도메인 확정 후 실제 URL로 교체 필요
- 관련 이슈: #43