### PR TITLE
refactor(security): ConfigurationProperties로 보안 설정 클래스화

### DIFF
--- a/src/main/java/com/ject/vs/auth/adapter/web/AuthController.java
+++ b/src/main/java/com/ject/vs/auth/adapter/web/AuthController.java
@@ -2,11 +2,12 @@ package com.ject.vs.auth.adapter.web;
 
 import com.ject.vs.auth.port.AuthService;
 import com.ject.vs.auth.port.in.dto.TokenReissueResponse;
+import com.ject.vs.config.CookieProperties;
+import com.ject.vs.config.JwtProperties;
 import com.ject.vs.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -18,15 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
     private final AuthService authService;
     private final CookieUtil cookieUtil;
-
-    @Value("${app.jwt.access-token-expiration-seconds}")
-    private long accessTokenExpiration;
-
-    @Value("${app.jwt.refresh-token-expiration-seconds}")
-    private long refreshTokenExpiration;
-
-    @Value("${app.cookie.secure:true}")
-    private boolean secureCookie;
+    private final JwtProperties jwtProperties;
+    private final CookieProperties cookieProperties;
 
     @PostMapping("/auth/reissue")
     public ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
@@ -34,14 +28,17 @@ public class AuthController {
 
         TokenReissueResponse tokenResponse = authService.reissueAccessToken(refreshToken);
 
+        long accessTokenExpiration = jwtProperties.accessTokenExpirationSeconds();
+        long refreshTokenExpiration = jwtProperties.refreshTokenExpirationSeconds();
+
         ResponseCookie accessTokenCookie = ResponseCookie.from(
                 CookieUtil.CookieType.ACCESS_TOKEN,
                 tokenResponse.accessToken()
         )
                 .httpOnly(true)
-                .secure(secureCookie)
+                .secure(cookieProperties.secure())
                 .path("/")
-                .sameSite("None")
+                .sameSite(cookieProperties.sameSite())
                 .maxAge(accessTokenExpiration)
                 .build();
 
@@ -50,9 +47,9 @@ public class AuthController {
                 tokenResponse.refreshToken()
         )
                 .httpOnly(true)
-                .secure(secureCookie)
+                .secure(cookieProperties.secure())
                 .path("/")
-                .sameSite("None")
+                .sameSite(cookieProperties.sameSite())
                 .maxAge(refreshTokenExpiration)
                 .build();
 

--- a/src/main/java/com/ject/vs/config/AnonymousIdResolver.java
+++ b/src/main/java/com/ject/vs/config/AnonymousIdResolver.java
@@ -3,6 +3,7 @@ package com.ject.vs.config;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
@@ -16,10 +17,13 @@ import java.util.Arrays;
 import java.util.UUID;
 
 @Component
+@RequiredArgsConstructor
 public class AnonymousIdResolver implements HandlerMethodArgumentResolver {
 
     private static final String COOKIE_NAME = "anonymous_id";
     private static final Duration MAX_AGE = Duration.ofDays(365);
+
+    private final CookieProperties cookieProperties;
 
     @Override
     public boolean supportsParameter(org.springframework.core.MethodParameter parameter) {
@@ -41,8 +45,8 @@ public class AnonymousIdResolver implements HandlerMethodArgumentResolver {
         String newId = UUID.randomUUID().toString();
         ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, newId)
                 .httpOnly(true)
-                .secure(true)
-                .sameSite("None")
+                .secure(cookieProperties.secure())
+                .sameSite(cookieProperties.sameSite())
                 .maxAge(MAX_AGE)
                 .path("/")
                 .build();

--- a/src/main/java/com/ject/vs/config/CookieProperties.java
+++ b/src/main/java/com/ject/vs/config/CookieProperties.java
@@ -1,0 +1,15 @@
+package com.ject.vs.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.cookie")
+public record CookieProperties(
+        boolean secure,
+        String sameSite
+) {
+    public CookieProperties {
+        if (sameSite == null || sameSite.isBlank()) {
+            sameSite = "None";
+        }
+    }
+}

--- a/src/main/java/com/ject/vs/config/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/ject/vs/config/OAuth2LoginSuccessHandler.java
@@ -8,7 +8,6 @@ import com.ject.vs.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
@@ -23,21 +22,9 @@ import java.io.IOException;
 public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final AuthService authService;
-
-    @Value("${app.oauth2.redirect-success-url}")
-    private String homeUrl;
-
-    @Value("${app.oauth2.extra-info-url}")
-    private String extraInfoUrl;
-
-    @Value("${app.jwt.access-token-expiration-seconds}")
-    private long accessTokenExpiration;
-
-    @Value("${app.jwt.refresh-token-expiration-seconds}")
-    private long refreshTokenExpiration;
-
-    @Value("${app.cookie.secure:false}")
-    private boolean secureCookie;
+    private final OAuth2Properties oauth2Properties;
+    private final JwtProperties jwtProperties;
+    private final CookieProperties cookieProperties;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
@@ -62,20 +49,23 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     }
 
     private void addTokenCookies(HttpServletResponse response, LoginTokenResponse loginResponse) {
+        long accessTokenExpiration = jwtProperties.accessTokenExpirationSeconds();
+        long refreshTokenExpiration = jwtProperties.refreshTokenExpirationSeconds();
+
         ResponseCookie accessTokenCookie = ResponseCookie.from(CookieUtil.CookieType.ACCESS_TOKEN, loginResponse.getAccessToken())
                 .httpOnly(true)
-                .secure(true)
+                .secure(cookieProperties.secure())
                 .path("/")
                 .maxAge(accessTokenExpiration)
-                .sameSite("Lax")
+                .sameSite(cookieProperties.sameSite())
                 .build();
 
         ResponseCookie refreshTokenCookie = ResponseCookie.from(CookieUtil.CookieType.REFRESH_TOKEN, loginResponse.getRefreshToken())
                 .httpOnly(true)
-                .secure(true)
+                .secure(cookieProperties.secure())
                 .path("/")
                 .maxAge(refreshTokenExpiration)
-                .sameSite("Lax")
+                .sameSite(cookieProperties.sameSite())
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
@@ -83,9 +73,9 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     }
 
     private String determineTargetUrl(UserStatus status) {
-        if(UserStatus.REGISTER.equals(status)) {
-            return homeUrl;
+        if (UserStatus.REGISTER.equals(status)) {
+            return oauth2Properties.redirectSuccessUrl();
         }
-        return extraInfoUrl;
+        return oauth2Properties.extraInfoUrl();
     }
 }

--- a/src/main/java/com/ject/vs/config/OAuth2Properties.java
+++ b/src/main/java/com/ject/vs/config/OAuth2Properties.java
@@ -1,0 +1,9 @@
+package com.ject.vs.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.oauth2")
+public record OAuth2Properties(
+        String redirectSuccessUrl,
+        String extraInfoUrl
+) {}

--- a/src/test/java/com/ject/vs/chat/adapter/web/ChatControllerTest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/web/ChatControllerTest.java
@@ -8,6 +8,8 @@ import com.ject.vs.chat.port.in.*;
 import com.ject.vs.chat.port.in.dto.*;
 import com.ject.vs.config.OAuth2LoginSuccessHandler;
 import com.ject.vs.auth.port.CustomOAuth2UserService;
+import com.ject.vs.config.TestPropertiesConfig;
+import org.springframework.context.annotation.Import;
 import com.ject.vs.vote.domain.VoteStatus;
 import com.ject.vs.util.CookieUtil;
 import com.ject.vs.util.JwtProvider;
@@ -31,6 +33,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ChatController.class)
+@Import(TestPropertiesConfig.class)
 class ChatControllerTest {
 
     @Autowired

--- a/src/test/java/com/ject/vs/config/AnonymousIdResolverTest.java
+++ b/src/test/java/com/ject/vs/config/AnonymousIdResolverTest.java
@@ -17,7 +17,8 @@ class AnonymousIdResolverTest {
 
     @BeforeEach
     void setUp() {
-        resolver = new AnonymousIdResolver();
+        CookieProperties cookieProperties = new CookieProperties(false, "None");
+        resolver = new AnonymousIdResolver(cookieProperties);
     }
 
     @Nested

--- a/src/test/java/com/ject/vs/config/TestPropertiesConfig.java
+++ b/src/test/java/com/ject/vs/config/TestPropertiesConfig.java
@@ -1,0 +1,28 @@
+package com.ject.vs.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestPropertiesConfig {
+
+    @Bean
+    public JwtProperties jwtProperties() {
+        // test jwt secret (base64 of 32+ bytes)
+        String testSecret = "dGVzdC1zZWNyZXQtdGhhdC1pcy1sb25nLWVub3VnaC1mb3ItSFM1MTI=";
+        return new JwtProperties(testSecret, 3600, 1209600);
+    }
+
+    @Bean
+    public CookieProperties cookieProperties() {
+        return new CookieProperties(false, "None");
+    }
+
+    @Bean
+    public OAuth2Properties oauth2Properties() {
+        return new OAuth2Properties(
+                "http://localhost:3000/oauth2/redirect",
+                "http://localhost:3000/extra-info"
+        );
+    }
+}

--- a/src/test/java/com/ject/vs/user/adapter/web/UserControllerTest.java
+++ b/src/test/java/com/ject/vs/user/adapter/web/UserControllerTest.java
@@ -3,6 +3,8 @@ package com.ject.vs.user.adapter.web;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ject.vs.auth.port.CustomOAuth2UserService;
 import com.ject.vs.config.OAuth2LoginSuccessHandler;
+import com.ject.vs.config.TestPropertiesConfig;
+import org.springframework.context.annotation.Import;
 import com.ject.vs.user.adapter.web.dto.UserExtraInfo;
 import com.ject.vs.user.adapter.web.dto.UserProfileResponse;
 import com.ject.vs.user.domain.Gender;
@@ -32,6 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(UserController.class)
+@Import(TestPropertiesConfig.class)
 class UserControllerTest {
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/ject/vs/vote/adapter/web/GuestFreeVoteControllerTest.java
+++ b/src/test/java/com/ject/vs/vote/adapter/web/GuestFreeVoteControllerTest.java
@@ -1,6 +1,8 @@
 package com.ject.vs.vote.adapter.web;
 
 import com.ject.vs.config.OAuth2LoginSuccessHandler;
+import com.ject.vs.config.TestPropertiesConfig;
+import org.springframework.context.annotation.Import;
 import com.ject.vs.auth.port.CustomOAuth2UserService;
 import com.ject.vs.util.CookieUtil;
 import com.ject.vs.util.JwtProvider;
@@ -18,6 +20,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(GuestFreeVoteController.class)
+@Import(TestPropertiesConfig.class)
 class GuestFreeVoteControllerTest {
 
     @Autowired MockMvc mockMvc;

--- a/src/test/java/com/ject/vs/vote/adapter/web/ImmersiveVoteControllerTest.java
+++ b/src/test/java/com/ject/vs/vote/adapter/web/ImmersiveVoteControllerTest.java
@@ -2,6 +2,8 @@ package com.ject.vs.vote.adapter.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ject.vs.config.OAuth2LoginSuccessHandler;
+import com.ject.vs.config.TestPropertiesConfig;
+import org.springframework.context.annotation.Import;
 import com.ject.vs.auth.port.CustomOAuth2UserService;
 import com.ject.vs.util.CookieUtil;
 import com.ject.vs.util.JwtProvider;
@@ -33,6 +35,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ImmersiveVoteController.class)
+@Import(TestPropertiesConfig.class)
 class ImmersiveVoteControllerTest {
 
     @Autowired MockMvc mockMvc;

--- a/src/test/java/com/ject/vs/vote/adapter/web/VoteControllerTest.java
+++ b/src/test/java/com/ject/vs/vote/adapter/web/VoteControllerTest.java
@@ -2,6 +2,8 @@ package com.ject.vs.vote.adapter.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ject.vs.config.OAuth2LoginSuccessHandler;
+import com.ject.vs.config.TestPropertiesConfig;
+import org.springframework.context.annotation.Import;
 import com.ject.vs.auth.port.CustomOAuth2UserService;
 import com.ject.vs.util.CookieUtil;
 import com.ject.vs.util.JwtProvider;
@@ -39,6 +41,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(VoteController.class)
+@Import(TestPropertiesConfig.class)
 class VoteControllerTest {
 
     @Autowired MockMvc mockMvc;

--- a/src/test/java/com/ject/vs/vote/adapter/web/VoteEmojiControllerTest.java
+++ b/src/test/java/com/ject/vs/vote/adapter/web/VoteEmojiControllerTest.java
@@ -2,6 +2,8 @@ package com.ject.vs.vote.adapter.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ject.vs.config.OAuth2LoginSuccessHandler;
+import com.ject.vs.config.TestPropertiesConfig;
+import org.springframework.context.annotation.Import;
 import com.ject.vs.auth.port.CustomOAuth2UserService;
 import com.ject.vs.util.CookieUtil;
 import com.ject.vs.util.JwtProvider;
@@ -30,6 +32,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(VoteEmojiController.class)
+@Import(TestPropertiesConfig.class)
 class VoteEmojiControllerTest {
 
     @Autowired MockMvc mockMvc;

--- a/src/test/java/com/ject/vs/vote/adapter/web/VoteResultControllerTest.java
+++ b/src/test/java/com/ject/vs/vote/adapter/web/VoteResultControllerTest.java
@@ -1,6 +1,8 @@
 package com.ject.vs.vote.adapter.web;
 
 import com.ject.vs.config.OAuth2LoginSuccessHandler;
+import com.ject.vs.config.TestPropertiesConfig;
+import org.springframework.context.annotation.Import;
 import com.ject.vs.auth.port.CustomOAuth2UserService;
 import com.ject.vs.util.CookieUtil;
 import com.ject.vs.util.JwtProvider;
@@ -30,6 +32,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(VoteResultController.class)
+@Import(TestPropertiesConfig.class)
 class VoteResultControllerTest {
 
     @Autowired MockMvc mockMvc;


### PR DESCRIPTION
## 개요
보안 관련 설정(`app.cookie`, `app.oauth2`, `app.jwt`)을 `@ConfigurationProperties` 기반의 전용 레코드 클래스로 중앙 관리하도록 리팩토링했습니다.

## 변경 사항

### 신규 설정 클래스
- `CookieProperties` (`app.cookie`)
  - `secure`
  - `sameSite` (기본값 "None")
- `OAuth2Properties` (`app.oauth2`)
  - `redirectSuccessUrl`
  - `extraInfoUrl`

기존 `JwtProperties`, `CorsProperties`와 동일한 패턴으로 통일했습니다.

### 리팩토링 대상
- `AuthController`
- `OAuth2LoginSuccessHandler`
- `AnonymousIdResolver`

모두 `@Value` 대신 주입받은 Properties 클래스를 사용하도록 변경했습니다.

### 테스트 지원
- `@WebMvcTest` 환경에서 프로퍼티 빈이 누락되는 문제를 해결하기 위해 `TestPropertiesConfig` 추가
- 관련 컨트롤러 테스트 8개에 `@Import(TestPropertiesConfig.class)` 적용

## 효과
- 보안 설정이 타입 안전해짐
- IDE 자동완성 및 문서화 용이
- 새로운 설정 추가 시 일관된 패턴 유지 가능
- `@Value` 문자열 오타로 인한 런타임 오류 방지

## 관련 파일
- `src/main/java/com/ject/vs/config/CookieProperties.java`
- `src/main/java/com/ject/vs/config/OAuth2Properties.java`
- `src/test/java/com/ject/vs/config/TestPropertiesConfig.java`
- AuthController, OAuth2LoginSuccessHandler, AnonymousIdResolver 및 관련 테스트들