### PR TITLE
Allow actuator readiness health checks without authentication

### DIFF
--- a/src/main/java/com/ject/vs/config/JwtAuthFilter.java
+++ b/src/main/java/com/ject/vs/config/JwtAuthFilter.java
@@ -29,6 +29,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             "/swagger-ui.html",
             "/api/**",
             "/actuator/health",
+            "/actuator/health/**",
             "/",
             "/error",
             "/auth/reissue"

--- a/src/main/java/com/ject/vs/config/SecurityConfig.java
+++ b/src/main/java/com/ject/vs/config/SecurityConfig.java
@@ -20,6 +20,7 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/api/**",
                                 "/actuator/health",
+                                "/actuator/health/**",
                                 "/",
                                 "/error",
                                 "/auth/reissue"


### PR DESCRIPTION
## Summary
- Permit nested actuator health endpoints such as `/actuator/health/readiness`
- Exclude the same health probe path from JWT filtering

## Why
Caddy active health checks call `app:8081/actuator/health/readiness`. The app currently permits only `/actuator/health`, so readiness requests are redirected with HTTP 302 and Caddy marks the upstream unhealthy, causing `no upstreams available` 503s.

## Verification
- `./gradlew test` passed
- `git diff --check` passed

## Not tested
- Live EC2/Caddy health check after deployment