### PR TITLE
Fix OpenAPI client generation JWT filter handling

### DIFF
--- a/src/main/java/com/ject/vs/config/JwtAuthFilter.java
+++ b/src/main/java/com/ject/vs/config/JwtAuthFilter.java
@@ -13,15 +13,51 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
+    private static final List<String> JWT_EXCLUDED_PATHS = List.of(
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/api/**",
+            "/actuator/health",
+            "/",
+            "/error",
+            "/auth/reissue"
+    );
+
     private final JwtProvider jwtProvider;
     private final CookieUtil cookieUtil;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    @Override
+    protected boolean shouldNotFilter(@NonNull HttpServletRequest request) {
+        String path = getRequestPath(request);
+        return JWT_EXCLUDED_PATHS.stream()
+                .anyMatch(pattern -> pathMatcher.match(pattern, path));
+    }
+
+    private String getRequestPath(HttpServletRequest request) {
+        String servletPath = request.getServletPath();
+        if (StringUtils.hasText(servletPath)) {
+            return servletPath;
+        }
+
+        String requestUri = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (StringUtils.hasText(contextPath) && requestUri.startsWith(contextPath)) {
+            return requestUri.substring(contextPath.length());
+        }
+        return requestUri;
+    }
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
@@ -30,12 +66,15 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         String accessToken = cookieUtil.getCookieValue(request, CookieUtil.CookieType.ACCESS_TOKEN);
 
+        if (!StringUtils.hasText(accessToken) || !jwtProvider.validationToken(accessToken)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         var tokenInfo = jwtProvider.parseToken(accessToken);
 
-        if (accessToken != null
-                && tokenInfo.isAccessToken()
+        if (tokenInfo.isAccessToken()
                 && SecurityContextHolder.getContext().getAuthentication() == null) {
-
 
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(

--- a/src/main/resources/application-openapi.yaml
+++ b/src/main/resources/application-openapi.yaml
@@ -1,7 +1,43 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:openapi;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE
+    url: jdbc:h2:mem:openapi;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: false
   jpa:
     hibernate:
       ddl-auto: create-drop
+  flyway:
+    enabled: false
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: openapi-dummy-client-id
+            client-secret: openapi-dummy-client-secret
+            scope:
+              - email
+              - profile
+
+app:
+  jwt:
+    secret: NHk7ya+qk5IVD/24BO7/BLFfdpqrZ6bSw/J9EyQDP7uCHtoF9NxD7OUwiHpiqt+MsxQd5eOcCknYJhvF+N8AVg==
+    access-token-expiration-seconds: 3600
+    refresh-token-expiration-seconds: 1209600
+  oauth2:
+    redirect-success-url: http://localhost:3000/oauth2/redirect
+  cookie:
+    secure: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/src/test/java/com/ject/vs/config/JwtAuthFilterTest.java
+++ b/src/test/java/com/ject/vs/config/JwtAuthFilterTest.java
@@ -1,0 +1,80 @@
+package com.ject.vs.config;
+
+import com.ject.vs.domain.TokenType;
+import com.ject.vs.dto.TokenInfo;
+import com.ject.vs.util.CookieUtil;
+import com.ject.vs.util.JwtProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class JwtAuthFilterTest {
+    private final JwtProvider jwtProvider = mock(JwtProvider.class);
+    private final CookieUtil cookieUtil = mock(CookieUtil.class);
+    private final JwtAuthFilter filter = new JwtAuthFilter(jwtProvider, cookieUtil);
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void skipsJwtProcessingForExcludedPaths() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v3/api-docs");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        verifyNoInteractions(cookieUtil, jwtProvider);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void continuesWithoutAuthenticationWhenAccessTokenIsMissing() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/chat/messages");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        when(cookieUtil.getCookieValue(request, CookieUtil.CookieType.ACCESS_TOKEN)).thenReturn(null);
+
+        filter.doFilter(request, response, chain);
+
+        verify(jwtProvider, never()).parseToken(null);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void setsAuthenticationForValidAccessToken() throws ServletException, IOException {
+        String accessToken = "access-token";
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/chat/messages");
+        request.setCookies(new Cookie(CookieUtil.CookieType.ACCESS_TOKEN, accessToken));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        when(cookieUtil.getCookieValue(request, CookieUtil.CookieType.ACCESS_TOKEN)).thenReturn(accessToken);
+        when(jwtProvider.validationToken(accessToken)).thenReturn(true);
+        when(jwtProvider.parseToken(accessToken))
+                .thenReturn(new TokenInfo(accessToken, TokenType.ACCESS, LocalDateTime.now().plusMinutes(10), 1L));
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal()).isEqualTo(1L);
+    }
+}


### PR DESCRIPTION
## Summary
- Add deterministic `openapi` profile defaults so `extractSwagger` can boot without external secrets
- Replace profile-gated `JwtAuthFilter` activation with explicit JWT-excluded paths
- Add unit coverage for excluded paths, missing tokens, and valid access tokens

## Verification
- `./gradlew test --stacktrace`
- `./gradlew generateApiClient --rerun-tasks --stacktrace`
- `cd generated-api-client && npm install && npm run build`

## Not tested
- `npm publish` was not run locally to avoid publishing a package.