### PR TITLE
fix: create-release-pr 워크플로우 파서 오류 완전 해결 (주석의 ${{ 문자 제거)

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -40,14 +40,14 @@ jobs:
           fi
 
           # Always write to a fixed temp file. Never pass arbitrary commit
-          # messages through GITHUB_OUTPUT or ${{ }} expansion.
+          # messages through GITHUB_OUTPUT or expression interpolation.
           printf '%s\n' "$LOG" > /tmp/release-changelog.txt
 
       - name: Build PR body
         run: |
           # Build the PR body using only hardcoded paths. This guarantees
-          # the workflow file itself never contains ${{ }} inside a run: block,
-          # which was causing "An expression was expected" parser errors.
+          # the workflow file itself never contains expression syntax inside
+          # a run: block (the cause of previous "An expression was expected" errors).
           {
             echo "## Release: develop → main"
             echo ""


### PR DESCRIPTION
## 문제 (재발)
PR #111 머지 후에도 develop push 시 동일한 에러가 발생했습니다:

```
(Line: 29, Col: 14): An expression was expected
(Line: 47, Col: 14): An expression was expected
```

## 진짜 원인
GitHub Actions 워크플로우 파서는 파일 전체를 스캔하면서 `${{` 문자열을 찾습니다.  
`run: |` 블록 **내부의 주석**에조차 `${{ }}` 문자가 있으면 expression parser가 해당 컨텍스트를 expression으로 오해하여 `run: |` 라인에서 "An expression was expected" 에러를 보고합니다.

PR #111에서는 코드의 `${{ steps...outputs... }}`는 제거했지만, **설명 주석**에 `${{ }}` 를 그대로 남겨둬서 문제가 지속됐습니다.

## 해결
- 주석에서 `${{` 문자를 완전히 제거
- "expression interpolation", "expression syntax" 같은 표현으로 대체
- 이제 `run:` 블록 안에 `${{` 문자열이 **전혀** 존재하지 않음

이 PR을 머지하면 release 워크플로우가 정상 동작할 것입니다.