### PR TITLE
fix: application-openapi.yaml에 extra-info-url 환경변수 추가

### DIFF
--- a/src/main/resources/application-openapi.yaml
+++ b/src/main/resources/application-openapi.yaml
@@ -29,7 +29,8 @@ app:
     access-token-expiration-seconds: 1800
     refresh-token-expiration-seconds: 2592000
   oauth2:
-    redirect-success-url: http://localhost:3000/oauth2/redirect
+    redirect-success-url: ${APP_OAUTH2_REDIRECT_SUCCESS_URL:http://localhost:3000/oauth2/redirect}
+    extra-info-url: ${APP_OAUTH2_EXTRA_INFO_URL:http://localhost:3000/extra-info}
   cookie:
     secure: false
 


### PR DESCRIPTION
release 시 `publish-api-client` 작업에서 `ExtractSwaggerTask`가 openapi 프로파일로 애플리케이션을 시작할 때 `app.oauth2.extra-info-url` placeholder를 찾지 못해 실패하는 문제 해결.

- `application-openapi.yaml`에도 동일한 환경변수 패턴 적용
- release workflow의 API 클라이언트 생성/배포 단계가 정상 동작하도록 보장