### PR TITLE
Refactor/code review cleanup

### DIFF
--- a/src/main/java/com/ject/vs/domain/User.java
+++ b/src/main/java/com/ject/vs/domain/User.java
@@ -5,7 +5,7 @@ import com.ject.vs.dto.UserProfileRequest;
 import jakarta.persistence.*;
 import lombok.Getter;
 
-import java.time.LocalDate;
+import java.time.Year;
 
 @Entity
 @Getter
@@ -16,11 +16,7 @@ public class User {
 
     private String sub;
 
-    private String gender;
-
-    private LocalDate birthDate;
     private String email;
-    // 아직 유저에 대한 정보 확정 아님
     private String nickname;
 
     private Year birthYear;

--- a/src/main/java/com/ject/vs/vote/domain/AgeGroup.java
+++ b/src/main/java/com/ject/vs/vote/domain/AgeGroup.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.Year;
 
 @Getter
 @RequiredArgsConstructor
@@ -17,8 +18,8 @@ public enum AgeGroup {
 
     private final String label;
 
-    public static AgeGroup fromBirthDate(LocalDate birthDate, Clock clock) {
-        int age = LocalDate.now(clock).getYear() - birthDate.getYear();
+    public static AgeGroup fromBirthYear(Year birthYear, Clock clock) {
+        int age = LocalDate.now(clock).getYear() - birthYear.getValue();
         if (age < 20) return TEENS;
         if (age < 30) return TWENTIES;
         if (age < 40) return THIRTIES;

--- a/src/main/java/com/ject/vs/vote/domain/GenderCount.java
+++ b/src/main/java/com/ject/vs/vote/domain/GenderCount.java
@@ -1,4 +1,6 @@
 package com.ject.vs.vote.domain;
 
-public record GenderCount(String gender, long count) {
+import com.ject.vs.domain.Gender;
+
+public record GenderCount(Gender gender, long count) {
 }

--- a/src/main/java/com/ject/vs/vote/port/VoteResultQueryService.java
+++ b/src/main/java/com/ject/vs/vote/port/VoteResultQueryService.java
@@ -1,5 +1,6 @@
 package com.ject.vs.vote.port;
 
+import com.ject.vs.domain.Gender;
 import com.ject.vs.domain.User;
 import com.ject.vs.repository.UserRepository;
 import com.ject.vs.vote.domain.*;
@@ -101,7 +102,7 @@ public class VoteResultQueryService implements VoteResultQueryUseCase {
 
     private AgeGroup resolveMyAgeGroup(Long userId) {
         return userRepository.findById(userId)
-                .map(u -> u.getBirthDate() != null ? AgeGroup.fromBirthDate(u.getBirthDate(), clock) : null)
+                .map(u -> u.getBirthYear() != null ? AgeGroup.fromBirthYear(u.getBirthYear(), clock) : null)
                 .orElse(null);
     }
 
@@ -110,7 +111,7 @@ public class VoteResultQueryService implements VoteResultQueryUseCase {
         if (totalGender == 0) return new GenderDistribution(0, 0);
 
         long maleCount = genderCounts.stream()
-                .filter(gc -> "MALE".equals(gc.gender())).mapToLong(GenderCount::count).sum();
+                .filter(gc -> Gender.MALE == gc.gender()).mapToLong(GenderCount::count).sum();
         int maleRatio = (int) Math.round(maleCount * 100.0 / totalGender);
         return new GenderDistribution(maleRatio, 100 - maleRatio);
     }
@@ -129,9 +130,9 @@ public class VoteResultQueryService implements VoteResultQueryUseCase {
         List<User> users = userRepository.findAllById(userIds);
 
         Map<AgeGroup, Long> groupCounts = users.stream()
-                .filter(u -> u.getBirthDate() != null)
+                .filter(u -> u.getBirthYear() != null)
                 .collect(Collectors.groupingBy(
-                        u -> AgeGroup.fromBirthDate(u.getBirthDate(), clock),
+                        u -> AgeGroup.fromBirthYear(u.getBirthYear(), clock),
                         Collectors.counting()));
 
         long total = groupCounts.values().stream().mapToLong(Long::longValue).sum();


### PR DESCRIPTION
## 📌 관련 이슈
- closes #

## 🔍 작업 내용
develop 브랜치 머지 과정에서 발생한 User 도메인의 gender/birthDate 중복 필드를 정리하고,
관련 vote 도메인의 타입 불일치를 함께 수정합니다.

## 📝 변경 사항
- `User.java`: 기존 `String gender`, `LocalDate birthDate` 제거 → `Gender enum`, `Year birthYear`로 통일
- `GenderCount.java`: `gender` 타입을 `String`에서 `Gender` enum으로 변경해 타입 안전성 확보
- `AgeGroup.java`: `fromBirthDate(LocalDate)` → `fromBirthYear(Year)`로 변경
- `VoteResultQueryService.java`: 변경된 타입에 맞게 `getBirthYear()`, `fromBirthYear()`, `Gender.MALE ==` 비교로 수정

## 💬 리뷰어에게
- `AgeGroup.fromBirthYear`는 연도만 사용해 나이를 계산하므로 기존 `fromBirthDate`와 동작 차이 없습니다.
- `GenderCount.gender`가 `String`일 때 JPA 쿼리에서 enum → String 암묵적 변환에 의존하던 부분을 명시적 enum 타입으로 바꿨습니다.
- `"MALE".equals(gc.gender())` → `Gender.MALE == gc.gender()` 변경으로 enum 비교는 `==` 사용이 맞는지 확인 부탁드립니다.
