### PR TITLE
fix: 배포 시 nginx 설정 reload 추가

### DIFF
--- a/scripts/setup-docker-nginx.sh
+++ b/scripts/setup-docker-nginx.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 APP_DIR="${APP_DIR:-/home/ubuntu/app}"
 REPO_RAW_BASE="${REPO_RAW_BASE:-https://raw.githubusercontent.com/JECT-Study/JECT2-4th-Server/main}"
 NETWORK="${NETWORK:-app-network}"
+NGINX_CONTAINER="${NGINX_CONTAINER:-nginx}"
 REMOVE_SYSTEM_NGINX="${REMOVE_SYSTEM_NGINX:-false}"
 
 log() {
@@ -54,6 +55,10 @@ fi
 log "Docker nginx 실행"
 cd "$APP_DIR"
 docker compose up -d nginx
+
+log "Docker nginx 설정 reload"
+docker exec "$NGINX_CONTAINER" nginx -t
+docker exec "$NGINX_CONTAINER" nginx -s reload
 
 log "Docker nginx 상태"
 docker compose ps nginx


### PR DESCRIPTION
## Summary

- `setup-docker-nginx.sh`에서 `app.conf` 갱신 후 `nginx -s reload`를 호출하지 않아 변경된 설정이 적용되지 않는 문제 수정
- `docker compose up -d nginx`는 컨테이너 스펙이 바뀌지 않으면 no-op이므로, 파일만 덮어써서는 nginx에 반영되지 않음

## Test plan

- [ ] main 머지 후 배포 시 nginx 설정이 즉시 반영되는지 확인