### PR TITLE
chore: add api HTTPS deployment workflow

### DIFF
--- a/.github/workflows/https-cert.yml
+++ b/.github/workflows/https-cert.yml
@@ -1,0 +1,39 @@
+name: Issue HTTPS Certificate
+
+on:
+  workflow_dispatch:
+    inputs:
+      domain:
+        description: "인증서를 발급할 도메인"
+        required: true
+        default: "api.vs.io.kr"
+      certbot_email:
+        description: "Let's Encrypt 알림 이메일(선택)"
+        required: false
+        default: ""
+      staging:
+        description: "Let's Encrypt staging 사용 여부"
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  issue-cert:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 서버에서 HTTPS 인증서 발급/갱신 설정
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          DOMAIN: ${{ inputs.domain }}
+          CERTBOT_EMAIL: ${{ inputs.certbot_email }}
+          CERTBOT_STAGING: ${{ inputs.staging }}
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          envs: DOMAIN,CERTBOT_EMAIL,CERTBOT_STAGING
+          script: |
+            curl -fsSL https://raw.githubusercontent.com/JECT-Study/JECT2-4th-Server/main/scripts/setup-docker-nginx.sh \
+              | bash
+            curl -fsSL https://raw.githubusercontent.com/JECT-Study/JECT2-4th-Server/main/scripts/issue-https-cert.sh \
+              | bash

--- a/.github/workflows/https-cert.yml
+++ b/.github/workflows/https-cert.yml
@@ -1,6 +1,8 @@
 name: Issue HTTPS Certificate
 
 on:
+  schedule:
+    - cron: "0 0 1 * *"
   workflow_dispatch:
     inputs:
       domain:
@@ -24,9 +26,9 @@ jobs:
       - name: 서버에서 HTTPS 인증서 발급/갱신 설정
         uses: appleboy/ssh-action@v1.0.3
         env:
-          DOMAIN: ${{ inputs.domain }}
-          CERTBOT_EMAIL: ${{ inputs.certbot_email }}
-          CERTBOT_STAGING: ${{ inputs.staging }}
+          DOMAIN: ${{ inputs.domain || 'api.vs.io.kr' }}
+          CERTBOT_EMAIL: ${{ inputs.certbot_email || '' }}
+          CERTBOT_STAGING: ${{ inputs.staging || false }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,8 +4,11 @@ services:
     container_name: nginx
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./nginx/app.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./certbot/www:/var/www/certbot:ro
+      - ./certbot/conf:/etc/letsencrypt:ro
     networks:
       - app-network
     restart: unless-stopped

--- a/docs/https-deployment.md
+++ b/docs/https-deployment.md
@@ -1,0 +1,75 @@
+# api.vs.io.kr HTTPS 배포/인증서 발급 워크플로우
+
+## 구조
+
+- Route53: `api.vs.io.kr` A 레코드가 EC2 public IP를 가리켜야 합니다.
+- NGINX: Docker 컨테이너가 80/443을 열고 Spring Boot 앱 컨테이너(`app:8080`)로 프록시합니다.
+- 인증서: Let's Encrypt HTTP-01 webroot challenge를 사용합니다.
+- 인증서 파일 위치(서버): `/home/ubuntu/app/certbot/conf`
+- ACME challenge webroot(서버): `/home/ubuntu/app/certbot/www`
+
+## 사전 준비
+
+Route53에서 `api.vs.io.kr` A 레코드가 EC2 public IP를 가리키고 있어야 합니다.
+또한 EC2 보안 그룹/방화벽에서 80, 443 포트가 열려 있어야 합니다.
+
+DNS 설정은 이 저장소의 배포 스크립트에서 변경하지 않습니다.
+
+## 서버 최초 세팅 + 인증서 발급(수동)
+
+EC2에 SSH 접속 후 실행합니다.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/JECT-Study/JECT2-4th-Server/main/scripts/setup-docker-nginx.sh | bash
+curl -fsSL https://raw.githubusercontent.com/JECT-Study/JECT2-4th-Server/main/scripts/issue-https-cert.sh \
+  | CERTBOT_EMAIL=team@example.com bash
+```
+
+이 스크립트는 다음을 수행합니다.
+
+1. 인증서가 없으면 HTTP bootstrap NGINX 설정을 적용합니다.
+2. `http://api.vs.io.kr/.well-known/acme-challenge/...` 접근성을 확인합니다.
+3. `certbot/certbot` Docker 이미지로 Let's Encrypt 인증서를 발급합니다.
+4. HTTPS NGINX 설정으로 교체하고 reload 합니다.
+5. 매일 03:17에 인증서 renew 후 NGINX reload 하는 cron을 등록합니다.
+
+> 이메일 없이 발급하려면 `CERTBOT_EMAIL`을 생략할 수 있습니다. 테스트 발급은 `CERTBOT_STAGING=true`를 함께 지정하세요.
+
+## GitHub Actions에서 수동 발급
+
+`Actions` → `Issue HTTPS Certificate` → `Run workflow`를 실행합니다.
+
+필요 secrets:
+
+- `EC2_HOST`
+- `EC2_USERNAME`
+- `EC2_SSH_KEY`
+
+입력값:
+
+- `domain`: 기본 `api.vs.io.kr`
+- `certbot_email`: Let's Encrypt 알림 이메일(선택)
+- `staging`: 테스트 발급 여부
+
+## 일반 배포 시 동작
+
+`release.yml`의 서버 배포 단계는 매번 `scripts/setup-docker-nginx.sh`를 먼저 실행합니다.
+
+- 인증서가 없으면 HTTP 설정(`nginx/http.conf`)으로 NGINX를 기동합니다.
+- 인증서가 있으면 HTTPS 설정(`nginx/app.conf`)으로 NGINX를 기동합니다.
+
+따라서 최초 인증서 발급 이후에는 일반 배포만으로 HTTPS 설정이 유지됩니다.
+
+## 점검 명령
+
+```bash
+curl -I http://api.vs.io.kr
+curl -I https://api.vs.io.kr
+ssh ubuntu@<EC2_HOST> 'cd /home/ubuntu/app && docker compose ps nginx && docker exec nginx nginx -t'
+```
+
+정상 상태:
+
+- `http://api.vs.io.kr` → `301 https://api.vs.io.kr/...`
+- `https://api.vs.io.kr` → 앱 응답 또는 Spring Security 응답
+- `docker exec nginx nginx -t` → successful

--- a/nginx/app.conf
+++ b/nginx/app.conf
@@ -1,5 +1,28 @@
 server {
     listen 80;
+    server_name api.vs.io.kr;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        default_type "text/plain";
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name api.vs.io.kr;
+
+    ssl_certificate /etc/letsencrypt/live/api.vs.io.kr/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.vs.io.kr/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
 
     resolver 127.0.0.11 valid=5s ipv6=off;
     set $app_upstream app:8080;
@@ -9,7 +32,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_connect_timeout 10s;
         proxy_read_timeout 60s;
         proxy_send_timeout 60s;

--- a/nginx/http.conf
+++ b/nginx/http.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+    server_name api.vs.io.kr;
+
+    resolver 127.0.0.11 valid=5s ipv6=off;
+    set $app_upstream app:8080;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        default_type "text/plain";
+    }
+
+    location / {
+        proxy_pass http://$app_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
+    }
+}

--- a/scripts/issue-https-cert.sh
+++ b/scripts/issue-https-cert.sh
@@ -70,18 +70,29 @@ if [ "$CERTBOT_STAGING" = "true" ]; then
   STAGING_ARGS=(--staging)
 fi
 
-log "Let's Encrypt 인증서 발급: $DOMAIN"
-docker run --rm \
-  -v "$APP_DIR/certbot/conf:/etc/letsencrypt" \
-  -v "$APP_DIR/certbot/www:/var/www/certbot" \
-  certbot/certbot certonly \
-  --webroot \
-  --webroot-path /var/www/certbot \
-  --domain "$DOMAIN" \
-  --agree-tos \
-  --non-interactive \
-  "${EMAIL_ARGS[@]}" \
-  "${STAGING_ARGS[@]}"
+if [ ! -f "$APP_DIR/certbot/conf/live/$DOMAIN/fullchain.pem" ]; then
+  log "Let's Encrypt 인증서 신규 발급: $DOMAIN"
+  docker run --rm \
+    -v "$APP_DIR/certbot/conf:/etc/letsencrypt" \
+    -v "$APP_DIR/certbot/www:/var/www/certbot" \
+    certbot/certbot certonly \
+    --webroot \
+    --webroot-path /var/www/certbot \
+    --domain "$DOMAIN" \
+    --agree-tos \
+    --non-interactive \
+    "${EMAIL_ARGS[@]}" \
+    "${STAGING_ARGS[@]}"
+else
+  log "Let's Encrypt 인증서 갱신 시도: $DOMAIN"
+  docker run --rm \
+    -v "$APP_DIR/certbot/conf:/etc/letsencrypt" \
+    -v "$APP_DIR/certbot/www:/var/www/certbot" \
+    certbot/certbot renew \
+    --webroot \
+    --webroot-path /var/www/certbot \
+    --quiet
+fi
 
 log "HTTPS nginx 설정 적용"
 curl -fsSL "$REPO_RAW_BASE/nginx/app.conf" | sed "s/api.vs.io.kr/$DOMAIN/g" > "$APP_DIR/nginx/app.conf"
@@ -89,27 +100,4 @@ docker compose up -d nginx
 docker exec "$NGINX_CONTAINER" nginx -t
 docker exec "$NGINX_CONTAINER" nginx -s reload
 
-log "인증서 자동 갱신 cron 등록"
-RENEW_SCRIPT="$APP_DIR/renew-https-cert.sh"
-cat > "$RENEW_SCRIPT" <<RENEW_EOF
-#!/bin/bash
-set -euo pipefail
-cd "$APP_DIR"
-docker run --rm \\
-  -v "$APP_DIR/certbot/conf:/etc/letsencrypt" \\
-  -v "$APP_DIR/certbot/www:/var/www/certbot" \\
-  certbot/certbot renew --webroot --webroot-path /var/www/certbot --quiet
-if docker ps --format '{{.Names}}' | grep -qx "$NGINX_CONTAINER"; then
-  docker exec "$NGINX_CONTAINER" nginx -s reload >/dev/null 2>&1 || true
-fi
-RENEW_EOF
-chmod +x "$RENEW_SCRIPT"
-
-CRON_LINE="17 3 * * * $RENEW_SCRIPT >> $APP_DIR/certbot/renew.log 2>&1"
-TMP_CRON=$(mktemp)
-{ crontab -l 2>/dev/null || true; } | grep -vF "$RENEW_SCRIPT" > "$TMP_CRON" || true
-echo "$CRON_LINE" >> "$TMP_CRON"
-crontab "$TMP_CRON"
-rm -f "$TMP_CRON"
-
-log "HTTPS 인증서 발급 및 NGINX 전환 완료: https://$DOMAIN"
+log "HTTPS 인증서 발급/갱신 및 NGINX 전환 완료: https://$DOMAIN"

--- a/scripts/issue-https-cert.sh
+++ b/scripts/issue-https-cert.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-api.vs.io.kr}"
+APP_DIR="${APP_DIR:-/home/ubuntu/app}"
+REPO_RAW_BASE="${REPO_RAW_BASE:-https://raw.githubusercontent.com/JECT-Study/JECT2-4th-Server/main}"
+CERTBOT_EMAIL="${CERTBOT_EMAIL:-}"
+CERTBOT_STAGING="${CERTBOT_STAGING:-false}"
+NGINX_CONTAINER="${NGINX_CONTAINER:-nginx}"
+
+log() {
+  echo ">>> $*"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo ">>> 필수 명령어를 찾을 수 없습니다: $1" >&2
+    exit 1
+  fi
+}
+
+require_command curl
+require_command docker
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo ">>> Docker Compose v2 플러그인을 찾을 수 없습니다." >&2
+  exit 1
+fi
+
+mkdir -p "$APP_DIR/nginx" "$APP_DIR/certbot/www" "$APP_DIR/certbot/conf"
+cd "$APP_DIR"
+
+if [ ! -f "$APP_DIR/docker-compose.yaml" ]; then
+  log "docker-compose.yaml 다운로드"
+  curl -fsSL "$REPO_RAW_BASE/docker-compose.yaml" -o "$APP_DIR/docker-compose.yaml"
+fi
+
+if [ ! -f "$APP_DIR/certbot/conf/live/$DOMAIN/fullchain.pem" ] || [ ! -f "$APP_DIR/certbot/conf/live/$DOMAIN/privkey.pem" ]; then
+  log "인증서가 없어 HTTP bootstrap nginx 설정을 적용"
+  curl -fsSL "$REPO_RAW_BASE/nginx/http.conf" | sed "s/api.vs.io.kr/$DOMAIN/g" > "$APP_DIR/nginx/app.conf"
+elif [ ! -f "$APP_DIR/nginx/app.conf" ]; then
+  log "nginx HTTPS 설정 다운로드"
+  curl -fsSL "$REPO_RAW_BASE/nginx/app.conf" | sed "s/api.vs.io.kr/$DOMAIN/g" > "$APP_DIR/nginx/app.conf"
+fi
+
+if ! docker ps --format '{{.Names}}' | grep -qx "$NGINX_CONTAINER"; then
+  log "nginx 컨테이너 시작(HTTP challenge용)"
+  docker compose up -d nginx
+fi
+
+log "ACME webroot challenge 테스트 파일 생성"
+TOKEN="health-$(date +%s)"
+mkdir -p "$APP_DIR/certbot/www/.well-known/acme-challenge"
+echo "$TOKEN" > "$APP_DIR/certbot/www/.well-known/acme-challenge/$TOKEN"
+if ! curl -fsS --max-time 10 "http://$DOMAIN/.well-known/acme-challenge/$TOKEN" | grep -qx "$TOKEN"; then
+  rm -f "$APP_DIR/certbot/www/.well-known/acme-challenge/$TOKEN"
+  echo ">>> http://$DOMAIN/.well-known/acme-challenge/ 경로가 외부에서 접근되지 않습니다." >&2
+  echo ">>> Route53 A/AAAA 레코드가 이 서버의 public IP를 가리키는지, 보안그룹이 80/443을 허용하는지 확인하세요." >&2
+  exit 1
+fi
+rm -f "$APP_DIR/certbot/www/.well-known/acme-challenge/$TOKEN"
+
+EMAIL_ARGS=(--register-unsafely-without-email)
+if [ -n "$CERTBOT_EMAIL" ]; then
+  EMAIL_ARGS=(--email "$CERTBOT_EMAIL")
+fi
+
+STAGING_ARGS=()
+if [ "$CERTBOT_STAGING" = "true" ]; then
+  STAGING_ARGS=(--staging)
+fi
+
+log "Let's Encrypt 인증서 발급: $DOMAIN"
+docker run --rm \
+  -v "$APP_DIR/certbot/conf:/etc/letsencrypt" \
+  -v "$APP_DIR/certbot/www:/var/www/certbot" \
+  certbot/certbot certonly \
+  --webroot \
+  --webroot-path /var/www/certbot \
+  --domain "$DOMAIN" \
+  --agree-tos \
+  --non-interactive \
+  "${EMAIL_ARGS[@]}" \
+  "${STAGING_ARGS[@]}"
+
+log "HTTPS nginx 설정 적용"
+curl -fsSL "$REPO_RAW_BASE/nginx/app.conf" | sed "s/api.vs.io.kr/$DOMAIN/g" > "$APP_DIR/nginx/app.conf"
+docker compose up -d nginx
+docker exec "$NGINX_CONTAINER" nginx -t
+docker exec "$NGINX_CONTAINER" nginx -s reload
+
+log "인증서 자동 갱신 cron 등록"
+RENEW_SCRIPT="$APP_DIR/renew-https-cert.sh"
+cat > "$RENEW_SCRIPT" <<RENEW_EOF
+#!/bin/bash
+set -euo pipefail
+cd "$APP_DIR"
+docker run --rm \\
+  -v "$APP_DIR/certbot/conf:/etc/letsencrypt" \\
+  -v "$APP_DIR/certbot/www:/var/www/certbot" \\
+  certbot/certbot renew --webroot --webroot-path /var/www/certbot --quiet
+if docker ps --format '{{.Names}}' | grep -qx "$NGINX_CONTAINER"; then
+  docker exec "$NGINX_CONTAINER" nginx -s reload >/dev/null 2>&1 || true
+fi
+RENEW_EOF
+chmod +x "$RENEW_SCRIPT"
+
+CRON_LINE="17 3 * * * $RENEW_SCRIPT >> $APP_DIR/certbot/renew.log 2>&1"
+TMP_CRON=$(mktemp)
+{ crontab -l 2>/dev/null || true; } | grep -vF "$RENEW_SCRIPT" > "$TMP_CRON" || true
+echo "$CRON_LINE" >> "$TMP_CRON"
+crontab "$TMP_CRON"
+rm -f "$TMP_CRON"
+
+log "HTTPS 인증서 발급 및 NGINX 전환 완료: https://$DOMAIN"

--- a/scripts/setup-docker-nginx.sh
+++ b/scripts/setup-docker-nginx.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 APP_DIR="${APP_DIR:-/home/ubuntu/app}"
+DOMAIN="${DOMAIN:-api.vs.io.kr}"
 REPO_RAW_BASE="${REPO_RAW_BASE:-https://raw.githubusercontent.com/JECT-Study/JECT2-4th-Server/main}"
 NETWORK="${NETWORK:-app-network}"
 REMOVE_SYSTEM_NGINX="${REMOVE_SYSTEM_NGINX:-false}"
@@ -26,11 +27,16 @@ if ! docker compose version >/dev/null 2>&1; then
 fi
 
 log "앱 디렉터리 준비: $APP_DIR"
-mkdir -p "$APP_DIR/nginx"
+mkdir -p "$APP_DIR/nginx" "$APP_DIR/certbot/www" "$APP_DIR/certbot/conf"
 
 log "repo에서 Docker nginx 설정 다운로드"
 curl -fsSL "$REPO_RAW_BASE/docker-compose.yaml" -o "$APP_DIR/docker-compose.yaml"
-curl -fsSL "$REPO_RAW_BASE/nginx/app.conf" -o "$APP_DIR/nginx/app.conf"
+if [ -f "$APP_DIR/certbot/conf/live/$DOMAIN/fullchain.pem" ] && [ -f "$APP_DIR/certbot/conf/live/$DOMAIN/privkey.pem" ]; then
+  curl -fsSL "$REPO_RAW_BASE/nginx/app.conf" | sed "s/api.vs.io.kr/$DOMAIN/g" > "$APP_DIR/nginx/app.conf"
+else
+  log "인증서가 없어 HTTP bootstrap nginx 설정을 적용합니다. HTTPS 전환은 scripts/issue-https-cert.sh를 실행하세요."
+  curl -fsSL "$REPO_RAW_BASE/nginx/http.conf" | sed "s/api.vs.io.kr/$DOMAIN/g" > "$APP_DIR/nginx/app.conf"
+fi
 
 log "Docker 네트워크 확인: $NETWORK"
 docker network inspect "$NETWORK" >/dev/null 2>&1 || docker network create "$NETWORK" >/dev/null


### PR DESCRIPTION
## 작업 내용
- `api.vs.io.kr` HTTPS용 NGINX 설정 추가
  - 인증서 발급 전: HTTP bootstrap + ACME challenge 경로 제공
  - 인증서 발급 후: HTTP → HTTPS redirect, 443 TLS 프록시
- Docker NGINX compose에 443 포트와 certbot 볼륨 추가
- `scripts/issue-https-cert.sh`로 인증서 발급/갱신 워크플로우 추가
  - 인증서 없으면 `certonly`(신규 발급), 있으면 `renew`(갱신 시도) 분기 처리
  - 서버 cron 등록 방식 제거 — 갱신 스케줄은 GitHub Actions가 전담
- GitHub Actions 워크플로우(`Issue HTTPS Certificate`) 추가
  - `workflow_dispatch`: 수동 실행 (도메인/이메일/staging 입력)
  - `schedule`: 매월 1일 자정(UTC) 자동 실행
- HTTPS 배포 문서 추가

## 서버 적용/검증 결과
- Route53 전파 후 EC2에서 `api.vs.io.kr` 인증서 발급 완료
- 인증서 만료일: 2026-07-30
- NGINX 80/443 리스닝 확인
- `http://api.vs.io.kr/` → `301 https://api.vs.io.kr/`
- `https://api.vs.io.kr/` → NGINX 통해 앱 응답 확인 (`404`, 루트 API 없음으로 정상)
- `nginx -t` 성공

## 로컬 검증
- `bash -n scripts/setup-docker-nginx.sh scripts/deploy.sh scripts/issue-https-cert.sh`
- `docker-compose.yaml`, GitHub workflow YAML parse 확인

## 참고
- Route53 DNS 레코드는 스크립트에서 변경하지 않습니다. `api.vs.io.kr -> 15.135.178.55`는 수동 관리 전제입니다.