### PR TITLE
chore: Docker Hub에서 AWS ECR로 이미지 레지스트리 전환

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   calculate-version:
@@ -61,15 +62,18 @@ jobs:
       - name: Repository 접근
         uses: actions/checkout@v4
 
-      - name: Docker Hub 로그인
-        uses: docker/login-action@v3
+      - name: AWS 자격증명 설정
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: ECR 로그인
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Docker 이미지 빌드 & 푸시
         run: |
-          IMAGE=${{ secrets.DOCKER_HUB_USERNAME }}/vs-server
+          IMAGE=${{ secrets.ECR_REGISTRY }}/backend
           TAG=v${{ needs.calculate-version.outputs.version }}
 
           docker build -t $IMAGE:$TAG .
@@ -95,7 +99,7 @@ jobs:
             curl -fsSL https://raw.githubusercontent.com/JECT-Study/JECT2-4th-Server/main/scripts/setup-docker-nginx.sh \
               | bash
             curl -fsSL https://raw.githubusercontent.com/JECT-Study/JECT2-4th-Server/main/scripts/deploy.sh \
-              | bash -s ${{ secrets.DOCKER_HUB_USERNAME }}/vs-server:v${{ needs.calculate-version.outputs.version }}
+              | bash -s ${{ secrets.ECR_REGISTRY }}/backend:v${{ needs.calculate-version.outputs.version }}
 
   publish-api-client:
     needs: [ calculate-version, release, check-source-changes ]

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -75,6 +75,15 @@ fi
 
 log "현재: ${CURRENT:-없음} → 새로운: $NEW_CONTAINER"
 
+# ECR 이미지인 경우 로그인
+if [[ "$IMAGE" == *".dkr.ecr."* ]]; then
+  ECR_REGISTRY=$(echo "$IMAGE" | cut -d'/' -f1)
+  REGION=$(echo "$IMAGE" | sed 's/.*\.dkr\.ecr\.\([^.]*\)\..*/\1/')
+  log "ECR 로그인 중: $ECR_REGISTRY"
+  aws ecr get-login-password --region "$REGION" \
+    | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+fi
+
 # 새 이미지 pull
 log "이미지 pull 중: $IMAGE"
 docker pull "$IMAGE"


### PR DESCRIPTION
## Summary
- GitHub Actions OIDC를 통해 AWS Role을 획득하여 장기 자격증명(Docker Hub 비밀번호) 제거
- ECR 리포지토리(`637131561434.dkr.ecr.ap-southeast-2.amazonaws.com/backend`)로 이미지 푸시
- EC2 Instance Profile 기반으로 deploy.sh에서 ECR 자동 로그인 처리

## Changes
- `.github/workflows/release.yml`: `id-token: write` 권한 추가, Docker Hub → AWS credentials + ECR 로그인으로 교체
- `scripts/deploy.sh`: ECR 이미지 감지 시 `aws ecr get-login-password`로 자동 인증

## Required GitHub Secrets
| Secret | 값 |
|--------|-----|
| `AWS_ROLE_ARN` | `arn:aws:iam::637131561434:role/github-actions-ecr-push` |
| `AWS_REGION` | `ap-southeast-2` |
| `ECR_REGISTRY` | `637131561434.dkr.ecr.ap-southeast-2.amazonaws.com` |

## Test plan
- [ ] PR을 main에 머지하면 release 워크플로우가 자동 트리거됨
- [ ] Actions 탭에서 `AWS 자격증명 설정` → `ECR 로그인` → `Docker 이미지 빌드 & 푸시` 단계 정상 통과 확인
- [ ] ECR 콘솔에서 `backend` 리포지토리에 이미지 푸시 확인
- [ ] EC2에서 컨테이너 정상 기동 및 헬스체크 통과 확인