### PR TITLE
채팅 API OpenAPI 명세 추가

### DIFF
--- a/src/main/java/com/ject/vs/chat/adapter/web/ChatController.java
+++ b/src/main/java/com/ject/vs/chat/adapter/web/ChatController.java
@@ -13,12 +13,13 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/chats")
 @RequiredArgsConstructor
-public class ChatController {
+public class ChatController implements ChatDocs {
 
     private final ChatQueryUseCase chatQueryUseCase;
     private final ChatCommandUseCase chatCommandUseCase;
 
     @GetMapping
+    @Override
     public ChatListResponse getChatList(@AuthenticationPrincipal Long userId,
                                         @RequestParam VoteStatus status) {
         return new ChatListResponse(
@@ -29,17 +30,20 @@ public class ChatController {
     }
 
     @GetMapping("/{voteId}")
+    @Override
     public ChatRoomResponse getChatRoom(@AuthenticationPrincipal Long userId,
                                         @PathVariable Long voteId) {
         return ChatRoomResponse.from(chatQueryUseCase.getChatRoom(voteId));
     }
 
     @GetMapping("/{voteId}/gauge")
+    @Override
     public GaugeResponse getGauge(@PathVariable Long voteId) {
         return GaugeResponse.from(chatQueryUseCase.getGauge(voteId));
     }
 
     @GetMapping("/{voteId}/messages")
+    @Override
     public MessagePageResponse getMessages(@PathVariable Long voteId,
                                            @AuthenticationPrincipal Long userId,
                                            @RequestParam(required = false) Long cursor,
@@ -49,6 +53,7 @@ public class ChatController {
 
     @PostMapping("/{voteId}/messages")
     @ResponseStatus(HttpStatus.CREATED)
+    @Override
     public MessageResponse sendMessage(@PathVariable Long voteId,
                                        @AuthenticationPrincipal Long userId,
                                        @RequestBody @Valid SendMessageRequest request) {
@@ -58,6 +63,7 @@ public class ChatController {
 
     @PostMapping("/{voteId}/read")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Override
     public void markAsRead(@PathVariable Long voteId,
                            @AuthenticationPrincipal Long userId,
                            @RequestBody @Valid MarkAsReadRequest request) {

--- a/src/main/java/com/ject/vs/chat/adapter/web/ChatDocs.java
+++ b/src/main/java/com/ject/vs/chat/adapter/web/ChatDocs.java
@@ -1,0 +1,127 @@
+package com.ject.vs.chat.adapter.web;
+
+import com.ject.vs.chat.adapter.web.dto.ChatListResponse;
+import com.ject.vs.chat.adapter.web.dto.ChatRoomResponse;
+import com.ject.vs.chat.adapter.web.dto.GaugeResponse;
+import com.ject.vs.chat.adapter.web.dto.MarkAsReadRequest;
+import com.ject.vs.chat.adapter.web.dto.MessagePageResponse;
+import com.ject.vs.chat.adapter.web.dto.MessageResponse;
+import com.ject.vs.chat.adapter.web.dto.SendMessageRequest;
+import com.ject.vs.vote.port.in.dto.VoteStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Chat", description = "채팅 API")
+public interface ChatDocs {
+
+    @Operation(
+            summary = "채팅방 목록 조회",
+            description = "로그인 사용자가 참여한 채팅방을 투표 진행 상태별로 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "채팅방 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ChatListResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content)
+    })
+    ChatListResponse getChatList(
+            @Parameter(hidden = true) Long userId,
+            @Parameter(description = "조회할 투표 상태", required = true, example = "ONGOING", schema = @Schema(allowableValues = {"ONGOING", "ENDED"}))
+            VoteStatus status
+    );
+
+    @Operation(
+            summary = "채팅방 상세 조회",
+            description = "채팅방 상단에 표시할 투표 제목, 진행 상태, 선택지, 참여자 수, 종료 시간을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "채팅방 상세 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ChatRoomResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 투표 또는 채팅방", content = @Content)
+    })
+    ChatRoomResponse getChatRoom(
+            @Parameter(hidden = true) Long userId,
+            @Parameter(description = "채팅방이 연결된 투표 ID", required = true, example = "1") Long voteId
+    );
+
+    @Operation(
+            summary = "투표 게이지 조회",
+            description = "채팅방에서 표시할 A/B 선택지 투표 비율과 참여자 수를 조회합니다. 비율 값은 0부터 100까지의 정수입니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "투표 게이지 조회 성공",
+                    content = @Content(schema = @Schema(implementation = GaugeResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 투표", content = @Content)
+    })
+    GaugeResponse getGauge(
+            @Parameter(description = "게이지를 조회할 투표 ID", required = true, example = "1") Long voteId
+    );
+
+    @Operation(
+            summary = "채팅 메시지 목록 조회",
+            description = "채팅방 메시지를 커서 기반으로 조회합니다. cursor가 없으면 최신 메시지 기준으로 조회하고, nextCursor와 hasNext로 다음 페이지 요청 여부를 판단합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "채팅 메시지 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = MessagePageResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "403", description = "채팅방 접근 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 투표 또는 채팅방", content = @Content)
+    })
+    MessagePageResponse getMessages(
+            @Parameter(description = "메시지를 조회할 투표 ID", required = true, example = "1") Long voteId,
+            @Parameter(hidden = true) Long userId,
+            @Parameter(description = "이전 페이지의 nextCursor. 첫 조회 시 생략합니다.", example = "128") Long cursor,
+            @Parameter(description = "조회할 메시지 수", example = "30") int size
+    );
+
+    @Operation(
+            summary = "채팅 메시지 전송",
+            description = "채팅방에 새 메시지를 전송하고 저장된 메시지 정보를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "채팅 메시지 전송 성공",
+                    content = @Content(schema = @Schema(implementation = MessageResponse.class))),
+            @ApiResponse(responseCode = "400", description = "메시지 내용이 비어 있거나 유효하지 않음", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "403", description = "채팅방 접근 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 투표 또는 채팅방", content = @Content)
+    })
+    MessageResponse sendMessage(
+            @Parameter(description = "메시지를 전송할 투표 ID", required = true, example = "1") Long voteId,
+            @Parameter(hidden = true) Long userId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "전송할 메시지 내용",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = SendMessageRequest.class))
+            )
+            SendMessageRequest request
+    );
+
+    @Operation(
+            summary = "채팅방 읽음 처리",
+            description = "사용자가 마지막으로 읽은 메시지 ID를 저장해 이후 채팅방 목록의 unreadCount 계산에 사용합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "읽음 처리 성공", content = @Content),
+            @ApiResponse(responseCode = "400", description = "마지막 읽은 메시지 ID가 유효하지 않음", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "403", description = "채팅방 접근 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 투표, 채팅방 또는 메시지", content = @Content)
+    })
+    void markAsRead(
+            @Parameter(description = "읽음 처리할 투표 ID", required = true, example = "1") Long voteId,
+            @Parameter(hidden = true) Long userId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "마지막으로 읽은 메시지 ID",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = MarkAsReadRequest.class))
+            )
+            MarkAsReadRequest request
+    );
+}

--- a/src/main/java/com/ject/vs/chat/adapter/web/dto/ChatListItemResponse.java
+++ b/src/main/java/com/ject/vs/chat/adapter/web/dto/ChatListItemResponse.java
@@ -1,19 +1,40 @@
 package com.ject.vs.chat.adapter.web.dto;
 
 import com.ject.vs.chat.port.in.dto.ChatListItemResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
 
+@Schema(description = "채팅방 목록 항목 응답")
 public record ChatListItemResponse(
+        @Schema(description = "채팅방이 연결된 투표 ID", example = "1")
         Long voteId,
+
+        @Schema(description = "투표 제목", example = "오늘 점심 메뉴는?")
         String title,
+
+        @Schema(description = "투표 썸네일 이미지 URL", example = "https://cdn.example.com/votes/1/thumbnail.png", nullable = true)
         String thumbnailUrl,
+
+        @Schema(description = "A 선택지 이름", example = "김치찌개")
         String optionA,
+
+        @Schema(description = "B 선택지 이름", example = "된장찌개")
         String optionB,
+
+        @Schema(description = "투표 참여자 수", example = "42")
         int participantCount,
+
+        @Schema(description = "채팅방의 마지막 메시지 내용", example = "저는 A가 좋아요", nullable = true)
         String lastMessage,
+
+        @Schema(description = "마지막 메시지가 전송된 시각. UTC 기준으로 내려가며 사용자 시간대에 맞춰 변환이 필요합니다.", example = "2026-05-01T06:30:00Z", nullable = true)
         Instant lastMessageAt,
+
+        @Schema(description = "투표 종료 시각. UTC 기준으로 내려가며 사용자 시간대에 맞춰 변환이 필요합니다.", example = "2026-05-02T15:00:00Z")
         Instant endAt,
+
+        @Schema(description = "현재 사용자가 아직 읽지 않은 메시지 수", example = "3")
         int unreadCount
 ) {
     public static ChatListItemResponse from(ChatListItemResult result) {

--- a/src/main/java/com/ject/vs/chat/adapter/web/dto/ChatListResponse.java
+++ b/src/main/java/com/ject/vs/chat/adapter/web/dto/ChatListResponse.java
@@ -1,5 +1,11 @@
 package com.ject.vs.chat.adapter.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
-public record ChatListResponse(List<ChatListItemResponse> chats) {}
+@Schema(description = "채팅방 목록 응답")
+public record ChatListResponse(
+        @Schema(description = "조회된 채팅방 목록")
+        List<ChatListItemResponse> chats
+) {}

--- a/src/main/java/com/ject/vs/chat/adapter/web/dto/ChatRoomResponse.java
+++ b/src/main/java/com/ject/vs/chat/adapter/web/dto/ChatRoomResponse.java
@@ -2,16 +2,31 @@ package com.ject.vs.chat.adapter.web.dto;
 
 import com.ject.vs.chat.port.in.dto.ChatRoomResult;
 import com.ject.vs.vote.port.in.dto.VoteStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
 
+@Schema(description = "채팅방 상세 응답")
 public record ChatRoomResponse(
+        @Schema(description = "채팅방이 연결된 투표 ID", example = "1")
         Long voteId,
+
+        @Schema(description = "투표 제목", example = "오늘 점심 메뉴는?")
         String title,
+
+        @Schema(description = "투표 진행 상태", example = "ONGOING", allowableValues = {"ONGOING", "ENDED"})
         VoteStatus status,
+
+        @Schema(description = "투표 참여자 수", example = "42")
         int participantCount,
+
+        @Schema(description = "A 선택지 이름", example = "김치찌개")
         String optionA,
+
+        @Schema(description = "B 선택지 이름", example = "된장찌개")
         String optionB,
+
+        @Schema(description = "투표 종료 시각. UTC 기준으로 내려가며 사용자 시간대에 맞춰 변환이 필요합니다.", example = "2026-05-02T15:00:00Z")
         Instant endAt
 ) {
     public static ChatRoomResponse from(ChatRoomResult result) {

--- a/src/main/java/com/ject/vs/chat/adapter/web/dto/GaugeResponse.java
+++ b/src/main/java/com/ject/vs/chat/adapter/web/dto/GaugeResponse.java
@@ -1,8 +1,19 @@
 package com.ject.vs.chat.adapter.web.dto;
 
 import com.ject.vs.chat.port.in.dto.GaugeResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record GaugeResponse(int optionARatio, int optionBRatio, int participantCount) {
+@Schema(description = "투표 게이지 응답")
+public record GaugeResponse(
+        @Schema(description = "A 선택지 투표 비율. 0부터 100까지의 정수입니다.", example = "55", minimum = "0", maximum = "100")
+        int optionARatio,
+
+        @Schema(description = "B 선택지 투표 비율. 0부터 100까지의 정수입니다.", example = "45", minimum = "0", maximum = "100")
+        int optionBRatio,
+
+        @Schema(description = "투표 참여자 수", example = "42")
+        int participantCount
+) {
 
     public static GaugeResponse from(GaugeResult result) {
         return new GaugeResponse(result.optionARatio(), result.optionBRatio(), result.participantCount());

--- a/src/main/java/com/ject/vs/chat/adapter/web/dto/MarkAsReadRequest.java
+++ b/src/main/java/com/ject/vs/chat/adapter/web/dto/MarkAsReadRequest.java
@@ -1,5 +1,11 @@
 package com.ject.vs.chat.adapter.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-public record MarkAsReadRequest(@NotNull Long lastReadMessageId) {}
+@Schema(description = "채팅방 읽음 처리 요청")
+public record MarkAsReadRequest(
+        @Schema(description = "현재 사용자가 마지막으로 읽은 메시지 ID", example = "128", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
+        Long lastReadMessageId
+) {}

--- a/src/main/java/com/ject/vs/chat/adapter/web/dto/MessagePageResponse.java
+++ b/src/main/java/com/ject/vs/chat/adapter/web/dto/MessagePageResponse.java
@@ -1,10 +1,21 @@
 package com.ject.vs.chat.adapter.web.dto;
 
 import com.ject.vs.chat.port.in.dto.MessagePageResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-public record MessagePageResponse(List<MessageResponse> messages, Long nextCursor, boolean hasNext) {
+@Schema(description = "채팅 메시지 페이지 응답")
+public record MessagePageResponse(
+        @Schema(description = "조회된 메시지 목록")
+        List<MessageResponse> messages,
+
+        @Schema(description = "다음 페이지 조회에 사용할 커서. 다음 페이지가 없으면 null입니다.", example = "96", nullable = true)
+        Long nextCursor,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext
+) {
 
     public static MessagePageResponse from(MessagePageResult result) {
         List<MessageResponse> responses = result.messages().stream()

--- a/src/main/java/com/ject/vs/chat/adapter/web/dto/MessageResponse.java
+++ b/src/main/java/com/ject/vs/chat/adapter/web/dto/MessageResponse.java
@@ -1,16 +1,31 @@
 package com.ject.vs.chat.adapter.web.dto;
 
 import com.ject.vs.chat.port.in.dto.MessageResult;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
 
+@Schema(description = "채팅 메시지 응답")
 public record MessageResponse(
+        @Schema(description = "채팅 메시지 ID", example = "128")
         Long messageId,
+
+        @Schema(description = "메시지 내용", example = "저는 A가 좋아요")
         String content,
+
+        @Schema(description = "메시지 전송 시각. UTC 기준으로 내려가며 사용자 시간대에 맞춰 변환이 필요합니다.", example = "2026-05-01T06:30:00Z")
         Instant sentAt,
+
+        @Schema(description = "메시지를 보낸 사용자의 닉네임", example = "승부사")
         String senderNickname,
+
+        @Schema(description = "메시지를 보낸 사용자의 프로필 아이콘", example = "https://cdn.example.com/profile-icons/rabbit.png", nullable = true)
         String senderProfileIcon,
+
+        @Schema(description = "메시지를 보낸 사용자가 선택한 투표 선택지", example = "A", allowableValues = {"A", "B"}, nullable = true)
         String senderVoteOption,
+
+        @Schema(description = "현재 로그인 사용자가 보낸 메시지인지 여부", example = "false")
         boolean isMine
 ) {
     public static MessageResponse from(MessageResult result) {

--- a/src/main/java/com/ject/vs/chat/adapter/web/dto/SendMessageRequest.java
+++ b/src/main/java/com/ject/vs/chat/adapter/web/dto/SendMessageRequest.java
@@ -1,5 +1,11 @@
 package com.ject.vs.chat.adapter.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
-public record SendMessageRequest(@NotBlank String content) {}
+@Schema(description = "채팅 메시지 전송 요청")
+public record SendMessageRequest(
+        @Schema(description = "전송할 메시지 내용", example = "저는 A가 좋아요", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
+        String content
+) {}


### PR DESCRIPTION
## 요약
- 채팅 API 설명을 `ChatDocs` 인터페이스로 분리했습니다.
- 채팅 request/response DTO 필드에 `@Schema` 설명과 예시를 추가했습니다.
- `Instant` 시간 필드는 UTC 기준 응답 및 사용자 시간대 변환 필요성을 명시했습니다.

## 검증
- `./gradlew compileJava`

## 참고
- `extractSwagger` 및 npm 클라이언트 생성은 실행하지 않았습니다.