### PR TITLE
fix: ECR 로그인 output으로 레지스트리 URL 참조

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,11 +69,14 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: ECR 로그인
+        id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Docker 이미지 빌드 & 푸시
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          IMAGE=${{ secrets.ECR_REGISTRY }}/backend
+          IMAGE=$REGISTRY/backend
           TAG=v${{ needs.calculate-version.outputs.version }}
 
           docker build -t $IMAGE:$TAG .


### PR DESCRIPTION
## Summary
- `amazon-ecr-login@v2` 액션의 `outputs.registry`를 직접 사용하도록 수정
- 기존: `secrets.ECR_REGISTRY` 시크릿 값을 직접 참조 → Docker가 자격증명을 찾지 못해 `no basic auth credentials` 에러 발생
- 변경: 로그인 step의 output URL을 그대로 사용해 인증된 레지스트리와 push 대상이 항상 일치

## Test plan
- [ ] Actions 탭에서 `ECR 로그인` → `Docker 이미지 빌드 & 푸시` 단계 정상 통과 확인
- [ ] ECR 콘솔에서 `backend` 리포지토리에 이미지 푸시 확인