### PR TITLE
Let Neon suspend during application idle time

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,6 +4,13 @@ spring:
     driver-class-name: org.postgresql.Driver
     username: ${DATABASE_USERNAME}
     password: ${DATABASE_PASSWORD}
+    hikari:
+      minimum-idle: 0
+      maximum-pool-size: ${DB_POOL_MAX_SIZE:3}
+      idle-timeout: 30000
+      connection-timeout: 30000
+      validation-timeout: 3000
+      keepalive-time: 0
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
## Summary
- Tune production HikariCP to allow idle connections to shrink to zero
- Keep pool size small and configurable via DB_POOL_MAX_SIZE
- Disable Hikari keepalive pings so Neon scale-to-zero can suspend during idle periods

## Verification
- ./gradlew test

## Notes
- Repo health check callers use /actuator/health/readiness; root /actuator/health remains exposed/allowed but is not used by Docker or Caddy checks.