### PR TITLE
feat: actuator 포트를 8081로 분리하여 외부 접근 차단

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ COPY --from=build /app/build/libs/*.jar app.jar
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
-HEALTHCHECK --interval=5s --timeout=3s --start-period=30s --retries=10 \
-  CMD curl -f http://localhost:8080/actuator/health || exit 1
+HEALTHCHECK --interval=10s --timeout=5s --start-period=90s --retries=18 \
+  CMD curl -f http://localhost:8081/actuator/health/readiness || exit 1
 
 EXPOSE 8080
 ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "app.jar"]

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -115,11 +115,6 @@ docker run -d --name "$NEW_CONTAINER" \
   -e APP_JWT_SECRET \
   -e APP_JWT_ACCESS_TOKEN_EXPIRATION_SECONDS \
   -e APP_JWT_REFRESH_TOKEN_EXPIRATION_SECONDS \
-  --health-cmd="curl -f http://localhost:8081/actuator/health || exit 1" \
-  --health-interval=10s \
-  --health-timeout=5s \
-  --health-start-period=90s \
-  --health-retries=18 \
   "$IMAGE" >/dev/null
 
 # 헬스체크 (docker inspect로 healthy 상태 확인)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -115,7 +115,7 @@ docker run -d --name "$NEW_CONTAINER" \
   -e APP_JWT_SECRET \
   -e APP_JWT_ACCESS_TOKEN_EXPIRATION_SECONDS \
   -e APP_JWT_REFRESH_TOKEN_EXPIRATION_SECONDS \
-  --health-cmd="curl -f http://localhost:8080/actuator/health || exit 1" \
+  --health-cmd="curl -f http://localhost:8081/actuator/health || exit 1" \
   --health-interval=10s \
   --health-timeout=5s \
   --health-start-period=90s \

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -32,6 +32,8 @@ app:
     refresh-token-expiration-seconds: ${APP_JWT_REFRESH_TOKEN_EXPIRATION_SECONDS:1209600}
 
 management:
+  server:
+    port: 8081
   endpoints:
     web:
       exposure:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -34,6 +34,9 @@ app:
 management:
   server:
     port: 8081
+  health:
+    probes:
+      enabled: true
   endpoints:
     web:
       exposure:


### PR DESCRIPTION
## Summary
- `management.server.port: 8081` 설정으로 actuator를 앱 포트(8080)와 분리
- nginx는 8080만 프록시하므로 8081은 외부에서 접근 불가 (Docker 내부 전용)
- `deploy.sh` 헬스체크도 8081로 변경

## Changes
- `application-prod.yml`: `management.server.port: 8081` 추가
- `scripts/deploy.sh`: 헬스체크 URL `localhost:8080` → `localhost:8081`

## Test plan
- [ ] 배포 후 `https://api.vs.io.kr/actuator/health` 외부 접근 불가 확인 (404 또는 연결 거부)
- [ ] 컨테이너 헬스체크 정상 통과 확인 (`docker ps`에서 healthy 상태)