### PR TITLE
fix: certbot live 디렉토리 권한 문제로 HTTPS 설정 누락 수정

### DIFF
--- a/scripts/setup-docker-nginx.sh
+++ b/scripts/setup-docker-nginx.sh
@@ -32,7 +32,7 @@ mkdir -p "$APP_DIR/nginx" "$APP_DIR/certbot/www" "$APP_DIR/certbot/conf"
 
 log "repo에서 Docker nginx 설정 다운로드"
 curl -fsSL "$REPO_RAW_BASE/docker-compose.yaml" -o "$APP_DIR/docker-compose.yaml"
-if [ -f "$APP_DIR/certbot/conf/live/$DOMAIN/fullchain.pem" ] && [ -f "$APP_DIR/certbot/conf/live/$DOMAIN/privkey.pem" ]; then
+if sudo test -f "$APP_DIR/certbot/conf/live/$DOMAIN/fullchain.pem" && sudo test -f "$APP_DIR/certbot/conf/live/$DOMAIN/privkey.pem"; then
   curl -fsSL "$REPO_RAW_BASE/nginx/app.conf" | sed "s/api.vs.io.kr/$DOMAIN/g" > "$APP_DIR/nginx/app.conf"
 else
   log "인증서가 없어 HTTP bootstrap nginx 설정을 적용합니다. HTTPS 전환은 scripts/issue-https-cert.sh를 실행하세요."


### PR DESCRIPTION
## Summary
- `setup-docker-nginx.sh`에서 인증서 존재 여부를 `[ -f ... ]`로 체크 시, `certbot/conf/live` 디렉토리가 `root:root 700`이라 ubuntu 유저가 접근 불가 → HTTP bootstrap 설정으로 덮어씌워지는 문제 수정
- `sudo test -f`로 변경하여 root 권한으로 파일 존재 여부 확인

## Root Cause
배포 시 `setup-docker-nginx.sh`가 실행될 때마다 인증서 체크가 실패 → nginx HTTPS 설정이 HTTP bootstrap으로 초기화됨

## Test plan
- [ ] 배포 후 HTTPS 정상 응답 확인 (`https://api.vs.io.kr/actuator/health`)
- [ ] nginx 설정이 HTTPS 버전으로 유지되는지 확인