### PR TITLE
fix: app.oauth2.extra-info-url 환경변수 지원 추가

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -35,7 +35,8 @@ server:
 app:
   oauth2:
     # 운영 도메인 확정 후 실제 URL로 교체 필요 (관련 이슈: #43)
-    redirect-success-url: https://example.com/oauth2/redirect
+    redirect-success-url: ${APP_OAUTH2_REDIRECT_SUCCESS_URL:https://example.com/oauth2/redirect}
+    extra-info-url: ${APP_OAUTH2_EXTRA_INFO_URL:https://example.com/extra-info}
   cookie:
     secure: true
   jwt:


### PR DESCRIPTION
배포 시 `app.oauth2.extra-info-url` 누락으로 인한 `PlaceholderResolutionException` 해결.

- `APP_OAUTH2_EXTRA_INFO_URL` 환경변수 지원
- `redirect-success-url`도 동일 패턴으로 통일
- 기본값은 기존 placeholder 유지