### PR TITLE
chore: allow local frontend origins for CORS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,6 @@ node_modules/
 package-lock.json
 
 ### api key ###
-src/main/resources/application-google.yml
-src/main/resources/application-dev.yml
 
 
 ### harness ###

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,53 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: true
+  flyway:
+    enabled: true
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: local-dummy-client-id
+            client-secret: local-dummy-client-secret
+            scope:
+              - email
+              - profile
+
+app:
+  jwt:
+    secret: NHk7ya+qk5IVD/24BO7/BLFfdpqrZ6bSw/J9EyQDP7uCHtoF9NxD7OUwiHpiqt+MsxQd5eOcCknYJhvF+N8AVg==
+    access-token-expiration-seconds: 3600
+    refresh-token-expiration-seconds: 1209600
+  oauth2:
+    redirect-success-url: http://localhost:3000/oauth2/redirect
+  cookie:
+    secure: false
+  cors:
+    allowed-origins:
+      - https://vs.io.kr
+      - http://localhost:3000
+      - http://127.0.0.1:3000
+    allowed-methods: GET,POST,PUT,PATCH,DELETE,OPTIONS
+    allowed-headers: Authorization,Content-Type,X-Requested-With,Accept,Origin
+    allow-credentials: true
+    max-age: 3600
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -46,8 +46,9 @@ app:
   cors:
     # 브라우저 기반 운영 도메인은 APP_CORS_ALLOWED_ORIGINS에 콤마로 구분해 설정합니다.
     # 예: https://vs.io.kr,https://admin.vs.io.kr
+    # 로컬 프론트 개발 편의를 위해 기본값에 localhost:3000을 임시 포함합니다.
     # 백엔드 서버간 직접 호출에는 브라우저 CORS 검사가 적용되지 않습니다.
-    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:https://vs.io.kr}
+    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:https://vs.io.kr,http://localhost:3000,http://127.0.0.1:3000}
     allowed-methods: ${APP_CORS_ALLOWED_METHODS:GET,POST,PUT,PATCH,DELETE,OPTIONS}
     allowed-headers: ${APP_CORS_ALLOWED_HEADERS:Authorization,Content-Type,X-Requested-With,Accept,Origin}
     allow-credentials: ${APP_CORS_ALLOW_CREDENTIALS:true}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,6 @@
 spring:
   application:
     name: vs-server
-  profiles:
-    active: dev,google
   jackson:
     serialization:
       write-dates-as-timestamps: false

--- a/src/test/java/com/ject/vs/VsServerApplicationTests.java
+++ b/src/test/java/com/ject/vs/VsServerApplicationTests.java
@@ -2,11 +2,10 @@ package com.ject.vs;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(properties = {
-		"spring.security.oauth2.client.registration.google.client-id=test",
-		"spring.security.oauth2.client.registration.google.client-secret=test"
-})
+@ActiveProfiles("test")
+@SpringBootTest
 class VsServerApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,19 +6,28 @@ spring:
     password:
   h2:
     console:
-      enabled: true
+      enabled: false
   jpa:
     hibernate:
       ddl-auto: validate
-    show-sql: true
   flyway:
     enabled: true
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test-dummy-client-id
+            client-secret: test-dummy-client-secret
+            scope:
+              - email
+              - profile
 
 app:
   jwt:
     secret: NHk7ya+qk5IVD/24BO7/BLFfdpqrZ6bSw/J9EyQDP7uCHtoF9NxD7OUwiHpiqt+MsxQd5eOcCknYJhvF+N8AVg==
-    access-token-expiration-seconds: 10
-    refresh-token-expiration-seconds: 86400
+    access-token-expiration-seconds: 3600
+    refresh-token-expiration-seconds: 1209600
   oauth2:
     redirect-success-url: http://localhost:3000/oauth2/redirect
   cookie:
@@ -31,3 +40,12 @@ app:
     allowed-headers: Authorization,Content-Type,X-Requested-With,Accept,Origin
     allow-credentials: true
     max-age: 3600
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never


### PR DESCRIPTION
## 문제

현재 별도 개발 API 서버가 없어 로컬 Next.js 프론트에서 운영 API(`https://api.vs.io.kr`)를 직접 호출해 테스트해야 하는 상황입니다.

기존 production CORS 기본값은 운영 프론트 도메인만 허용했습니다.

```txt
https://vs.io.kr
```

그래서 로컬 프론트 개발 환경의 preflight 요청은 차단됩니다.

## 수정 내용

### 1. production CORS 기본 허용 origin에 로컬 프론트 origin 추가

wildcard(`*`)는 사용하지 않고, 필요한 로컬 origin만 명시적으로 추가했습니다.

```txt
https://vs.io.kr
http://localhost:3000
http://127.0.0.1:3000
```

`APP_CORS_ALLOWED_ORIGINS`를 명시하면 기존처럼 환경변수 값이 우선됩니다.

### 2. `dev` 프로필을 `local` 프로필로 정리

`application-dev.yml`을 `application-local.yml`로 변경했습니다.

- 로컬 H2 설정 유지
- 로컬 OAuth dummy client 설정 포함
- 로컬 CORS 설정 유지
- 기본 active profile에서는 제거

### 3. test 전용 프로필 추가

`src/test/resources/application-test.yml`을 추가하고, context load 테스트는 `@ActiveProfiles("test")`를 사용하도록 분리했습니다.

### 4. `openapi` 프로필은 유지

API 클라이언트 생성에서 사용하는 `application-openapi.yaml`은 그대로 유지했습니다.

## 주의

`allow-credentials=true` 상태에서 운영 API가 localhost origin을 신뢰하게 되므로, 이 설정은 개발 API 서버나 프론트 BFF/proxy 흐름이 생기면 제거하는 것을 권장합니다.

## 검증

- [x] `./gradlew test --no-daemon`
- [x] `git diff --check`
