### PR TITLE
feat: blue-green 고정 이름에서 버전 기반 컨테이너 이름으로 전환

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -62,16 +62,21 @@ if ! echo "$NGINX_NETWORKS" | grep -qx "$NETWORK"; then
   docker network connect "$NETWORK" "$NGINX_CONTAINER"
 fi
 
-# 현재 활성 컨테이너 확인
-CURRENT=$(cat "$APP_DIR/current_container" 2>/dev/null || echo "")
+# 버전 기반 컨테이너 이름 (이미지 태그 추출)
+VERSION=$(echo "$IMAGE" | cut -d':' -f2)
+NEW_CONTAINER="app-${VERSION}"
 
-if [ "$CURRENT" = "app-blue" ]; then
-  NEW_CONTAINER="app-green"
-  OLD_CONTAINER="app-blue"
-else
-  NEW_CONTAINER="app-blue"
-  OLD_CONTAINER="app-green"
-fi
+# 현재 활성 컨테이너를 네트워크 alias로 탐색
+CURRENT=""
+for cid in $(docker ps -q 2>/dev/null); do
+  aliases=$(docker inspect "$cid" \
+    --format "{{range \$net, \$cfg := .NetworkSettings.Networks}}{{if eq \$net \"$NETWORK\"}}{{range \$cfg.Aliases}}{{.}} {{end}}{{end}}{{end}}" \
+    2>/dev/null)
+  if [[ " $aliases " == *" app "* ]]; then
+    CURRENT=$(docker inspect "$cid" --format '{{.Name}}' | sed 's/^\///')
+    break
+  fi
+done
 
 log "현재: ${CURRENT:-없음} → 새로운: $NEW_CONTAINER"
 
@@ -163,16 +168,7 @@ if [ -n "$CURRENT" ] && docker ps -a --format '{{.Names}}' | grep -qx "$CURRENT"
   docker network disconnect "$NETWORK" "$CURRENT" 2>/dev/null || true
   docker stop "$CURRENT" >/dev/null 2>&1 || true
   docker rm "$CURRENT" >/dev/null 2>&1 || true
-elif docker ps -a --format '{{.Names}}' | grep -qx "$OLD_CONTAINER"; then
-  log "남아있는 이전 후보 컨테이너($OLD_CONTAINER) 정리 중"
-  docker network disconnect "$NETWORK" "$OLD_CONTAINER" 2>/dev/null || true
-  docker stop "$OLD_CONTAINER" >/dev/null 2>&1 || true
-  docker rm "$OLD_CONTAINER" >/dev/null 2>&1 || true
 fi
-
-# 현재 컨테이너 기록
-echo "$NEW_CONTAINER" > "$APP_DIR/current_container"
-rm -f "$APP_DIR/current_port"
 
 # 오래된 Docker 이미지 정리
 docker image prune -f >/dev/null


### PR DESCRIPTION
## Summary
- `app-blue` / `app-green` 고정 이름 순환 방식 제거
- 이미지 태그에서 버전을 추출해 `app-{version}` 형태로 컨테이너 이름 부여 (예: `app-v2026.0501.8`)
- `current_container` 파일 의존성 제거 → 네트워크 `app` alias로 현재 활성 컨테이너 탐색

## Changes
- `scripts/deploy.sh`: 버전 기반 컨테이너 명명 + alias 기반 이전 컨테이너 탐색

## Test plan
- [ ] 배포 후 `docker ps` 에서 `app-v{version}` 형태 컨테이너 확인
- [ ] 재배포 시 이전 버전 컨테이너 정상 정리 확인
- [ ] 트래픽 전환 (app alias) 정상 동작 확인