### PR TITLE
fix: remove apt curl install from runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,12 @@ COPY src ./src
 RUN gradle bootJar --no-daemon
 
 # ===== 실행 스테이지 =====
-FROM eclipse-temurin:25-jre
+FROM eclipse-temurin:25-jre-alpine
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
-
 HEALTHCHECK --interval=10s --timeout=5s --start-period=90s --retries=18 \
-  CMD curl -f http://localhost:8081/actuator/health/readiness || exit 1
+  CMD wget -q -O /dev/null http://127.0.0.1:8081/actuator/health/readiness || exit 1
 
 EXPOSE 8080
 ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "app.jar"]


### PR DESCRIPTION
## 문제

Docker 이미지 빌드 중 런타임 스테이지에서 `curl` 하나를 설치하기 위해 `apt-get update && apt-get install`을 수행하고 있었습니다.

```dockerfile
RUN apt-get update && apt-get install -y --no-install-recommends curl
```

GitHub Actions 환경에서 Ubuntu apt mirror 응답이 느려지면 이 단계가 수 분 이상 지연되어 전체 배포가 늦어질 수 있습니다.

## 수정 내용

런타임 이미지를 Alpine 기반 Temurin JRE로 변경하고, healthcheck는 Alpine/BusyBox에 기본 포함된 `wget`을 사용하도록 바꿨습니다.

```dockerfile
FROM eclipse-temurin:25-jre-alpine

HEALTHCHECK ... \
  CMD wget -q -O /dev/null http://127.0.0.1:8081/actuator/health/readiness || exit 1
```

## 기대 효과

- 런타임 스테이지에서 `apt-get update/install` 제거
- `curl` 설치를 위한 외부 패키지 다운로드 병목 제거
- 이미지 빌드 시간과 네트워크 실패 가능성 감소
- healthcheck 동작은 readiness endpoint 확인으로 유지

## 검증

- [x] `docker manifest inspect eclipse-temurin:25-jre-alpine`
- [x] `git diff --check`

## 참고

전체 Docker build는 로컬에서 수행하지 않았습니다. CI에서 실제 이미지 빌드까지 확인하면 됩니다.
