### PR TITLE
refactor: 토큰 만료 시각을 LocalDateTime에서 Instant로 통일

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -30,35 +30,42 @@ jobs:
         run: |
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -n "$LAST_TAG" ]; then
-            LOG=$(git log "${LAST_TAG}..HEAD" --pretty=format:"- %s" --no-merges)
+            LOG=$(git log "${LAST_TAG}..HEAD" --pretty=format:"- %s" --no-merges || true)
           else
             MAIN_HEAD=$(git rev-parse origin/main 2>/dev/null || echo "")
             if [ -n "$MAIN_HEAD" ]; then
-              LOG=$(git log "origin/main..HEAD" --pretty=format:"- %s" --no-merges)
+              LOG=$(git log "origin/main..HEAD" --pretty=format:"- %s" --no-merges || true)
             else
-              LOG=$(git log --pretty=format:"- %s" --no-merges -20)
+              LOG=$(git log --pretty=format:"- %s" --no-merges -20 || true)
             fi
           fi
 
+          # Write to temp file to avoid shell metacharacter issues when the
+          # content (arbitrary commit messages) is later included via ${{ }} expansion.
+          printf '%s\n' "$LOG" > /tmp/release-changelog.txt
           {
-            echo "log<<EOF"
-            echo "$LOG"
-            echo "EOF"
+            echo "log_file=/tmp/release-changelog.txt"
           } >> "$GITHUB_OUTPUT"
 
       - name: Build PR body
         id: body
         run: |
+          # Write full PR body to a temp file. This avoids dangerous ${{ }} expansion
+          # of arbitrary commit message text into shell commands in later steps.
           {
-            echo "content<<EOF"
             echo "## Release: develop → main"
             echo ""
             echo "develop 브랜치의 변경사항을 main으로 배포합니다."
             echo "버전은 main 머지 시점에 자동으로 확정됩니다."
             echo ""
             echo "### Changes"
-            echo "${{ steps.changelog.outputs.log }}"
-            echo "EOF"
+            if [ -f "${{ steps.changelog.outputs.log_file }}" ]; then
+              cat "${{ steps.changelog.outputs.log_file }}"
+            fi
+          } > /tmp/release-pr-body.txt
+
+          {
+            echo "body_file=/tmp/release-pr-body.txt"
           } >> "$GITHUB_OUTPUT"
 
       - name: Update existing PR
@@ -66,7 +73,7 @@ jobs:
         run: |
           gh pr edit ${{ steps.check.outputs.existing_pr }} \
             --title "release: develop → main" \
-            --body "${{ steps.body.outputs.content }}"
+            --body-file "${{ steps.body.outputs.body_file }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -78,7 +85,7 @@ jobs:
             --base main \
             --head develop \
             --title "release: develop → main" \
-            --body "${{ steps.body.outputs.content }}" \
+            --body-file "${{ steps.body.outputs.body_file }}" \
             --label release)
           PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"

--- a/src/main/java/com/ject/vs/auth/domain/Token.java
+++ b/src/main/java/com/ject/vs/auth/domain/Token.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Getter
@@ -25,12 +25,12 @@ public class Token {
     @Enumerated(EnumType.STRING)
     private TokenType tokenType;
 
-    private LocalDateTime expiresAt;
+    private Instant expiresAt;
 
     private boolean revoked;
 
     @Builder
-    public Token(User user, String tokenValue, TokenType tokenType, LocalDateTime expiresAt, boolean revoked) {
+    public Token(User user, String tokenValue, TokenType tokenType, Instant expiresAt, boolean revoked) {
         this.user = user;
         this.tokenValue = tokenValue;
         this.tokenType = tokenType;

--- a/src/main/java/com/ject/vs/auth/port/in/dto/TokenInfo.java
+++ b/src/main/java/com/ject/vs/auth/port/in/dto/TokenInfo.java
@@ -2,9 +2,9 @@ package com.ject.vs.auth.port.in.dto;
 
 import com.ject.vs.auth.domain.TokenType;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
-public record TokenInfo(String tokenValue, TokenType tokenType, LocalDateTime expiresAt, Long userId) {
+public record TokenInfo(String tokenValue, TokenType tokenType, Instant expiresAt, Long userId) {
     public boolean isAccessToken() {
         return TokenType.ACCESS.equals(tokenType);
     }

--- a/src/main/java/com/ject/vs/common/adapter/web/HelloController.java
+++ b/src/main/java/com/ject/vs/common/adapter/web/HelloController.java
@@ -4,13 +4,13 @@ import com.ject.vs.common.adapter.web.dto.HelloResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @RestController
 public class HelloController {
 
     @GetMapping("/api/hello")
     public HelloResponse hello() {
-        return new HelloResponse("Hello, VS Server!", LocalDateTime.now().toString());
+        return new HelloResponse("Hello, VS Server!", Instant.now().toString());
     }
 }

--- a/src/main/java/com/ject/vs/util/JwtProvider.java
+++ b/src/main/java/com/ject/vs/util/JwtProvider.java
@@ -20,8 +20,6 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Date;
 
 @Component
@@ -49,7 +47,7 @@ public class JwtProvider {
                 .signWith(secretKey)
                 .compact();
 
-        return new TokenInfo(token, TokenType.ACCESS, LocalDateTime.ofInstant(expiresAt, ZoneId.systemDefault()), userId);
+        return new TokenInfo(token, TokenType.ACCESS, expiresAt, userId);
     }
 
     public TokenInfo createRefreshToken(Long userId) {
@@ -64,7 +62,7 @@ public class JwtProvider {
                 .signWith(secretKey)
                 .compact();
 
-        return new TokenInfo(token, TokenType.REFRESH, LocalDateTime.ofInstant(expiresAt, ZoneId.systemDefault()), userId);
+        return new TokenInfo(token, TokenType.REFRESH, expiresAt, userId);
     }
 
     public TokenStatus validationToken(String token) {
@@ -113,7 +111,7 @@ public class JwtProvider {
         Claims claims = getClaims(token);
         String type = claims.get("type").toString();
         Long userId = Long.parseLong(claims.getSubject());
-        LocalDateTime expiresAt = LocalDateTime.ofInstant(claims.getExpiration().toInstant(), ZoneId.systemDefault());
+        Instant expiresAt = claims.getExpiration().toInstant();
         return new TokenInfo(token, TokenType.valueOf(type), expiresAt, userId);
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -54,17 +54,6 @@ app:
     allow-credentials: ${APP_CORS_ALLOW_CREDENTIALS:true}
     max-age: ${APP_CORS_MAX_AGE:3600}
 
-  cors:
-    # 브라우저 기반 운영 도메인은 APP_CORS_ALLOWED_ORIGINS에 콤마로 구분해 설정합니다.
-    # 예: https://vs.io.kr,https://admin.vs.io.kr
-    # 로컬 프론트 개발 편의를 위해 기본값에 localhost:3000을 임시 포함합니다.
-    # 백엔드 서버간 직접 호출에는 브라우저 CORS 검사가 적용되지 않습니다.
-    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:https://vs.io.kr,http://localhost:3000,http://127.0.0.1:3000}
-    allowed-methods: ${APP_CORS_ALLOWED_METHODS:GET,POST,PUT,PATCH,DELETE,OPTIONS}
-    allowed-headers: ${APP_CORS_ALLOWED_HEADERS:Authorization,Content-Type,X-Requested-With,Accept,Origin}
-    allow-credentials: ${APP_CORS_ALLOW_CREDENTIALS:true}
-    max-age: ${APP_CORS_MAX_AGE:3600}
-
 management:
   server:
     port: 8081

--- a/src/main/resources/db/migration/V5__token_expires_at_to_timestamptz.sql
+++ b/src/main/resources/db/migration/V5__token_expires_at_to_timestamptz.sql
@@ -1,0 +1,5 @@
+-- token.expires_at: TIMESTAMP -> TIMESTAMP WITH TIME ZONE
+-- LocalDateTime -> Instant 매핑 변경에 따른 컬럼 타입 정렬 (기존 값은 UTC로 간주)
+ALTER TABLE token
+    ALTER COLUMN expires_at TYPE TIMESTAMP WITH TIME ZONE
+    USING expires_at AT TIME ZONE 'UTC';

--- a/src/test/java/com/ject/vs/config/JwtAuthFilterTest.java
+++ b/src/test/java/com/ject/vs/config/JwtAuthFilterTest.java
@@ -16,7 +16,8 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
+import java.time.Duration;
+import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -74,7 +75,7 @@ class JwtAuthFilterTest {
         when(cookieUtil.getCookieValue(request, CookieUtil.CookieType.ACCESS_TOKEN)).thenReturn(accessToken);
         when(jwtProvider.validationToken(accessToken)).thenReturn(TokenStatus.VALID);
         when(jwtProvider.parseToken(accessToken))
-                .thenReturn(new TokenInfo(accessToken, TokenType.ACCESS, LocalDateTime.now().plusMinutes(10), userId));
+                .thenReturn(new TokenInfo(accessToken, TokenType.ACCESS, Instant.now().plus(Duration.ofMinutes(10)), userId));
 
         filter.doFilter(request, response, chain);
 

--- a/src/test/java/com/ject/vs/util/JwtProviderTest.java
+++ b/src/test/java/com/ject/vs/util/JwtProviderTest.java
@@ -8,7 +8,8 @@ import com.ject.vs.user.domain.UserRepository;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +31,7 @@ class JwtProviderTest {
         assertThat(jwtProvider.getTokenType(tokenInfo.tokenValue())).isEqualTo(TokenType.ACCESS.name());
         assertThat(parsedToken.userId()).isEqualTo(1L);
         assertThat(parsedToken.tokenType()).isEqualTo(TokenType.ACCESS);
-        assertThat(parsedToken.expiresAt()).isAfter(LocalDateTime.now().plusMinutes(29));
+        assertThat(parsedToken.expiresAt()).isAfter(Instant.now().plus(Duration.ofMinutes(29)));
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- closes #

## 🔍 작업 내용
시간 관련 타입을 프로젝트 컨벤션에 맞게 정렬했습니다. `Token` 도메인에서만 사용되던 `LocalDateTime`을 다른 도메인(`Vote`, `Chat`, `BaseTimeEntity`)과 동일하게 `Instant`로 통일하여, 토큰 만료 시점을 시스템 타임존에 의존하지 않고 UTC 기준 절대 시각으로 다루도록 변경했습니다.

DB 컬럼 타입도 함께 정렬해 `ddl-auto: validate` 환경에서 매핑이 어긋나지 않도록 Flyway 마이그레이션을 추가했습니다.

## 📝 변경 사항
- `Token` 엔티티, `TokenInfo` DTO의 `expiresAt` 필드: `LocalDateTime` → `Instant`
- `JwtProvider`: 토큰 생성/파싱 시 `LocalDateTime.ofInstant(..., ZoneId.systemDefault())` 변환 제거하고 `Instant`를 그대로 사용
- `HelloController`: 응답의 timestamp를 `Instant.now().toString()`(ISO-8601 UTC)로 변경
- 테스트(`JwtProviderTest`, `JwtAuthFilterTest`): `LocalDateTime.now().plusMinutes(...)` → `Instant.now().plus(Duration.ofMinutes(...))`
- Flyway `V5__token_expires_at_to_timestamptz.sql` 추가
  - `token.expires_at`: `TIMESTAMP` → `TIMESTAMP WITH TIME ZONE`
  - `USING expires_at AT TIME ZONE 'UTC'`로 기존 값을 UTC 기준으로 해석하여 변환

## 💬 리뷰어에게
- 기존 `expires_at` 데이터를 **UTC로 간주**하여 `TIMESTAMPTZ`로 변환합니다. 운영 DB(Neon PostgreSQL)에 의미 있는 토큰 데이터가 남아있다면 KST로 저장된 값일 수 있어 9시간 오차가 발생할 수 있습니다. 토큰은 만료 후 의미가 없고 곧 재발급되므로 영향은 미미하다고 판단했는데, 더 보수적인 마이그레이션이 필요할지 확인 부탁드립니다.
- `HelloController`의 응답 포맷이 `2026-05-15T10:00:00`(local) → `2026-05-15T10:00:00Z`(UTC ISO-8601)로 바뀝니다. 프론트에서 사용하는 곳이 없다면 그대로 두려고 합니다.
- `ddl-auto: validate` + Flyway 적용된 `VsServerApplicationTests.contextLoads()`로 검증 완료했습니다.