### PR TITLE
chore: GitHub Actions 워크플로우 검증을 위한 actionlint CI 추가

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  actionlint:
+    name: actionlint + shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1
+        with:
+          fail_level: error
+          filter_mode: nofilter
+          level: warning


### PR DESCRIPTION
## 배경
`create-release-pr.yml`에서 여러 번 "An expression was expected" 파서 오류가 발생했습니다.  
로컬에서 미리 잡지 못하고 develop에 머지된 후에야 발견되는 문제가 반복됐습니다.

## 해결
- `actionlint` (GitHub Actions 전용 정적 분석 도구 + shellcheck 연동)를 CI에 추가
- `.github/workflows/**` 파일이 변경되는 모든 PR에서 자동 실행
- 오류가 있으면 PR을 실패 처리 (`fail_level: error`)

## 효과
- 앞으로 workflow를 수정할 때 **로컬에서 `actionlint` 명령으로 바로 검증** 가능
- CI에서도 자동으로 막아줌
- shell script 실수, deprecated action input, expression 문법 오류 등을 사전에 차단

## 사용법 (로컬)
```bash
# actionlint 설치 (macOS)
brew install actionlint

# 현재 저장소의 모든 워크플로우 검사
actionlint

# 특정 파일만
actionlint .github/workflows/create-release-pr.yml
```

PR #112 이후 현재 모든 워크플로우 파일은 actionlint를 통과합니다.