### PR TITLE
ci: cache Gradle work during Docker image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*
+!Dockerfile
+!build/
+!build/libs/
+!build/libs/app.jar

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -37,21 +37,11 @@ jobs:
           java-version: '25'
           distribution: 'temurin'
 
-      - name: Gradle 의존성 캐싱
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
       - name: 프로젝트 빌드
-        run: ./gradlew build
+        run: ./gradlew build --build-cache
 
       - name: 빌드 결과 댓글
         if: always()
@@ -90,24 +80,11 @@ jobs:
           java-version: '25'
           distribution: 'temurin'
 
-      - name: Gradle 의존성 캐싱
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
       - name: 프로젝트 빌드
-        env:
-          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-        run: ./gradlew build
+        run: ./gradlew build --build-cache
 
       - name: 빌드 결과 댓글
         if: always()

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -20,21 +20,8 @@ jobs:
           java-version: '25'
           distribution: 'temurin'
 
-      - name: Gradle 의존성 캐싱
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
       - name: 프로젝트 빌드
-        env:
-          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-        run: ./gradlew build
+        run: ./gradlew build --build-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,22 @@ jobs:
       - name: Repository 접근
         uses: actions/checkout@v4
 
+      - name: JDK 25 셋팅
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: 애플리케이션 JAR 빌드
+        run: |
+          ./gradlew bootJar --no-daemon --build-cache
+          BOOT_JAR=$(find build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' | head -n 1)
+          test -n "$BOOT_JAR"
+          cp "$BOOT_JAR" build/libs/app.jar
+
       - name: AWS 자격증명 설정
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -74,17 +90,19 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Docker 이미지 빌드 & 푸시
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run: |
-          IMAGE=$REGISTRY/backend
-          TAG=v${{ needs.calculate-version.outputs.version }}
+      - name: Docker Buildx 설정
+        uses: docker/setup-buildx-action@v3
 
-          docker build -t $IMAGE:$TAG .
-          docker tag $IMAGE:$TAG $IMAGE:latest
-          docker push $IMAGE:$TAG
-          docker push $IMAGE:latest
+      - name: Docker 이미지 빌드 & 푸시
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/backend:v${{ needs.calculate-version.outputs.version }}
+            ${{ steps.login-ecr.outputs.registry }}/backend:latest
+          cache-from: type=gha,scope=backend-runtime
+          cache-to: type=gha,scope=backend-runtime,mode=max
 
       - name: 서버 배포
         uses: appleboy/ssh-action@v1.0.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,11 @@
-# ===== 빌드 스테이지 =====
-FROM gradle:jdk25 AS build
-WORKDIR /app
-
-# 의존성 먼저 복사 (캐싱 활용)
-COPY build.gradle.kts settings.gradle.kts ./
-COPY buildSrc ./buildSrc
-COPY gradle ./gradle
-RUN gradle dependencies --no-daemon || true
-
-# 소스 코드 복사 & 빌드
-COPY src ./src
-RUN gradle bootJar --no-daemon
+# syntax=docker/dockerfile:1.7
 
 # ===== 실행 스테이지 =====
 FROM eclipse-temurin:25-jre-alpine
 WORKDIR /app
-COPY --from=build /app/build/libs/*.jar app.jar
+
+ARG JAR_FILE=build/libs/app.jar
+COPY ${JAR_FILE} app.jar
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=90s --retries=18 \
   CMD wget -q -O /dev/null http://127.0.0.1:8081/actuator/health/readiness || exit 1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching=true


### PR DESCRIPTION
## 문제

기존 release 이미지 빌드는 Dockerfile 내부에서 Gradle build를 수행했습니다.

```txt
docker build
└─ ./gradlew bootJar
```

이 구조에서는 CI가 제공하는 Gradle cache를 직접 활용하기 어렵고, Docker image build와 애플리케이션 컴파일이 강하게 묶입니다. 그 결과 소스만 조금 바뀌어도 Docker build 안에서 Gradle 의존성/빌드 캐시 재사용이 제한될 수 있습니다.

CI build workflow도 `actions/cache`와 `gradle/actions/setup-gradle`을 함께 사용하고 있어 캐시 책임이 중복되어 있었습니다.

## 수정 내용

### 1. Dockerfile을 jar-only runtime image로 단순화

Dockerfile에서 Gradle build stage를 제거하고, CI에서 만든 JAR만 이미지에 복사하도록 변경했습니다.

```dockerfile
FROM eclipse-temurin:25-jre-alpine

ARG JAR_FILE=build/libs/app.jar
COPY ${JAR_FILE} app.jar
```

이제 Docker image build는 런타임 이미지 구성만 담당합니다.

### 2. release workflow에서 먼저 JAR 빌드

release job에서 Docker build 전에 Gradle로 bootJar를 생성합니다.

```yml
- uses: gradle/actions/setup-gradle@v4

- name: 애플리케이션 JAR 빌드
  run: |
    ./gradlew bootJar --no-daemon --build-cache
    BOOT_JAR=$(find build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' | head -n 1)
    test -n "$BOOT_JAR"
    cp "$BOOT_JAR" build/libs/app.jar
```

`app.jar`로 고정해서 Dockerfile의 wildcard ambiguity도 제거했습니다.

### 3. Docker build context 최소화

`.dockerignore`를 추가해 Docker build context를 런타임 이미지 생성에 필요한 파일로 제한했습니다.

```dockerignore
*
!Dockerfile
!build/
!build/libs/
!build/libs/app.jar
```

### 4. CI build cache 정리

`ci-push`, `ci-pr`에서 수동 `actions/cache` 단계를 제거하고 `gradle/actions/setup-gradle@v4`에 캐시 책임을 일원화했습니다.

그리고 Gradle build cache 사용을 명시했습니다.

```bash
./gradlew build --build-cache
```

프로젝트 기본값으로도 build cache를 켰습니다.

```properties
org.gradle.caching=true
```

## 기대 효과

- CI Gradle cache를 release build와 CI build에서 직접 활용
- Docker image build는 `COPY app.jar` 중심으로 단순화
- Docker build context 축소
- Docker 내부 Gradle build 제거로 빌드/패키징 책임 분리
- 불필요한 OAuth secret env 제거

## 검증

- [x] `./gradlew build --build-cache --no-daemon`
- [x] `docker build --no-cache -t ject-server:jar-only-runtime-test .`
- [x] 컨테이너 내부 `/app/app.jar`, BusyBox `wget` 확인
- [x] `git diff --check`

## 참고

로컬에 `actionlint`가 없어 workflow 정적 검사는 수행하지 못했습니다. GitHub Actions cache round-trip은 CI 실행에서 최종 확인하면 됩니다.
