### PR TITLE
feat: Configure CORS origins by environment

### DIFF
--- a/src/main/java/com/ject/vs/config/CorsConfig.java
+++ b/src/main/java/com/ject/vs/config/CorsConfig.java
@@ -1,0 +1,31 @@
+package com.ject.vs.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@RequiredArgsConstructor
+public class CorsConfig {
+
+    private final CorsProperties corsProperties;
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(corsProperties.allowedOrigins());
+        configuration.setAllowedOriginPatterns(corsProperties.allowedOriginPatterns());
+        configuration.setAllowedMethods(corsProperties.allowedMethods());
+        configuration.setAllowedHeaders(corsProperties.allowedHeaders());
+        configuration.setExposedHeaders(corsProperties.exposedHeaders());
+        configuration.setAllowCredentials(corsProperties.allowCredentials());
+        configuration.setMaxAge(corsProperties.maxAge());
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/com/ject/vs/config/CorsProperties.java
+++ b/src/main/java/com/ject/vs/config/CorsProperties.java
@@ -1,0 +1,37 @@
+package com.ject.vs.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "app.cors")
+public record CorsProperties(
+        List<String> allowedOrigins,
+        List<String> allowedOriginPatterns,
+        List<String> allowedMethods,
+        List<String> allowedHeaders,
+        List<String> exposedHeaders,
+        boolean allowCredentials,
+        long maxAge
+) {
+    public CorsProperties {
+        allowedOrigins = defaultsIfEmpty(allowedOrigins, List.of(
+                "http://localhost:3000",
+                "http://localhost:5173",
+                "http://127.0.0.1:3000",
+                "http://127.0.0.1:5173"
+        ));
+        allowedOriginPatterns = defaultsIfEmpty(allowedOriginPatterns, List.of());
+        allowedMethods = defaultsIfEmpty(allowedMethods, List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        allowedHeaders = defaultsIfEmpty(allowedHeaders, List.of("Authorization", "Content-Type", "X-Requested-With", "Accept", "Origin"));
+        exposedHeaders = defaultsIfEmpty(exposedHeaders, List.of());
+        maxAge = maxAge > 0 ? maxAge : 3600;
+    }
+
+    private static List<String> defaultsIfEmpty(List<String> values, List<String> defaults) {
+        if (values == null || values.isEmpty()) {
+            return List.copyOf(defaults);
+        }
+        return List.copyOf(values);
+    }
+}

--- a/src/main/java/com/ject/vs/config/CorsProperties.java
+++ b/src/main/java/com/ject/vs/config/CorsProperties.java
@@ -17,9 +17,7 @@ public record CorsProperties(
     public CorsProperties {
         allowedOrigins = defaultsIfEmpty(allowedOrigins, List.of(
                 "http://localhost:3000",
-                "http://localhost:5173",
-                "http://127.0.0.1:3000",
-                "http://127.0.0.1:5173"
+                "http://127.0.0.1:3000"
         ));
         allowedOriginPatterns = defaultsIfEmpty(allowedOriginPatterns, List.of());
         allowedMethods = defaultsIfEmpty(allowedMethods, List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));

--- a/src/main/java/com/ject/vs/config/SecurityConfig.java
+++ b/src/main/java/com/ject/vs/config/SecurityConfig.java
@@ -5,13 +5,17 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                    OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler,
+                                                    CorsConfigurationSource corsConfigurationSource) throws Exception {
         return http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(

--- a/src/main/java/com/ject/vs/config/WebSocketConfig.java
+++ b/src/main/java/com/ject/vs/config/WebSocketConfig.java
@@ -14,10 +14,17 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final WebSocketAuthInterceptor webSocketAuthInterceptor;
+    private final CorsProperties corsProperties;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+        String[] allowedOriginPatterns = corsProperties.allowedOriginPatterns().toArray(String[]::new);
+        if (allowedOriginPatterns.length > 0) {
+            registry.addEndpoint("/ws").setAllowedOriginPatterns(allowedOriginPatterns).withSockJS();
+            return;
+        }
+
+        registry.addEndpoint("/ws").setAllowedOrigins(corsProperties.allowedOrigins().toArray(String[]::new)).withSockJS();
     }
 
     @Override

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,3 +23,13 @@ app:
     redirect-success-url: http://localhost:3000/oauth2/redirect
   cookie:
     secure: false
+  cors:
+    allowed-origins:
+      - http://localhost:3000
+      - http://localhost:5173
+      - http://127.0.0.1:3000
+      - http://127.0.0.1:5173
+    allowed-methods: GET,POST,PUT,PATCH,DELETE,OPTIONS
+    allowed-headers: Authorization,Content-Type,X-Requested-With,Accept,Origin
+    allow-credentials: true
+    max-age: 3600

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,9 +26,7 @@ app:
   cors:
     allowed-origins:
       - http://localhost:3000
-      - http://localhost:5173
       - http://127.0.0.1:3000
-      - http://127.0.0.1:5173
     allowed-methods: GET,POST,PUT,PATCH,DELETE,OPTIONS
     allowed-headers: Authorization,Content-Type,X-Requested-With,Accept,Origin
     allow-credentials: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -43,6 +43,16 @@ app:
     access-token-expiration-seconds: ${APP_JWT_ACCESS_TOKEN_EXPIRATION_SECONDS:3600}
     refresh-token-expiration-seconds: ${APP_JWT_REFRESH_TOKEN_EXPIRATION_SECONDS:1209600}
 
+  cors:
+    # 브라우저 기반 운영 도메인은 APP_CORS_ALLOWED_ORIGINS에 콤마로 구분해 설정합니다.
+    # 예: https://app.example.com,https://admin.example.com
+    # 백엔드 서버간 직접 호출에는 브라우저 CORS 검사가 적용되지 않습니다.
+    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:https://example.com}
+    allowed-methods: ${APP_CORS_ALLOWED_METHODS:GET,POST,PUT,PATCH,DELETE,OPTIONS}
+    allowed-headers: ${APP_CORS_ALLOWED_HEADERS:Authorization,Content-Type,X-Requested-With,Accept,Origin}
+    allow-credentials: ${APP_CORS_ALLOW_CREDENTIALS:true}
+    max-age: ${APP_CORS_MAX_AGE:3600}
+
 management:
   server:
     port: 8081

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -45,9 +45,9 @@ app:
 
   cors:
     # 브라우저 기반 운영 도메인은 APP_CORS_ALLOWED_ORIGINS에 콤마로 구분해 설정합니다.
-    # 예: https://app.example.com,https://admin.example.com
+    # 예: https://vs.io.kr,https://admin.vs.io.kr
     # 백엔드 서버간 직접 호출에는 브라우저 CORS 검사가 적용되지 않습니다.
-    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:https://example.com}
+    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:https://vs.io.kr}
     allowed-methods: ${APP_CORS_ALLOWED_METHODS:GET,POST,PUT,PATCH,DELETE,OPTIONS}
     allowed-headers: ${APP_CORS_ALLOWED_HEADERS:Authorization,Content-Type,X-Requested-With,Accept,Origin}
     allow-credentials: ${APP_CORS_ALLOW_CREDENTIALS:true}

--- a/src/test/java/com/ject/vs/config/CorsConfigTest.java
+++ b/src/test/java/com/ject/vs/config/CorsConfigTest.java
@@ -1,0 +1,57 @@
+package com.ject.vs.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CorsConfigTest {
+
+    @Test
+    void appliesLocalDevelopmentCorsDefaults() {
+        CorsProperties properties = new CorsProperties(null, null, null, null, null, true, 0);
+        CorsConfigurationSource source = new CorsConfig(properties).corsConfigurationSource();
+
+        CorsConfiguration configuration = source.getCorsConfiguration(new MockHttpServletRequest("OPTIONS", "/api/test"));
+
+        assertThat(configuration).isNotNull();
+        assertThat(configuration.getAllowedOrigins()).contains(
+                "http://localhost:3000",
+                "http://localhost:5173",
+                "http://127.0.0.1:3000",
+                "http://127.0.0.1:5173"
+        );
+        assertThat(configuration.getAllowedMethods()).contains("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS");
+        assertThat(configuration.getAllowedHeaders()).contains("Authorization", "Content-Type", "X-Requested-With", "Accept", "Origin");
+        assertThat(configuration.getAllowCredentials()).isTrue();
+        assertThat(configuration.getMaxAge()).isEqualTo(3600);
+    }
+
+    @Test
+    void appliesConfiguredServerOrigins() {
+        CorsProperties properties = new CorsProperties(
+                List.of("https://app.example.com", "https://admin.example.com"),
+                null,
+                List.of("GET", "POST", "OPTIONS"),
+                List.of("Authorization", "Content-Type"),
+                List.of("Location"),
+                true,
+                7200
+        );
+        CorsConfigurationSource source = new CorsConfig(properties).corsConfigurationSource();
+
+        CorsConfiguration configuration = source.getCorsConfiguration(new MockHttpServletRequest("OPTIONS", "/api/test"));
+
+        assertThat(configuration).isNotNull();
+        assertThat(configuration.getAllowedOrigins()).containsExactly("https://app.example.com", "https://admin.example.com");
+        assertThat(configuration.getAllowedMethods()).containsExactly("GET", "POST", "OPTIONS");
+        assertThat(configuration.getAllowedHeaders()).containsExactly("Authorization", "Content-Type");
+        assertThat(configuration.getExposedHeaders()).containsExactly("Location");
+        assertThat(configuration.getAllowCredentials()).isTrue();
+        assertThat(configuration.getMaxAge()).isEqualTo(7200);
+    }
+}

--- a/src/test/java/com/ject/vs/config/CorsConfigTest.java
+++ b/src/test/java/com/ject/vs/config/CorsConfigTest.java
@@ -21,9 +21,7 @@ class CorsConfigTest {
         assertThat(configuration).isNotNull();
         assertThat(configuration.getAllowedOrigins()).contains(
                 "http://localhost:3000",
-                "http://localhost:5173",
-                "http://127.0.0.1:3000",
-                "http://127.0.0.1:5173"
+                "http://127.0.0.1:3000"
         );
         assertThat(configuration.getAllowedMethods()).contains("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS");
         assertThat(configuration.getAllowedHeaders()).contains("Authorization", "Content-Type", "X-Requested-With", "Accept", "Origin");


### PR DESCRIPTION
## 요약
- Spring Security에 `app.cors` 기반 CORS 설정을 추가했습니다.
- 로컬 개발 환경에서는 `http://localhost:3000`, `http://127.0.0.1:3000`만 허용합니다.
- 운영 환경 기본 허용 origin을 실제 도메인인 `https://vs.io.kr`로 설정했습니다.
- SockJS WebSocket 엔드포인트(`/ws`)에도 동일한 CORS origin 설정을 적용했습니다.

## 참고
- CORS는 브라우저에서만 검사되는 정책이라 백엔드 서버 간 직접 통신에는 적용되지 않습니다. 서버 간 통신은 기존처럼 인증/네트워크 정책으로 보호됩니다.
- 운영에서 추가 프론트 도메인이 생기면 `APP_CORS_ALLOWED_ORIGINS` 환경변수에 콤마로 구분해 넣으면 됩니다.

## 테스트
- `./gradlew test`
