### PR TITLE
fix: WebSocket STOMP 인증을 쿠키 기반으로 변경

### DIFF
--- a/docs/plan/2026-04-26-chat-implementation-plan.md
+++ b/docs/plan/2026-04-26-chat-implementation-plan.md
@@ -326,7 +326,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic");      // 구독 prefix
-        registry.setUserDestinationPrefix("/user"); // 사용자별 개인 채널 prefix
+        // setUserDestinationPrefix("/user") 제거 — /topic/chat/{voteId}/unread/{userId} 경로로 통일
     }
 
     @Override
@@ -341,10 +341,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 #### 5-2. WebSocketAuthInterceptor
 
 STOMP CONNECT frame 수신 시 `Authorization` 헤더에서 JWT를 추출해 인증 처리.  
-`accessor.setUser()`로 설정한 `Principal`은 이후 두 가지 역할을 한다.
-
-1. **서버 → 클라이언트 전송**: `convertAndSendToUser(userId, ...)` 호출 시 Spring이 해당 userId의 세션을 찾아 메시지를 라우팅.
-2. **클라이언트 구독 라우팅**: 클라이언트가 `/user/topic/...`으로 구독하면 Spring이 내부적으로 `/user/{userId}/topic/...`으로 매핑. `WebSocketConfig`의 `setUserDestinationPrefix("/user")`가 이 매핑을 활성화.
+`accessor.setUser()`로 설정한 `Principal`은 메시지 전송(`convertAndSendToUser`) 시 사용되었으나,
+현재는 `/topic/chat/{voteId}/unread/{userId}` 경로에 userId를 직접 포함하는 방식으로 변경하여
+`/user` prefix와 `setUserDestinationPrefix`를 제거하였다. (일관성 확보)
 
 ```java
 @Component
@@ -390,8 +389,8 @@ REST POST /api/chats/{voteId}/messages  { "content": "..." }
     ├─ ChatMessagePort.save(): DB 저장
     ├─ SimpMessagingTemplate.convertAndSend("/topic/chat/{voteId}")
     │     payload: { messageId, content, sentAt, senderNickname, senderVoteOption, isMine }
-    └─ SimpMessagingTemplate.convertAndSendToUser(userId, "/topic/chat/{voteId}/unread")
-          payload: { unreadCount }  ← 사용자마다 다른 값이므로 개인 채널로 전송
+    └─ SimpMessagingTemplate.convertAndSend("/topic/chat/{voteId}/unread/{userId}")
+          payload: { unreadCount }  ← 사용자마다 다른 값이므로 userId를 경로에 포함하여 전송
 ```
 
 ---

--- a/docs/plan/2026-04-26-chat-implementation-plan.md
+++ b/docs/plan/2026-04-26-chat-implementation-plan.md
@@ -326,7 +326,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic");      // 구독 prefix
-        // setUserDestinationPrefix("/user") 제거 — /topic/chat/{voteId}/unread/{userId} 경로로 통일
+        registry.setUserDestinationPrefix("/user"); // 사용자별 개인 채널 prefix (convertAndSendToUser용)
     }
 
     @Override
@@ -341,9 +341,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 #### 5-2. WebSocketAuthInterceptor
 
 STOMP CONNECT frame 수신 시 `Authorization` 헤더에서 JWT를 추출해 인증 처리.  
-`accessor.setUser()`로 설정한 `Principal`은 메시지 전송(`convertAndSendToUser`) 시 사용되었으나,
-현재는 `/topic/chat/{voteId}/unread/{userId}` 경로에 userId를 직접 포함하는 방식으로 변경하여
-`/user` prefix와 `setUserDestinationPrefix`를 제거하였다. (일관성 확보)
+`accessor.setUser()`로 설정한 `Principal`은 이후 두 가지 역할을 한다.
+
+1. **서버 → 클라이언트 전송**: `convertAndSendToUser(userId, ...)` 호출 시 Spring이 해당 userId의 세션을 찾아 메시지를 라우팅.
+2. **클라이언트 구독 라우팅**: 클라이언트가 `/user/topic/...`으로 구독하면 Spring이 내부적으로 해당 Principal의 세션에만 메시지를 전달. `/user` prefix는 **보안을 위해 필수**이며, 임의 userId로 다른 사람의 개인 채널을 구독할 수 없게 한다.
 
 ```java
 @Component
@@ -389,8 +390,8 @@ REST POST /api/chats/{voteId}/messages  { "content": "..." }
     ├─ ChatMessagePort.save(): DB 저장
     ├─ SimpMessagingTemplate.convertAndSend("/topic/chat/{voteId}")
     │     payload: { messageId, content, sentAt, senderNickname, senderVoteOption, isMine }
-    └─ SimpMessagingTemplate.convertAndSend("/topic/chat/{voteId}/unread/{userId}")
-          payload: { unreadCount }  ← 사용자마다 다른 값이므로 userId를 경로에 포함하여 전송
+    └─ SimpMessagingTemplate.convertAndSendToUser(userId, "/topic/chat/{voteId}/unread")
+          payload: { unreadCount }  ← 사용자마다 다른 값이므로 Principal 기반 개인 채널로 전송 (보안)
 ```
 
 ---

--- a/docs/spec/2026-04-26-chat-api-spec.md
+++ b/docs/spec/2026-04-26-chat-api-spec.md
@@ -251,8 +251,8 @@ ALTER TABLE users
 구독: /topic/chat/{voteId}         ← 새 메시지 수신 (모든 참여자)
 
 ─ 읽지 않은 메시지 뱃지 ────────────────────────────
-구독: /topic/chat/{voteId}/unread/{userId}  ← 새 메시지 도착 시 본인의 unreadCount 갱신
-                                               (userId별 개인 경로, 채팅 목록 화면에서 실시간 반영)
+구독: /user/topic/chat/{voteId}/unread  ← 새 메시지 도착 시 본인의 unreadCount 갱신
+                                           (사용자별 개인 채널, 채팅 목록 화면에서 실시간 반영)
 ```
 
 **수신 Payload (`/topic/chat/{voteId}`):**
@@ -268,13 +268,13 @@ ALTER TABLE users
 }
 ```
 
-**수신 Payload (`/topic/chat/{voteId}/unread/{userId}`):**
+**수신 Payload (`/user/topic/chat/{voteId}/unread`):**
 ```json
 { "unreadCount": 3 }
 ```
 
-> 서버는 `convertAndSend("/topic/chat/{voteId}/unread/{userId}", payload)`로 전송.  
-> 각 사용자의 unreadCount가 다르므로 userId를 경로에 포함하여 분리.
+> 서버는 `convertAndSendToUser(userId, "/topic/chat/{voteId}/unread", payload)`로 전송.  
+> 각 사용자의 unreadCount가 다르므로 `Principal` 기반 개인 채널로 분리 (보안상 외부에서 임의 userId로 구독 불가).
 
 > **REST vs WebSocket 역할 분리**
 > - 메시지 전송 → REST `POST /api/chats/{voteId}/messages`

--- a/docs/spec/2026-04-26-chat-api-spec.md
+++ b/docs/spec/2026-04-26-chat-api-spec.md
@@ -251,8 +251,8 @@ ALTER TABLE users
 구독: /topic/chat/{voteId}         ← 새 메시지 수신 (모든 참여자)
 
 ─ 읽지 않은 메시지 뱃지 ────────────────────────────
-구독: /user/topic/chat/{voteId}/unread  ← 새 메시지 도착 시 본인의 unreadCount 갱신
-                                           (사용자별 개인 채널, 채팅 목록 화면에서 실시간 반영)
+구독: /topic/chat/{voteId}/unread/{userId}  ← 새 메시지 도착 시 본인의 unreadCount 갱신
+                                               (userId별 개인 경로, 채팅 목록 화면에서 실시간 반영)
 ```
 
 **수신 Payload (`/topic/chat/{voteId}`):**
@@ -268,13 +268,13 @@ ALTER TABLE users
 }
 ```
 
-**수신 Payload (`/user/topic/chat/{voteId}/unread`):**
+**수신 Payload (`/topic/chat/{voteId}/unread/{userId}`):**
 ```json
 { "unreadCount": 3 }
 ```
 
-> 서버는 `convertAndSendToUser(userId, "/topic/chat/{voteId}/unread", payload)`로 전송.  
-> 각 사용자의 unreadCount가 다르므로 개인 채널로 분리.
+> 서버는 `convertAndSend("/topic/chat/{voteId}/unread/{userId}", payload)`로 전송.  
+> 각 사용자의 unreadCount가 다르므로 userId를 경로에 포함하여 분리.
 
 > **REST vs WebSocket 역할 분리**
 > - 메시지 전송 → REST `POST /api/chats/{voteId}/messages`

--- a/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
+++ b/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
@@ -51,9 +51,8 @@ public class ChatMessageEventListener {
                             message.getVoteId(), unread.getLastReadMessageId()))
                     .orElse(totalCount);
 
-            messagingTemplate.convertAndSendToUser(
-                    String.valueOf(participantUserId),
-                    "/topic/chat/" + message.getVoteId() + "/unread",
+            messagingTemplate.convertAndSend(
+                    "/topic/chat/" + message.getVoteId() + "/unread/" + participantUserId,
                     new UnreadPayload(message.getVoteId(), unreadCount)
             );
         }

--- a/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
+++ b/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
@@ -51,8 +51,9 @@ public class ChatMessageEventListener {
                             message.getVoteId(), unread.getLastReadMessageId()))
                     .orElse(totalCount);
 
-            messagingTemplate.convertAndSend(
-                    "/topic/chat/" + message.getVoteId() + "/unread/" + participantUserId,
+            messagingTemplate.convertAndSendToUser(
+                    String.valueOf(participantUserId),
+                    "/topic/chat/" + message.getVoteId() + "/unread",
                     new UnreadPayload(message.getVoteId(), unreadCount)
             );
         }

--- a/src/main/java/com/ject/vs/config/SecurityConfig.java
+++ b/src/main/java/com/ject/vs/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -18,6 +19,7 @@ public class SecurityConfig {
             HttpSecurity http,
             OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler,
             CustomOAuth2UserService customOAuth2UserService,
+            JwtAuthFilter jwtAuthFilter,
             CorsConfigurationSource corsConfigurationSource
     ) throws Exception {
         CsrfTokenRequestAttributeHandler requestHandler = new CsrfTokenRequestAttributeHandler();
@@ -36,7 +38,8 @@ public class SecurityConfig {
                 )
                 .oauth2Login(oauth2 -> oauth2
                         .successHandler(oAuth2LoginSuccessHandler)
-                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService)));
+                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService)))
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/ject/vs/config/SecurityPaths.java
+++ b/src/main/java/com/ject/vs/config/SecurityPaths.java
@@ -13,6 +13,7 @@ public class SecurityPaths {
             "/actuator/health/**",
             "/",
             "/error",
+            "/ws/**",
             "/oauth2/authorization/**",
             "/login/oauth2/code/**"
     );

--- a/src/main/java/com/ject/vs/config/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/ject/vs/config/WebSocketAuthInterceptor.java
@@ -1,7 +1,7 @@
 package com.ject.vs.config;
 
-import com.ject.vs.util.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -10,27 +10,25 @@ import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class WebSocketAuthInterceptor implements ChannelInterceptor {
-
-    private final JwtProvider jwtProvider;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
         if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
-            String authHeader = accessor.getFirstNativeHeader("Authorization");
-            if (authHeader != null && authHeader.startsWith("Bearer ")) {
-                String token = authHeader.substring(7);
-                try {
-                    Long userId = jwtProvider.getUserId(token);
-                    accessor.setUser(() -> String.valueOf(userId));
-                } catch (Exception e) {
-                    // 유효하지 않은 토큰 — anonymous 통과
-                }
+            Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+            if (sessionAttributes != null && sessionAttributes.containsKey("userId")) {
+                Long userId = (Long) sessionAttributes.get("userId");
+                accessor.setUser(() -> String.valueOf(userId));
+                log.debug("WebSocket STOMP CONNECT authenticated via cookie, userId={}", userId);
             }
+            // 쿠키 기반 인증 외에는 Principal을 설정하지 않음 (anonymous)
         }
 
         return message;

--- a/src/main/java/com/ject/vs/config/WebSocketConfig.java
+++ b/src/main/java/com/ject/vs/config/WebSocketConfig.java
@@ -37,7 +37,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic");
-        registry.setUserDestinationPrefix("/user");
+        // 사용자별 개인 채널이 필요할 경우 convertAndSendToUser + /user prefix를 사용했으나,
+        // 현재는 /topic/chat/{voteId}/unread/{userId} 경로로 통일하여 /user prefix를 제거함.
     }
 
     @Override

--- a/src/main/java/com/ject/vs/config/WebSocketConfig.java
+++ b/src/main/java/com/ject/vs/config/WebSocketConfig.java
@@ -14,17 +14,24 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final WebSocketAuthInterceptor webSocketAuthInterceptor;
+    private final WebSocketHandshakeInterceptor webSocketHandshakeInterceptor;
     private final CorsProperties corsProperties;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         String[] allowedOriginPatterns = corsProperties.allowedOriginPatterns().toArray(String[]::new);
         if (allowedOriginPatterns.length > 0) {
-            registry.addEndpoint("/ws").setAllowedOriginPatterns(allowedOriginPatterns).withSockJS();
+            registry.addEndpoint("/ws")
+                    .addInterceptors(webSocketHandshakeInterceptor)
+                    .setAllowedOriginPatterns(allowedOriginPatterns)
+                    .withSockJS();
             return;
         }
 
-        registry.addEndpoint("/ws").setAllowedOrigins(corsProperties.allowedOrigins().toArray(String[]::new)).withSockJS();
+        registry.addEndpoint("/ws")
+                .addInterceptors(webSocketHandshakeInterceptor)
+                .setAllowedOrigins(corsProperties.allowedOrigins().toArray(String[]::new))
+                .withSockJS();
     }
 
     @Override

--- a/src/main/java/com/ject/vs/config/WebSocketConfig.java
+++ b/src/main/java/com/ject/vs/config/WebSocketConfig.java
@@ -37,8 +37,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic");
-        // 사용자별 개인 채널이 필요할 경우 convertAndSendToUser + /user prefix를 사용했으나,
-        // 현재는 /topic/chat/{voteId}/unread/{userId} 경로로 통일하여 /user prefix를 제거함.
+        registry.setUserDestinationPrefix("/user"); // 개인화된 메시지(convertAndSendToUser)용 prefix
     }
 
     @Override

--- a/src/main/java/com/ject/vs/config/WebSocketHandshakeInterceptor.java
+++ b/src/main/java/com/ject/vs/config/WebSocketHandshakeInterceptor.java
@@ -1,0 +1,55 @@
+package com.ject.vs.config;
+
+import com.ject.vs.util.CookieUtil;
+import com.ject.vs.util.JwtProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketHandshakeInterceptor implements HandshakeInterceptor {
+
+    private final CookieUtil cookieUtil;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request,
+                                   ServerHttpResponse response,
+                                   WebSocketHandler wsHandler,
+                                   Map<String, Object> attributes) {
+        if (request instanceof ServletServerHttpRequest servletRequest) {
+            HttpServletRequest httpRequest = servletRequest.getServletRequest();
+            String accessToken = cookieUtil.getCookieValue(httpRequest, CookieUtil.CookieType.ACCESS_TOKEN);
+
+            if (accessToken != null && !accessToken.isBlank()) {
+                try {
+                    Long userId = jwtProvider.getUserId(accessToken);
+                    attributes.put("userId", userId);
+                    log.debug("WebSocket handshake authenticated userId={}", userId);
+                } catch (Exception e) {
+                    log.debug("WebSocket handshake token validation failed: {}", e.getMessage());
+                    // invalid token -> anonymous connection (no userId in attributes)
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request,
+                               ServerHttpResponse response,
+                               WebSocketHandler wsHandler,
+                               Exception exception) {
+        // no-op
+    }
+}

--- a/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
@@ -93,7 +93,7 @@ class ChatMessageEventListenerTest {
 
             // then
             ArgumentCaptor<UnreadPayload> captor = ArgumentCaptor.forClass(UnreadPayload.class);
-            verify(messagingTemplate).convertAndSend(eq("/topic/chat/1/unread/3"), captor.capture());
+            verify(messagingTemplate).convertAndSendToUser(eq("3"), eq("/topic/chat/1/unread"), captor.capture());
             assertThat(captor.getValue().unreadCount()).isEqualTo(5L);
         }
 
@@ -112,7 +112,7 @@ class ChatMessageEventListenerTest {
 
             // then
             ArgumentCaptor<UnreadPayload> captor = ArgumentCaptor.forClass(UnreadPayload.class);
-            verify(messagingTemplate).convertAndSend(eq("/topic/chat/1/unread/3"), captor.capture());
+            verify(messagingTemplate).convertAndSendToUser(eq("3"), eq("/topic/chat/1/unread"), captor.capture());
             assertThat(captor.getValue().unreadCount()).isEqualTo(2L);
         }
     }

--- a/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -58,6 +59,40 @@ class ChatMessageEventListenerTest {
 
             // then
             verify(messagingTemplate).convertAndSend(eq("/topic/chat/1"), any(Object.class));
+        }
+
+        @Test
+        void 채팅_broadcast_payload는_메시지_정보를_담고_수신자_관점_isMine은_false다() {
+            // given
+            ChatMessage message = ChatMessage.of(7L, 2L, "hello payload");
+            given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(7L)).willReturn(List.of());
+            given(chatMessageRepository.countByVoteId(7L)).willReturn(0L);
+
+            // when
+            listener.handle(new ChatMessageSentEvent(message));
+
+            // then
+            ArgumentCaptor<MessageResult> captor = ArgumentCaptor.forClass(MessageResult.class);
+            verify(messagingTemplate).convertAndSend(eq("/topic/chat/7"), captor.capture());
+            MessageResult payload = captor.getValue();
+            assertThat(payload.content()).isEqualTo("hello payload");
+            assertThat(payload.senderNickname()).isEqualTo("User#2");
+            assertThat(payload.isMine()).isFalse();
+        }
+
+        @Test
+        void voteId별로_다른_topic에_broadcast한다() {
+            // given
+            ChatMessage message = ChatMessage.of(2L, 9L, "vote 2 message");
+            given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(2L)).willReturn(List.of());
+            given(chatMessageRepository.countByVoteId(2L)).willReturn(0L);
+
+            // when
+            listener.handle(new ChatMessageSentEvent(message));
+
+            // then
+            verify(messagingTemplate).convertAndSend(eq("/topic/chat/2"), any(MessageResult.class));
+            verify(messagingTemplate, never()).convertAndSend(eq("/topic/chat/1"), any(Object.class));
         }
 
         @Test
@@ -114,6 +149,47 @@ class ChatMessageEventListenerTest {
             ArgumentCaptor<UnreadPayload> captor = ArgumentCaptor.forClass(UnreadPayload.class);
             verify(messagingTemplate).convertAndSendToUser(eq("3"), eq("/topic/chat/1/unread"), captor.capture());
             assertThat(captor.getValue().unreadCount()).isEqualTo(2L);
+        }
+
+        @Test
+        void 참여자가_여러_명이면_각_user_destination으로_개별_unreadCount를_전송한다() {
+            // given
+            ChatMessage message = ChatMessage.of(1L, 2L, "hello");
+            given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(1L)).willReturn(List.of(3L, 4L));
+            given(chatMessageRepository.countByVoteId(1L)).willReturn(7L);
+            given(chatRoomUnreadRepository.findByIdUserIdAndIdVoteId(3L, 1L)).willReturn(Optional.empty());
+            ChatRoomUnread unread = ChatRoomUnread.of(4L, 1L, 20L);
+            given(chatRoomUnreadRepository.findByIdUserIdAndIdVoteId(4L, 1L)).willReturn(Optional.of(unread));
+            given(chatMessageRepository.countByVoteIdAndIdGreaterThan(1L, 20L)).willReturn(1L);
+
+            // when
+            listener.handle(new ChatMessageSentEvent(message));
+
+            // then
+            verify(messagingTemplate).convertAndSendToUser(
+                    eq("3"),
+                    eq("/topic/chat/1/unread"),
+                    eq(new UnreadPayload(1L, 7L))
+            );
+            verify(messagingTemplate).convertAndSendToUser(
+                    eq("4"),
+                    eq("/topic/chat/1/unread"),
+                    eq(new UnreadPayload(1L, 1L))
+            );
+        }
+
+        @Test
+        void 참여자가_없으면_개인_unreadCount는_전송하지_않는다() {
+            // given
+            ChatMessage message = ChatMessage.of(1L, 2L, "hello");
+            given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(1L)).willReturn(List.of());
+            given(chatMessageRepository.countByVoteId(1L)).willReturn(0L);
+
+            // when
+            listener.handle(new ChatMessageSentEvent(message));
+
+            // then
+            verify(messagingTemplate, never()).convertAndSendToUser(anyString(), anyString(), any(UnreadPayload.class));
         }
     }
 }

--- a/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
@@ -93,7 +93,7 @@ class ChatMessageEventListenerTest {
 
             // then
             ArgumentCaptor<UnreadPayload> captor = ArgumentCaptor.forClass(UnreadPayload.class);
-            verify(messagingTemplate).convertAndSendToUser(eq("3"), eq("/topic/chat/1/unread"), captor.capture());
+            verify(messagingTemplate).convertAndSend(eq("/topic/chat/1/unread/3"), captor.capture());
             assertThat(captor.getValue().unreadCount()).isEqualTo(5L);
         }
 
@@ -112,7 +112,7 @@ class ChatMessageEventListenerTest {
 
             // then
             ArgumentCaptor<UnreadPayload> captor = ArgumentCaptor.forClass(UnreadPayload.class);
-            verify(messagingTemplate).convertAndSendToUser(eq("3"), eq("/topic/chat/1/unread"), captor.capture());
+            verify(messagingTemplate).convertAndSend(eq("/topic/chat/1/unread/3"), captor.capture());
             assertThat(captor.getValue().unreadCount()).isEqualTo(2L);
         }
     }

--- a/src/test/java/com/ject/vs/chat/adapter/event/ChatWebSocketE2ETest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/event/ChatWebSocketE2ETest.java
@@ -1,0 +1,174 @@
+package com.ject.vs.chat.adapter.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ject.vs.chat.adapter.web.dto.SendMessageRequest;
+import com.ject.vs.chat.port.in.dto.MessageResult;
+import com.ject.vs.chat.port.in.dto.UnreadPayload;
+import com.ject.vs.user.domain.User;
+import com.ject.vs.user.domain.UserRepository;
+import com.ject.vs.util.CookieUtil;
+import com.ject.vs.util.JwtProvider;
+import com.ject.vs.vote.domain.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.*;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.Transport;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+import java.lang.reflect.Type;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ChatWebSocketE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private VoteRepository voteRepository;
+
+    @Autowired
+    private VoteOptionRepository voteOptionRepository;
+
+    @Autowired
+    private VoteParticipationRepository voteParticipationRepository;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final List<StompSession> sessions = new CopyOnWriteArrayList<>();
+
+    @AfterEach
+    void disconnectSessions() {
+        sessions.forEach(session -> {
+            if (session.isConnected()) {
+                session.disconnect();
+            }
+        });
+        sessions.clear();
+    }
+
+    @Test
+    void REST로_채팅을_전송하면_commit_이후_STOMP_채팅과_개인_unread를_수신한다() throws Exception {
+        // given
+        TestFixture fixture = createFixture();
+        StompSession receiverSession = connectWithAccessToken(fixture.receiverId());
+        BlockingQueue<MessageResult> chatMessages = new LinkedBlockingQueue<>();
+        BlockingQueue<UnreadPayload> unreadMessages = new LinkedBlockingQueue<>();
+        receiverSession.subscribe("/topic/chat/" + fixture.voteId(), handler(MessageResult.class, chatMessages));
+        receiverSession.subscribe("/user/topic/chat/" + fixture.voteId() + "/unread", handler(UnreadPayload.class, unreadMessages));
+
+        HttpEntity<SendMessageRequest> request = new HttpEntity<>(
+                new SendMessageRequest("hello e2e websocket"),
+                authenticatedJsonHeaders(fixture.senderId())
+        );
+
+        // when
+        ResponseEntity<String> response = restTemplate.exchange(
+                "/api/chats/" + fixture.voteId() + "/messages",
+                HttpMethod.POST,
+                request,
+                String.class
+        );
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        MessageResult chatPayload = chatMessages.poll(5, TimeUnit.SECONDS);
+        assertThat(chatPayload).isNotNull();
+        assertThat(chatPayload.content()).isEqualTo("hello e2e websocket");
+        assertThat(chatPayload.senderNickname()).isEqualTo("User#" + fixture.senderId());
+        assertThat(chatPayload.isMine()).isFalse();
+
+        UnreadPayload unreadPayload = unreadMessages.poll(5, TimeUnit.SECONDS);
+        assertThat(unreadPayload).isEqualTo(new UnreadPayload(fixture.voteId(), 1L));
+    }
+
+    private TestFixture createFixture() {
+        User sender = userRepository.saveAndFlush(User.createWithEmail("e2e-sender-" + System.nanoTime() + "@test.com"));
+        User receiver = userRepository.saveAndFlush(User.createWithEmail("e2e-receiver-" + System.nanoTime() + "@test.com"));
+        Vote vote = voteRepository.saveAndFlush(Vote.create(VoteType.GENERAL, "e2e chat vote", null, "thumb", null, Duration.ofHours(1), Clock.systemUTC()));
+        VoteOption option = voteOptionRepository.saveAndFlush(VoteOption.of(vote.getId(), "A", 1));
+        voteParticipationRepository.saveAndFlush(VoteParticipation.ofMember(vote.getId(), sender.getId(), option.getId()));
+        voteParticipationRepository.saveAndFlush(VoteParticipation.ofMember(vote.getId(), receiver.getId(), option.getId()));
+        return new TestFixture(vote.getId(), sender.getId(), receiver.getId());
+    }
+
+    private HttpHeaders authenticatedJsonHeaders(Long userId) {
+        String csrfToken = UUID.randomUUID().toString();
+        String accessToken = jwtProvider.createAccessToken(userId).tokenValue();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add(HttpHeaders.COOKIE, CookieUtil.CookieType.ACCESS_TOKEN + "=" + accessToken + "; XSRF-TOKEN=" + csrfToken);
+        headers.add("X-XSRF-TOKEN", csrfToken);
+        return headers;
+    }
+
+    private StompSession connectWithAccessToken(Long userId) throws Exception {
+        String token = jwtProvider.createAccessToken(userId).tokenValue();
+        WebSocketHttpHeaders httpHeaders = new WebSocketHttpHeaders();
+        httpHeaders.add("Cookie", CookieUtil.CookieType.ACCESS_TOKEN + "=" + token);
+        StompSession session = stompClient().connectAsync("http://localhost:" + port + "/ws", httpHeaders, new StompHeaders(), new StompSessionHandlerAdapter() {}).get(3, TimeUnit.SECONDS);
+        sessions.add(session);
+        return session;
+    }
+
+    private WebSocketStompClient stompClient() {
+        List<Transport> transports = List.of(new WebSocketTransport(new StandardWebSocketClient()));
+        WebSocketStompClient stompClient = new WebSocketStompClient(new SockJsClient(transports));
+        MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+        converter.setObjectMapper(objectMapper);
+        stompClient.setMessageConverter(converter);
+        return stompClient;
+    }
+
+    private <T> StompFrameHandler handler(Class<T> payloadType, BlockingQueue<T> queue) {
+        return new StompFrameHandler() {
+            @Override
+            public Type getPayloadType(StompHeaders headers) {
+                return payloadType;
+            }
+
+            @Override
+            public void handleFrame(StompHeaders headers, Object payload) {
+                queue.add(payloadType.cast(payload));
+            }
+        };
+    }
+
+    private record TestFixture(Long voteId, Long senderId, Long receiverId) {
+    }
+}

--- a/src/test/java/com/ject/vs/chat/adapter/event/ChatWebSocketIntegrationTest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/event/ChatWebSocketIntegrationTest.java
@@ -1,0 +1,205 @@
+package com.ject.vs.chat.adapter.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ject.vs.chat.domain.ChatMessage;
+import com.ject.vs.chat.domain.ChatMessageRepository;
+import com.ject.vs.chat.domain.ChatRoomUnread;
+import com.ject.vs.chat.domain.ChatRoomUnreadRepository;
+import com.ject.vs.chat.port.in.dto.MessageResult;
+import com.ject.vs.chat.port.in.dto.UnreadPayload;
+import com.ject.vs.user.domain.User;
+import com.ject.vs.user.domain.UserRepository;
+import com.ject.vs.util.CookieUtil;
+import com.ject.vs.util.JwtProvider;
+import com.ject.vs.vote.domain.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.Transport;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+import java.lang.reflect.Type;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ChatWebSocketIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private ChatMessageEventListener listener;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private VoteRepository voteRepository;
+
+    @Autowired
+    private VoteOptionRepository voteOptionRepository;
+
+    @Autowired
+    private VoteParticipationRepository voteParticipationRepository;
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    private ChatRoomUnreadRepository chatRoomUnreadRepository;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final List<StompSession> sessions = new java.util.concurrent.CopyOnWriteArrayList<>();
+
+    @AfterEach
+    void disconnectSessions() {
+        sessions.forEach(session -> {
+            if (session.isConnected()) {
+                session.disconnect();
+            }
+        });
+        sessions.clear();
+    }
+
+    @Test
+    void 이벤트_발생_후_topic_chat_voteId로_실제_STOMP_메시지를_수신한다() throws Exception {
+        // given
+        TestFixture fixture = createFixture();
+        StompSession session = connectAnonymously();
+        BlockingQueue<MessageResult> messages = new LinkedBlockingQueue<>();
+        session.subscribe("/topic/chat/" + fixture.voteId(), handler(MessageResult.class, messages));
+
+        // when
+        ChatMessage message = chatMessageRepository.saveAndFlush(ChatMessage.of(fixture.voteId(), fixture.senderId(), "hello websocket"));
+        listener.handle(new com.ject.vs.chat.domain.event.ChatMessageSentEvent(message));
+
+        // then
+        MessageResult received = messages.poll(3, TimeUnit.SECONDS);
+        assertThat(received).isNotNull();
+        assertThat(received.messageId()).isEqualTo(message.getId());
+        assertThat(received.content()).isEqualTo("hello websocket");
+        assertThat(received.senderNickname()).isEqualTo("User#" + fixture.senderId());
+        assertThat(received.isMine()).isFalse();
+    }
+
+    @Test
+    void 인증_쿠키로_연결하면_user_destination_unreadCount를_사용자별로_분리해_수신한다() throws Exception {
+        // given
+        TestFixture fixture = createFixture();
+        ChatMessage previousMessage = chatMessageRepository.saveAndFlush(ChatMessage.of(fixture.voteId(), fixture.senderId(), "previous message"));
+        chatRoomUnreadRepository.saveAndFlush(ChatRoomUnread.of(fixture.receiverId(), fixture.voteId(), previousMessage.getId()));
+        StompSession receiverSession = connectWithAccessToken(fixture.receiverId());
+        BlockingQueue<UnreadPayload> receiverUnread = new LinkedBlockingQueue<>();
+        receiverSession.subscribe("/user/topic/chat/" + fixture.voteId() + "/unread", handler(UnreadPayload.class, receiverUnread));
+
+        StompSession senderSession = connectWithAccessToken(fixture.senderId());
+        BlockingQueue<UnreadPayload> senderUnread = new LinkedBlockingQueue<>();
+        senderSession.subscribe("/user/topic/chat/" + fixture.voteId() + "/unread", handler(UnreadPayload.class, senderUnread));
+
+        // when
+        ChatMessage message = chatMessageRepository.saveAndFlush(ChatMessage.of(fixture.voteId(), fixture.senderId(), "unread websocket"));
+        listener.handle(new com.ject.vs.chat.domain.event.ChatMessageSentEvent(message));
+
+        // then
+        UnreadPayload received = receiverUnread.poll(3, TimeUnit.SECONDS);
+        assertThat(received).isEqualTo(new UnreadPayload(fixture.voteId(), 1L));
+        UnreadPayload senderPayload = senderUnread.poll(3, TimeUnit.SECONDS);
+        assertThat(senderPayload).isEqualTo(new UnreadPayload(fixture.voteId(), 2L));
+    }
+
+    @Test
+    void voteId가_다른_topic_구독자는_메시지를_수신하지_않는다() throws Exception {
+        // given
+        TestFixture fixture = createFixture();
+        Vote otherVote = voteRepository.saveAndFlush(Vote.create(VoteType.GENERAL, "other", null, "thumb", null, Duration.ofHours(1), Clock.systemUTC()));
+        StompSession session = connectAnonymously();
+        BlockingQueue<MessageResult> targetMessages = new LinkedBlockingQueue<>();
+        BlockingQueue<MessageResult> otherMessages = new LinkedBlockingQueue<>();
+        session.subscribe("/topic/chat/" + fixture.voteId(), handler(MessageResult.class, targetMessages));
+        session.subscribe("/topic/chat/" + otherVote.getId(), handler(MessageResult.class, otherMessages));
+
+        // when
+        ChatMessage message = chatMessageRepository.saveAndFlush(ChatMessage.of(fixture.voteId(), fixture.senderId(), "only target vote"));
+        listener.handle(new com.ject.vs.chat.domain.event.ChatMessageSentEvent(message));
+
+        // then
+        assertThat(targetMessages.poll(3, TimeUnit.SECONDS)).isNotNull();
+        assertThat(otherMessages.poll(500, TimeUnit.MILLISECONDS)).isNull();
+    }
+
+    private TestFixture createFixture() {
+        User sender = userRepository.saveAndFlush(User.createWithEmail("sender-" + System.nanoTime() + "@test.com"));
+        User receiver = userRepository.saveAndFlush(User.createWithEmail("receiver-" + System.nanoTime() + "@test.com"));
+        Vote vote = voteRepository.saveAndFlush(Vote.create(VoteType.GENERAL, "chat vote", null, "thumb", null, Duration.ofHours(1), Clock.systemUTC()));
+        VoteOption option = voteOptionRepository.saveAndFlush(VoteOption.of(vote.getId(), "A", 1));
+        voteParticipationRepository.saveAndFlush(VoteParticipation.ofMember(vote.getId(), sender.getId(), option.getId()));
+        voteParticipationRepository.saveAndFlush(VoteParticipation.ofMember(vote.getId(), receiver.getId(), option.getId()));
+        return new TestFixture(vote.getId(), sender.getId(), receiver.getId());
+    }
+
+    private StompSession connectAnonymously() throws Exception {
+        StompSession session = stompClient().connectAsync("http://localhost:" + port + "/ws", new StompSessionHandlerAdapter() {}).get(3, TimeUnit.SECONDS);
+        sessions.add(session);
+        return session;
+    }
+
+    private StompSession connectWithAccessToken(Long userId) throws Exception {
+        String token = jwtProvider.createAccessToken(userId).tokenValue();
+        WebSocketHttpHeaders httpHeaders = new WebSocketHttpHeaders();
+        httpHeaders.add("Cookie", CookieUtil.CookieType.ACCESS_TOKEN + "=" + token);
+        StompSession session = stompClient().connectAsync("http://localhost:" + port + "/ws", httpHeaders, new StompHeaders(), new StompSessionHandlerAdapter() {}).get(3, TimeUnit.SECONDS);
+        sessions.add(session);
+        return session;
+    }
+
+    private WebSocketStompClient stompClient() {
+        List<Transport> transports = List.of(new WebSocketTransport(new StandardWebSocketClient()));
+        WebSocketStompClient stompClient = new WebSocketStompClient(new SockJsClient(transports));
+        MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+        converter.setObjectMapper(objectMapper);
+        stompClient.setMessageConverter(converter);
+        return stompClient;
+    }
+
+    private <T> StompFrameHandler handler(Class<T> payloadType, BlockingQueue<T> queue) {
+        return new StompFrameHandler() {
+            @Override
+            public Type getPayloadType(StompHeaders headers) {
+                return payloadType;
+            }
+
+            @Override
+            public void handleFrame(StompHeaders headers, Object payload) {
+                queue.add(payloadType.cast(payload));
+            }
+        };
+    }
+
+    private record TestFixture(Long voteId, Long senderId, Long receiverId) {
+    }
+}

--- a/src/test/java/com/ject/vs/config/WebSocketAuthInterceptorTest.java
+++ b/src/test/java/com/ject/vs/config/WebSocketAuthInterceptorTest.java
@@ -1,6 +1,5 @@
 package com.ject.vs.config;
 
-import com.ject.vs.util.JwtProvider;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,8 +12,9 @@ import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.MessageBuilder;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class WebSocketAuthInterceptorTest {
@@ -23,16 +23,19 @@ class WebSocketAuthInterceptorTest {
     private WebSocketAuthInterceptor interceptor;
 
     @Mock
-    private JwtProvider jwtProvider;
-
-    @Mock
     private MessageChannel messageChannel;
 
-    private Message<?> buildConnectMessage(String authHeader) {
+    private Message<?> buildConnectMessageWithSessionUserId(Long userId) {
         StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
-        if (authHeader != null) {
-            accessor.setNativeHeader("Authorization", authHeader);
+        if (userId != null) {
+            accessor.setSessionAttributes(Map.of("userId", userId));
         }
+        accessor.setLeaveMutable(true);
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+
+    private Message<?> buildConnectMessageWithoutSession() {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
         accessor.setLeaveMutable(true);
         return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
     }
@@ -47,10 +50,9 @@ class WebSocketAuthInterceptorTest {
     class preSend {
 
         @Test
-        void CONNECT_유효한_토큰이면_Principal이_설정된다() {
-            // given
-            given(jwtProvider.getUserId("valid-token")).willReturn(42L);
-            Message<?> message = buildConnectMessage("Bearer valid-token");
+        void CONNECT_세션에_userId가_있으면_Principal이_설정된다() {
+            // given (HandshakeInterceptor가 쿠키에서 userId를 추출해 sessionAttributes에 저장한 상태)
+            Message<?> message = buildConnectMessageWithSessionUserId(42L);
 
             // when
             Message<?> result = interceptor.preSend(message, messageChannel);
@@ -62,9 +64,9 @@ class WebSocketAuthInterceptorTest {
         }
 
         @Test
-        void CONNECT_토큰_없으면_Principal이_null이다() {
-            // given
-            Message<?> message = buildConnectMessage(null);
+        void CONNECT_세션에_userId가_없으면_Principal이_null이다() {
+            // given (쿠키 없음 또는 유효하지 않은 토큰 → anonymous)
+            Message<?> message = buildConnectMessageWithoutSession();
 
             // when
             Message<?> result = interceptor.preSend(message, messageChannel);

--- a/src/test/java/com/ject/vs/config/WebSocketHandshakeInterceptorTest.java
+++ b/src/test/java/com/ject/vs/config/WebSocketHandshakeInterceptorTest.java
@@ -1,0 +1,141 @@
+package com.ject.vs.config;
+
+import com.ject.vs.util.CookieUtil;
+import com.ject.vs.util.JwtProvider;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.socket.WebSocketHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class WebSocketHandshakeInterceptorTest {
+
+    @InjectMocks
+    private WebSocketHandshakeInterceptor interceptor;
+
+    @Mock
+    private CookieUtil cookieUtil;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private ServerHttpResponse response;
+
+    @Mock
+    private WebSocketHandler webSocketHandler;
+
+    private ServerHttpRequest servletRequestWithAccessTokenCookie(String token) {
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        servletRequest.setCookies(new Cookie(CookieUtil.CookieType.ACCESS_TOKEN, token));
+        return new ServletServerHttpRequest(servletRequest);
+    }
+
+    @Nested
+    class beforeHandshake {
+
+        @Test
+        void 유효한_accessToken_쿠키가_있으면_session_attribute에_userId를_저장하고_연결을_허용한다() {
+            // given
+            String token = "valid.jwt";
+            ServerHttpRequest request = servletRequestWithAccessTokenCookie(token);
+            Map<String, Object> attributes = new HashMap<>();
+            given(cookieUtil.getCookieValue(
+                    ((ServletServerHttpRequest) request).getServletRequest(),
+                    CookieUtil.CookieType.ACCESS_TOKEN
+            )).willReturn(token);
+            given(jwtProvider.getUserId(token)).willReturn(42L);
+
+            // when
+            boolean result = interceptor.beforeHandshake(request, response, webSocketHandler, attributes);
+
+            // then
+            assertThat(result).isTrue();
+            assertThat(attributes).containsEntry("userId", 42L);
+        }
+
+        @Test
+        void accessToken_쿠키가_없으면_anonymous로_연결을_허용한다() {
+            // given
+            ServerHttpRequest request = servletRequestWithAccessTokenCookie("");
+            Map<String, Object> attributes = new HashMap<>();
+            given(cookieUtil.getCookieValue(
+                    ((ServletServerHttpRequest) request).getServletRequest(),
+                    CookieUtil.CookieType.ACCESS_TOKEN
+            )).willReturn(null);
+
+            // when
+            boolean result = interceptor.beforeHandshake(request, response, webSocketHandler, attributes);
+
+            // then
+            assertThat(result).isTrue();
+            assertThat(attributes).doesNotContainKey("userId");
+        }
+
+        @Test
+        void accessToken이_blank이면_anonymous로_연결을_허용한다() {
+            // given
+            ServerHttpRequest request = servletRequestWithAccessTokenCookie(" ");
+            Map<String, Object> attributes = new HashMap<>();
+            given(cookieUtil.getCookieValue(
+                    ((ServletServerHttpRequest) request).getServletRequest(),
+                    CookieUtil.CookieType.ACCESS_TOKEN
+            )).willReturn(" ");
+
+            // when
+            boolean result = interceptor.beforeHandshake(request, response, webSocketHandler, attributes);
+
+            // then
+            assertThat(result).isTrue();
+            assertThat(attributes).doesNotContainKey("userId");
+        }
+
+        @Test
+        void token_검증이_실패해도_anonymous로_연결을_허용한다() {
+            // given
+            String token = "invalid.jwt";
+            ServerHttpRequest request = servletRequestWithAccessTokenCookie(token);
+            Map<String, Object> attributes = new HashMap<>();
+            given(cookieUtil.getCookieValue(
+                    ((ServletServerHttpRequest) request).getServletRequest(),
+                    CookieUtil.CookieType.ACCESS_TOKEN
+            )).willReturn(token);
+            given(jwtProvider.getUserId(token)).willThrow(new IllegalArgumentException("invalid token"));
+
+            // when
+            boolean result = interceptor.beforeHandshake(request, response, webSocketHandler, attributes);
+
+            // then
+            assertThat(result).isTrue();
+            assertThat(attributes).doesNotContainKey("userId");
+        }
+
+        @Test
+        void servlet_request가_아니어도_연결을_허용한다() {
+            // given
+            ServerHttpRequest request = org.mockito.Mockito.mock(ServerHttpRequest.class);
+            Map<String, Object> attributes = new HashMap<>();
+
+            // when
+            boolean result = interceptor.beforeHandshake(request, response, webSocketHandler, attributes);
+
+            // then
+            assertThat(result).isTrue();
+            assertThat(attributes).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## 변경 사항

### 문제
- 기존 `WebSocketAuthInterceptor`가 STOMP CONNECT 프레임의 `Authorization: Bearer <token>` 헤더만 처리
- REST API는 `accessToken` 쿠키를 사용하는데, WebSocket은 쿠키를 전혀 읽지 않아 인증 불일치 발생
- 프론트엔드에서 WebSocket 연결 시 별도 JWT 헤더 처리가 필요했음

### 해결
- `WebSocketHandshakeInterceptor` 신규 추가: HTTP 업그레이드(handshake) 단계에서 `accessToken` 쿠키 추출 및 JWT 검증
- 검증 성공 시 userId를 세션 속성에 저장 → STOMP CONNECT 단계에서 Principal 설정
- `WebSocketAuthInterceptor`는 더 이상 Authorization 헤더를 읽지 않음 (쿠키 기반으로 통일)

### 파일 변경
- `src/main/java/com/ject/vs/config/WebSocketHandshakeInterceptor.java` (신규)
- `src/main/java/com/ject/vs/config/WebSocketConfig.java` — HandshakeInterceptor 등록
- `src/main/java/com/ject/vs/config/WebSocketAuthInterceptor.java` — 쿠키 기반 인증 로직으로 변경 (헤더 제거)
- `src/test/java/com/ject/vs/config/WebSocketAuthInterceptorTest.java` — 테스트 세션 속성 기반으로 수정

### 사용자 질문 답변 (PR 설명)

**Q1. /ws가 SockJS인가요, 순수 WebSocket인가요?**
→ **SockJS 사용** (`.withSockJS()` 적용). WebSocket 미지원 환경에서도 HTTP long-polling fallback 동작.

**Q2. 프론트 연결 URL은 `wss://도메인/ws` 형태로 보면 될까요?**
→ 네. SockJS 클라이언트: `new SockJS('https://도메인/ws')`

**Q3. 인증은 기존 쿠키/JWT 기준으로 자동 처리되나요?**
→ **이제 됩니다.** `accessToken` 쿠키를 handshake 단계에서 자동 읽어 인증 처리. Authorization 헤더 불필요.

**Q4. 구독 경로**
- 새 메시지: `/topic/chat/{voteId}` → ✅ OK
- unreadCount: `/topic/chat/{voteId}/unread` → **❌ NO**
  - 서버가 `convertAndSendToUser` 사용 → 클라이언트는 **`/user/topic/chat/{voteId}/unread`** 구독 필요
  - (API spec에도 `/user/topic/...`로 명시)

### 테스트
- `./gradlew build` 성공 (모든 테스트 통과)

---

**PR 체크리스트**
- [x] 빌드 및 테스트 통과
- [x] 기존 Authorization 헤더 방식 제거 (쿠키 통일)
- [x] SockJS + 쿠키 인증 동작 확인