### PR TITLE
fix: ECR_REGISTRY 시크릿 제거 및 로그인 output 재사용

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
             curl -fsSL https://raw.githubusercontent.com/JECT-Study/JECT2-4th-Server/main/scripts/setup-docker-nginx.sh \
               | bash
             curl -fsSL https://raw.githubusercontent.com/JECT-Study/JECT2-4th-Server/main/scripts/deploy.sh \
-              | bash -s ${{ secrets.ECR_REGISTRY }}/backend:v${{ needs.calculate-version.outputs.version }}
+              | bash -s ${{ steps.login-ecr.outputs.registry }}/backend:v${{ needs.calculate-version.outputs.version }}
 
   publish-api-client:
     needs: [ calculate-version, release, check-source-changes ]

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -79,6 +79,15 @@ log "현재: ${CURRENT:-없음} → 새로운: $NEW_CONTAINER"
 if [[ "$IMAGE" == *".dkr.ecr."* ]]; then
   ECR_REGISTRY=$(echo "$IMAGE" | cut -d'/' -f1)
   REGION=$(echo "$IMAGE" | sed 's/.*\.dkr\.ecr\.\([^.]*\)\..*/\1/')
+
+  if ! command -v aws &>/dev/null; then
+    log "AWS CLI 설치 중..."
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+    unzip -q /tmp/awscliv2.zip -d /tmp/aws-install
+    sudo /tmp/aws-install/aws/install --update
+    rm -rf /tmp/awscliv2.zip /tmp/aws-install
+  fi
+
   log "ECR 로그인 중: $ECR_REGISTRY"
   aws ecr get-login-password --region "$REGION" \
     | docker login --username AWS --password-stdin "$ECR_REGISTRY"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -75,22 +75,18 @@ fi
 
 log "현재: ${CURRENT:-없음} → 새로운: $NEW_CONTAINER"
 
-# ECR 이미지인 경우 로그인
+# ECR 이미지인 경우 credential helper로 인증 설정
 if [[ "$IMAGE" == *".dkr.ecr."* ]]; then
   ECR_REGISTRY=$(echo "$IMAGE" | cut -d'/' -f1)
-  REGION=$(echo "$IMAGE" | sed 's/.*\.dkr\.ecr\.\([^.]*\)\..*/\1/')
 
-  if ! command -v aws &>/dev/null; then
-    log "AWS CLI 설치 중..."
-    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
-    unzip -q /tmp/awscliv2.zip -d /tmp/aws-install
-    sudo /tmp/aws-install/aws/install --update
-    rm -rf /tmp/awscliv2.zip /tmp/aws-install
+  if ! command -v docker-credential-ecr-login &>/dev/null; then
+    log "ECR credential helper 설치 중..."
+    sudo apt-get install -y amazon-ecr-credential-helper
   fi
 
-  log "ECR 로그인 중: $ECR_REGISTRY"
-  aws ecr get-login-password --region "$REGION" \
-    | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+  mkdir -p ~/.docker
+  echo "{\"credHelpers\":{\"${ECR_REGISTRY}\":\"ecr-login\"}}" > ~/.docker/config.json
+  log "ECR credential helper 설정 완료: $ECR_REGISTRY"
 fi
 
 # 새 이미지 pull


### PR DESCRIPTION
## Summary
- `steps.login-ecr.outputs.registry`를 배포 스크립트 호출 시에도 재사용
- `secrets.ECR_REGISTRY` 시크릿이 더 이상 필요 없음 → GitHub Secrets에서 삭제 가능

## Changes
- `.github/workflows/release.yml`: deploy 스크립트 이미지 URI를 `secrets.ECR_REGISTRY` → `steps.login-ecr.outputs.registry`로 변경

## Test plan
- [ ] 워크플로우 정상 실행 확인
- [ ] GitHub Secrets에서 `ECR_REGISTRY` 삭제