### PR TITLE
fix: nginx WebSocket 헤더 추가 및 API 클라이언트 배포 순서 보장

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
               | bash -s ${{ secrets.DOCKER_HUB_USERNAME }}/vs-server:v${{ needs.calculate-version.outputs.version }}
 
   publish-api-client:
-    needs: calculate-version
+    needs: [ calculate-version, release ]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,23 @@ jobs:
         id: version
         uses: ./.github/actions/calculate-version
 
+  check-source-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'src/**'
+              - 'build.gradle.kts'
+              - 'buildSrc/**'
+
   release:
     needs: calculate-version
     runs-on: ubuntu-latest
@@ -81,7 +98,8 @@ jobs:
               | bash -s ${{ secrets.DOCKER_HUB_USERNAME }}/vs-server:v${{ needs.calculate-version.outputs.version }}
 
   publish-api-client:
-    needs: [ calculate-version, release ]
+    needs: [ calculate-version, release, check-source-changes ]
+    if: needs.check-source-changes.outputs.src == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/nginx/app.conf
+++ b/nginx/app.conf
@@ -29,6 +29,9 @@ server {
 
     location / {
         proxy_pass http://$app_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/http.conf
+++ b/nginx/http.conf
@@ -12,6 +12,9 @@ server {
 
     location / {
         proxy_pass http://$app_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary

- `nginx/app.conf`, `nginx/http.conf`에 WebSocket 프록시 헤더(`proxy_http_version 1.1`, `Upgrade`, `Connection`) 추가 — 누락 시 STOMP/WebSocket 연결 실패
- `publish-api-client` job에 `release` 의존성 추가 — GitHub Release 생성 전 npm 패키지가 먼저 배포되는 타이밍 이슈 수정

## Test plan

- [ ] WebSocket 연결 확인 (채팅 기능)
- [ ] main 머지 후 `publish-api-client`가 `release` job 완료 이후에 실행되는지 Actions 탭에서 확인