### PR TITLE
feat: 투표 정보를 채팅에 연동 (VoteChatSummary, sender vote option)

### DIFF
--- a/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
+++ b/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
@@ -6,7 +6,10 @@ import com.ject.vs.chat.domain.ChatRoomUnreadRepository;
 import com.ject.vs.chat.domain.event.ChatMessageSentEvent;
 import com.ject.vs.chat.port.in.dto.MessageResult;
 import com.ject.vs.chat.port.in.dto.UnreadPayload;
+import com.ject.vs.user.domain.User;
+import com.ject.vs.user.domain.UserRepository;
 import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
+import com.ject.vs.vote.port.in.VoteQueryUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
@@ -19,8 +22,10 @@ public class ChatMessageEventListener {
 
     private final SimpMessagingTemplate messagingTemplate;
     private final VoteParticipationQueryUseCase voteParticipationQueryUseCase;
+    private final VoteQueryUseCase voteQueryUseCase;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomUnreadRepository chatRoomUnreadRepository;
+    private final UserRepository userRepository;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(ChatMessageSentEvent event) {
@@ -30,9 +35,9 @@ public class ChatMessageEventListener {
                 message.getId(),
                 message.getContent(),
                 message.getCreatedAt(),
-                "User#" + message.getSenderId(), // TODO: User.nickname 추가 후 교체
+                resolveNickname(message.getSenderId()),
                 null,
-                null,   // TODO: Vote 도메인 연동 후 senderVoteOption 채워야 함
+                resolveSelectedOptionCode(message.getVoteId(), message.getSenderId()),
                 false
         );
 
@@ -57,5 +62,18 @@ public class ChatMessageEventListener {
                     new UnreadPayload(message.getVoteId(), unreadCount)
             );
         }
+    }
+
+    private String resolveNickname(Long userId) {
+        return userRepository.findById(userId)
+                .map(User::getNickname)
+                .filter(nickname -> !nickname.isBlank())
+                .orElse("User#" + userId);
+    }
+
+    private String resolveSelectedOptionCode(Long voteId, Long userId) {
+        return voteQueryUseCase.getSelectedOptionCode(voteId, userId)
+                .map(Enum::name)
+                .orElse(null);
     }
 }

--- a/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
+++ b/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
@@ -7,7 +7,7 @@ import com.ject.vs.chat.domain.event.ChatMessageSentEvent;
 import com.ject.vs.chat.port.in.dto.MessageResult;
 import com.ject.vs.chat.port.in.dto.UnreadPayload;
 import com.ject.vs.user.domain.User;
-import com.ject.vs.user.domain.UserRepository;
+import com.ject.vs.user.port.in.UserQueryUseCase;
 import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
 import com.ject.vs.vote.port.in.VoteQueryUseCase;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +25,7 @@ public class ChatMessageEventListener {
     private final VoteQueryUseCase voteQueryUseCase;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomUnreadRepository chatRoomUnreadRepository;
-    private final UserRepository userRepository;
+    private final UserQueryUseCase userQueryUseCase;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(ChatMessageSentEvent event) {
@@ -65,10 +65,9 @@ public class ChatMessageEventListener {
     }
 
     private String resolveNickname(Long userId) {
-        return userRepository.findById(userId)
-                .map(User::getNickname)
-                .filter(nickname -> !nickname.isBlank())
-                .orElse("User#" + userId);
+        return userQueryUseCase.findById(userId)
+                .map(User::getUserNameOrEmpty)
+                .orElse(null);
     }
 
     private String resolveSelectedOptionCode(Long voteId, Long userId) {

--- a/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
+++ b/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
@@ -6,8 +6,10 @@ import com.ject.vs.chat.domain.ChatRoomUnreadRepository;
 import com.ject.vs.chat.domain.event.ChatMessageSentEvent;
 import com.ject.vs.chat.port.in.dto.MessageResult;
 import com.ject.vs.chat.port.in.dto.UnreadPayload;
+import com.ject.vs.user.domain.ImageColor;
 import com.ject.vs.user.domain.User;
 import com.ject.vs.user.port.in.UserQueryUseCase;
+import com.ject.vs.vote.domain.VoteOptionCode;
 import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
 import com.ject.vs.vote.port.in.VoteQueryUseCase;
 import lombok.RequiredArgsConstructor;
@@ -32,15 +34,17 @@ public class ChatMessageEventListener {
     public void handle(ChatMessageSentEvent event) {
         ChatMessage message = event.message();
 
-        var sender = userQueryUseCase.getUser(message.getSenderId());
+        User sender = userQueryUseCase.getUser(message.getSenderId());
+        VoteOptionCode voteOptionCode =
+                voteQueryUseCase.getSelectedOption(message.getVoteId(), message.getSenderId()).getCode();
 
         MessageResult messageResult = new MessageResult(
                 message.getId(),
                 message.getContent(),
                 message.getCreatedAt(),
-                sender.getUserNameOrEmpty(),
+                sender.getNickname(),
                 sender.getImageColor(),
-                voteQueryUseCase.getSelectedOption(message.getVoteId(), message.getSenderId()).getCode(),
+                voteOptionCode,
                 false
         );
 

--- a/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
+++ b/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
@@ -37,7 +37,7 @@ public class ChatMessageEventListener {
                 message.getCreatedAt(),
                 resolveNickname(message.getSenderId()),
                 null,
-                resolveSelectedOptionCode(message.getVoteId(), message.getSenderId()),
+                voteQueryUseCase.getSelectedOption(message.getVoteId(), message.getSenderId()).getCode(),
                 false
         );
 
@@ -67,12 +67,6 @@ public class ChatMessageEventListener {
     private String resolveNickname(Long userId) {
         return userQueryUseCase.findById(userId)
                 .map(User::getUserNameOrEmpty)
-                .orElse(null);
-    }
-
-    private String resolveSelectedOptionCode(Long voteId, Long userId) {
-        return voteQueryUseCase.getSelectedOptionCode(voteId, userId)
-                .map(Enum::name)
                 .orElse(null);
     }
 }

--- a/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
+++ b/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
@@ -11,6 +11,7 @@ import com.ject.vs.user.port.in.UserQueryUseCase;
 import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
 import com.ject.vs.vote.port.in.VoteQueryUseCase;
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -31,12 +32,14 @@ public class ChatMessageEventListener {
     public void handle(ChatMessageSentEvent event) {
         ChatMessage message = event.message();
 
+        var sender = userQueryUseCase.getUser(message.getSenderId());
+
         MessageResult messageResult = new MessageResult(
                 message.getId(),
                 message.getContent(),
                 message.getCreatedAt(),
-                resolveNickname(message.getSenderId()),
-                null,
+                sender.getUserNameOrEmpty(),
+                sender.getImageColor(),
                 voteQueryUseCase.getSelectedOption(message.getVoteId(), message.getSenderId()).getCode(),
                 false
         );
@@ -62,11 +65,5 @@ public class ChatMessageEventListener {
                     new UnreadPayload(message.getVoteId(), unreadCount)
             );
         }
-    }
-
-    private String resolveNickname(Long userId) {
-        return userQueryUseCase.findById(userId)
-                .map(User::getUserNameOrEmpty)
-                .orElse(null);
     }
 }

--- a/src/main/java/com/ject/vs/chat/adapter/web/dto/MessageResponse.java
+++ b/src/main/java/com/ject/vs/chat/adapter/web/dto/MessageResponse.java
@@ -1,6 +1,7 @@
 package com.ject.vs.chat.adapter.web.dto;
 
 import com.ject.vs.chat.port.in.dto.MessageResult;
+import com.ject.vs.user.domain.ImageColor;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
@@ -19,8 +20,8 @@ public record MessageResponse(
         @Schema(description = "메시지를 보낸 사용자의 닉네임", example = "승부사")
         String senderNickname,
 
-        @Schema(description = "메시지를 보낸 사용자의 프로필 아이콘", example = "https://cdn.example.com/profile-icons/rabbit.png", nullable = true)
-        String senderProfileIcon,
+        @Schema(description = "메시지를 보낸 사용자의 프로필 아이콘 색상", example = "GREEN", allowableValues = {"GREEN", "RED", "BLUE", "YELLOW"}, nullable = true)
+        ImageColor senderProfileIcon,
 
         @Schema(description = "메시지를 보낸 사용자가 선택한 투표 선택지", example = "A", allowableValues = {"A", "B"}, nullable = true)
         String senderVoteOption,
@@ -29,13 +30,14 @@ public record MessageResponse(
         boolean isMine
 ) {
     public static MessageResponse from(MessageResult result) {
+        String voteOption = result.senderVoteOption() != null ? result.senderVoteOption().name() : null;
         return new MessageResponse(
                 result.messageId(),
                 result.content(),
                 result.sentAt(),
                 result.senderNickname(),
                 result.senderProfileIcon(),
-                result.senderVoteOption(),
+                voteOption,
                 result.isMine()
         );
     }

--- a/src/main/java/com/ject/vs/chat/domain/ChatMessage.java
+++ b/src/main/java/com/ject/vs/chat/domain/ChatMessage.java
@@ -2,9 +2,8 @@ package com.ject.vs.chat.domain;
 
 import com.ject.vs.chat.domain.event.ChatMessageSentEvent;
 import com.ject.vs.common.domain.BaseAggregateEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import com.ject.vs.vote.domain.Vote;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/ject/vs/chat/port/ChatService.java
+++ b/src/main/java/com/ject/vs/chat/port/ChatService.java
@@ -137,7 +137,7 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
                         msg.getCreatedAt(),
                         resolveNickname(msg.getSenderId()),
                         null,
-                        resolveSelectedOptionCode(voteId, msg.getSenderId()),
+                        voteQueryUseCase.getSelectedOption(voteId, userId).getCode(),
                         msg.getSenderId().equals(userId)
                 ))
                 .toList();
@@ -148,12 +148,6 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
     private String resolveNickname(Long userId) {
         return userQueryUseCase.findById(userId)
                 .map(User::getUserNameOrEmpty)
-                .orElse(null);
-    }
-
-    private String resolveSelectedOptionCode(Long voteId, Long userId) {
-        return voteQueryUseCase.getSelectedOptionCode(voteId, userId)
-                .map(Enum::name)
                 .orElse(null);
     }
 }

--- a/src/main/java/com/ject/vs/chat/port/ChatService.java
+++ b/src/main/java/com/ject/vs/chat/port/ChatService.java
@@ -9,11 +9,13 @@ import com.ject.vs.chat.exception.InvalidMessageException;
 import com.ject.vs.chat.port.in.ChatCommandUseCase;
 import com.ject.vs.chat.port.in.ChatQueryUseCase;
 import com.ject.vs.chat.port.in.dto.*;
+import com.ject.vs.user.domain.ImageColor;
 import com.ject.vs.user.domain.User;
 import com.ject.vs.user.port.in.UserQueryUseCase;
+import com.ject.vs.vote.domain.VoteOptionCode;
+import com.ject.vs.vote.domain.VoteStatus;
 import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
 import com.ject.vs.vote.port.in.VoteQueryUseCase;
-import com.ject.vs.vote.domain.VoteStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.data.domain.PageRequest;
@@ -45,15 +47,17 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
         }
 
         ChatMessage saved = chatMessageRepository.save(message);
-        var sender = userQueryUseCase.getUser(command.senderId());
+        User sender = userQueryUseCase.getUser(command.senderId());
+        VoteOptionCode voteOptionCode =
+                voteQueryUseCase.getSelectedOption(command.voteId(), command.senderId()).getCode();
 
         return new MessageResult(
                 saved.getId(),
                 saved.getContent(),
                 saved.getCreatedAt(),
-                sender.getUserNameOrEmpty(),
+                sender.getNickname(),
                 sender.getImageColor(),
-                voteQueryUseCase.getSelectedOption(message.getVoteId(), message.getSenderId()).getCode(),
+                voteOptionCode,
                 true
         );
     }
@@ -134,15 +138,17 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
 
         List<MessageResult> results = pageMessages.stream()
                 .map(msg -> {
-                    var sender = userQueryUseCase.getUser(msg.getSenderId());
+                    User sender = userQueryUseCase.getUser(msg.getSenderId());
+                    VoteOptionCode voteOptionCode =
+                            voteQueryUseCase.getSelectedOption(voteId, msg.getSenderId()).getCode();
 
                     return new MessageResult(
                             msg.getId(),
                             msg.getContent(),
                             msg.getCreatedAt(),
-                            sender.getUserNameOrEmpty(),
+                            sender.getNickname(),
                             sender.getImageColor(),
-                            voteQueryUseCase.getSelectedOption(voteId, userId).getCode(),
+                            voteOptionCode,
                             msg.getSenderId().equals(userId)
                     );
                 })

--- a/src/main/java/com/ject/vs/chat/port/ChatService.java
+++ b/src/main/java/com/ject/vs/chat/port/ChatService.java
@@ -9,6 +9,8 @@ import com.ject.vs.chat.exception.InvalidMessageException;
 import com.ject.vs.chat.port.in.ChatCommandUseCase;
 import com.ject.vs.chat.port.in.ChatQueryUseCase;
 import com.ject.vs.chat.port.in.dto.*;
+import com.ject.vs.user.domain.User;
+import com.ject.vs.user.domain.UserRepository;
 import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
 import com.ject.vs.vote.port.in.VoteQueryUseCase;
 import com.ject.vs.vote.domain.VoteStatus;
@@ -28,6 +30,7 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
     private final VoteQueryUseCase voteQueryUseCase;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomUnreadRepository chatRoomUnreadRepository;
+    private final UserRepository userRepository;
 
     @Override
     public MessageResult sendMessage(SendMessageCommand command) {
@@ -46,9 +49,9 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
                 saved.getId(),
                 saved.getContent(),
                 saved.getCreatedAt(),
-                "User#" + command.senderId(), // TODO: User.nickname 추가 후 교체
+                resolveNickname(command.senderId()),
                 null,
-                null,   // TODO: Vote 도메인 연동 후 senderVoteOption 채워야 함
+                resolveSelectedOptionCode(command.voteId(), command.senderId()),
                 true
         );
     }
@@ -73,6 +76,7 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
 
         return filteredVoteIds.stream()
                 .map(voteId -> {
+                    VoteQueryUseCase.VoteChatSummary vote = voteQueryUseCase.getVoteChatSummary(voteId);
                     long participantCount = voteParticipationQueryUseCase.countParticipantsByVoteId(voteId);
 
                     ChatMessage lastMsg = chatMessageRepository.findFirstByVoteIdOrderByIdDesc(voteId).orElse(null);
@@ -84,7 +88,7 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
                             .orElse(0);
 
                     return ChatListItemResult.of(
-                            voteId,
+                            vote,
                             (int) participantCount,
                             lastMessage,
                             lastMsg != null ? lastMsg.getCreatedAt() : null,
@@ -97,16 +101,16 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
     @Override
     @Transactional(readOnly = true)
     public ChatRoomResult getChatRoom(Long voteId) {
+        VoteQueryUseCase.VoteChatSummary vote = voteQueryUseCase.getVoteChatSummary(voteId);
         long participantCount = voteParticipationQueryUseCase.countParticipantsByVoteId(voteId);
-        return ChatRoomResult.of(voteId, (int) participantCount);
+        return ChatRoomResult.of(vote, (int) participantCount);
     }
 
     @Override
     @Transactional(readOnly = true)
     public GaugeResult getGauge(Long voteId) {
-        // TODO: Vote 도메인 연동 후 실제 득표율로 교체
-        long participantCount = voteParticipationQueryUseCase.countParticipantsByVoteId(voteId);
-        return new GaugeResult(50, 50, (int) participantCount);
+        VoteQueryUseCase.VoteRatio ratio = voteQueryUseCase.getRatio(voteId);
+        return new GaugeResult(ratio.optionARatio(), ratio.optionBRatio(), ratio.participantCount());
     }
 
     @Override
@@ -131,13 +135,26 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
                         msg.getId(),
                         msg.getContent(),
                         msg.getCreatedAt(),
-                        "User#" + msg.getSenderId(), // TODO: User.nickname 추가 후 교체
+                        resolveNickname(msg.getSenderId()),
                         null,
-                        null,   // TODO: Vote 도메인 연동 후 senderVoteOption 채워야 함
+                        resolveSelectedOptionCode(voteId, msg.getSenderId()),
                         msg.getSenderId().equals(userId)
                 ))
                 .toList();
 
         return new MessagePageResult(results, nextCursor, hasNext);
+    }
+
+    private String resolveNickname(Long userId) {
+        return userRepository.findById(userId)
+                .map(User::getNickname)
+                .filter(nickname -> !nickname.isBlank())
+                .orElse("User#" + userId);
+    }
+
+    private String resolveSelectedOptionCode(Long voteId, Long userId) {
+        return voteQueryUseCase.getSelectedOptionCode(voteId, userId)
+                .map(Enum::name)
+                .orElse(null);
     }
 }

--- a/src/main/java/com/ject/vs/chat/port/ChatService.java
+++ b/src/main/java/com/ject/vs/chat/port/ChatService.java
@@ -51,7 +51,7 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
                 saved.getCreatedAt(),
                 resolveNickname(command.senderId()),
                 null,
-                resolveSelectedOptionCode(command.voteId(), command.senderId()),
+                voteQueryUseCase.getSelectedOption(message.getVoteId(), message.getSenderId()).getCode(),
                 true
         );
     }

--- a/src/main/java/com/ject/vs/chat/port/ChatService.java
+++ b/src/main/java/com/ject/vs/chat/port/ChatService.java
@@ -10,7 +10,7 @@ import com.ject.vs.chat.port.in.ChatCommandUseCase;
 import com.ject.vs.chat.port.in.ChatQueryUseCase;
 import com.ject.vs.chat.port.in.dto.*;
 import com.ject.vs.user.domain.User;
-import com.ject.vs.user.domain.UserRepository;
+import com.ject.vs.user.port.in.UserQueryUseCase;
 import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
 import com.ject.vs.vote.port.in.VoteQueryUseCase;
 import com.ject.vs.vote.domain.VoteStatus;
@@ -30,7 +30,7 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
     private final VoteQueryUseCase voteQueryUseCase;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomUnreadRepository chatRoomUnreadRepository;
-    private final UserRepository userRepository;
+    private final UserQueryUseCase userQueryUseCase;
 
     @Override
     public MessageResult sendMessage(SendMessageCommand command) {
@@ -146,10 +146,9 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
     }
 
     private String resolveNickname(Long userId) {
-        return userRepository.findById(userId)
-                .map(User::getNickname)
-                .filter(nickname -> !nickname.isBlank())
-                .orElse("User#" + userId);
+        return userQueryUseCase.findById(userId)
+                .map(User::getUserNameOrEmpty)
+                .orElse(null);
     }
 
     private String resolveSelectedOptionCode(Long voteId, Long userId) {

--- a/src/main/java/com/ject/vs/chat/port/ChatService.java
+++ b/src/main/java/com/ject/vs/chat/port/ChatService.java
@@ -15,6 +15,7 @@ import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
 import com.ject.vs.vote.port.in.VoteQueryUseCase;
 import com.ject.vs.vote.domain.VoteStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,13 +45,14 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
         }
 
         ChatMessage saved = chatMessageRepository.save(message);
+        var sender = userQueryUseCase.getUser(command.senderId());
 
         return new MessageResult(
                 saved.getId(),
                 saved.getContent(),
                 saved.getCreatedAt(),
-                resolveNickname(command.senderId()),
-                null,
+                sender.getUserNameOrEmpty(),
+                sender.getImageColor(),
                 voteQueryUseCase.getSelectedOption(message.getVoteId(), message.getSenderId()).getCode(),
                 true
         );
@@ -131,23 +133,21 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
         Long nextCursor = hasNext ? pageMessages.get(pageMessages.size() - 1).getId() : null;
 
         List<MessageResult> results = pageMessages.stream()
-                .map(msg -> new MessageResult(
-                        msg.getId(),
-                        msg.getContent(),
-                        msg.getCreatedAt(),
-                        resolveNickname(msg.getSenderId()),
-                        null,
-                        voteQueryUseCase.getSelectedOption(voteId, userId).getCode(),
-                        msg.getSenderId().equals(userId)
-                ))
+                .map(msg -> {
+                    var sender = userQueryUseCase.getUser(msg.getSenderId());
+
+                    return new MessageResult(
+                            msg.getId(),
+                            msg.getContent(),
+                            msg.getCreatedAt(),
+                            sender.getUserNameOrEmpty(),
+                            sender.getImageColor(),
+                            voteQueryUseCase.getSelectedOption(voteId, userId).getCode(),
+                            msg.getSenderId().equals(userId)
+                    );
+                })
                 .toList();
 
         return new MessagePageResult(results, nextCursor, hasNext);
-    }
-
-    private String resolveNickname(Long userId) {
-        return userQueryUseCase.findById(userId)
-                .map(User::getUserNameOrEmpty)
-                .orElse(null);
     }
 }

--- a/src/main/java/com/ject/vs/chat/port/in/dto/ChatListItemResult.java
+++ b/src/main/java/com/ject/vs/chat/port/in/dto/ChatListItemResult.java
@@ -1,36 +1,38 @@
 package com.ject.vs.chat.port.in.dto;
 
+import com.ject.vs.vote.port.in.VoteQueryUseCase.VoteChatSummary;
+
 import java.time.Instant;
 
 public record ChatListItemResult(
         Long voteId,
-        String title,           // TODO: Vote 도메인 연동 후 채워야 함
-        String thumbnailUrl,    // TODO: Vote 도메인 연동 후 채워야 함
-        String optionA,         // TODO: Vote 도메인 연동 후 채워야 함
-        String optionB,         // TODO: Vote 도메인 연동 후 채워야 함
+        String title,
+        String thumbnailUrl,
+        String optionA,
+        String optionB,
         int participantCount,
         String lastMessage,
         Instant lastMessageAt,
-        Instant endAt,          // TODO: Vote 도메인 연동 후 채워야 함
+        Instant endAt,
         int unreadCount
 ) {
     public static ChatListItemResult of(
-            Long voteId,
+            VoteChatSummary vote,
             int participantCount,
             String lastMessage,
             Instant lastMessageAt,
             int unreadCount
     ) {
         return new ChatListItemResult(
-                voteId,
-                null,   // TODO: Vote 도메인 연동 후 채워야 함
-                null,   // TODO: Vote 도메인 연동 후 채워야 함
-                null,   // TODO: Vote 도메인 연동 후 채워야 함
-                null,   // TODO: Vote 도메인 연동 후 채워야 함
+                vote.voteId(),
+                vote.title(),
+                vote.thumbnailUrl(),
+                vote.optionA(),
+                vote.optionB(),
                 participantCount,
                 lastMessage,
                 lastMessageAt,
-                null,   // TODO: Vote 도메인 연동 후 채워야 함
+                vote.endAt(),
                 unreadCount
         );
     }

--- a/src/main/java/com/ject/vs/chat/port/in/dto/ChatRoomResult.java
+++ b/src/main/java/com/ject/vs/chat/port/in/dto/ChatRoomResult.java
@@ -1,27 +1,28 @@
 package com.ject.vs.chat.port.in.dto;
 
 import com.ject.vs.vote.domain.VoteStatus;
+import com.ject.vs.vote.port.in.VoteQueryUseCase.VoteChatSummary;
 
 import java.time.Instant;
 
 public record ChatRoomResult(
         Long voteId,
-        String title,       // TODO: Vote 도메인 연동 후 채워야 함
-        VoteStatus status,  // TODO: Vote 도메인 연동 후 채워야 함
+        String title,
+        VoteStatus status,
         int participantCount,
-        String optionA,     // TODO: Vote 도메인 연동 후 채워야 함
-        String optionB,     // TODO: Vote 도메인 연동 후 채워야 함
-        Instant endAt       // TODO: Vote 도메인 연동 후 채워야 함
+        String optionA,
+        String optionB,
+        Instant endAt
 ) {
-    public static ChatRoomResult of(Long voteId, int participantCount) {
+    public static ChatRoomResult of(VoteChatSummary vote, int participantCount) {
         return new ChatRoomResult(
-                voteId,
-                null,   // TODO: Vote 도메인 연동 후 채워야 함
-                null,   // TODO: Vote 도메인 연동 후 채워야 함
+                vote.voteId(),
+                vote.title(),
+                vote.status(),
                 participantCount,
-                null,   // TODO: Vote 도메인 연동 후 채워야 함
-                null,   // TODO: Vote 도메인 연동 후 채워야 함
-                null    // TODO: Vote 도메인 연동 후 채워야 함
+                vote.optionA(),
+                vote.optionB(),
+                vote.endAt()
         );
     }
 }

--- a/src/main/java/com/ject/vs/chat/port/in/dto/MessageResult.java
+++ b/src/main/java/com/ject/vs/chat/port/in/dto/MessageResult.java
@@ -1,5 +1,6 @@
 package com.ject.vs.chat.port.in.dto;
 
+import com.ject.vs.user.domain.ImageColor;
 import com.ject.vs.vote.domain.VoteOptionCode;
 
 import java.time.Instant;
@@ -9,7 +10,7 @@ public record MessageResult(
         String content,
         Instant sentAt,
         String senderNickname,
-        String senderProfileIcon,
+        ImageColor senderProfileIcon,
         VoteOptionCode senderVoteOption,
         boolean isMine
 ) {}

--- a/src/main/java/com/ject/vs/chat/port/in/dto/MessageResult.java
+++ b/src/main/java/com/ject/vs/chat/port/in/dto/MessageResult.java
@@ -1,5 +1,7 @@
 package com.ject.vs.chat.port.in.dto;
 
+import com.ject.vs.vote.domain.VoteOptionCode;
+
 import java.time.Instant;
 
 public record MessageResult(
@@ -8,6 +10,6 @@ public record MessageResult(
         Instant sentAt,
         String senderNickname,
         String senderProfileIcon,
-        String senderVoteOption,
+        VoteOptionCode senderVoteOption,
         boolean isMine
 ) {}

--- a/src/main/java/com/ject/vs/common/domain/BaseEntity.java
+++ b/src/main/java/com/ject/vs/common/domain/BaseEntity.java
@@ -13,4 +13,8 @@ public abstract class BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    public Boolean isIdEqualTo(Long id) {
+        return this.id != null && this.id.equals(id);
+    }
 }

--- a/src/main/java/com/ject/vs/user/domain/User.java
+++ b/src/main/java/com/ject/vs/user/domain/User.java
@@ -57,4 +57,11 @@ public class User {
         this.imageColor = ImageColor.GREEN;
         this.nickname = nickname;
     }
+
+    public String getUserNameOrEmpty() {
+        if (nickname != null && !nickname.isBlank()) {
+            return nickname;
+        }
+        return "";
+    }
 }

--- a/src/main/java/com/ject/vs/user/domain/User.java
+++ b/src/main/java/com/ject/vs/user/domain/User.java
@@ -57,11 +57,4 @@ public class User {
         this.imageColor = ImageColor.GREEN;
         this.nickname = nickname;
     }
-
-    public String getUserNameOrEmpty() {
-        if (nickname != null && !nickname.isBlank()) {
-            return nickname;
-        }
-        return "";
-    }
 }

--- a/src/main/java/com/ject/vs/user/port/UserQueryService.java
+++ b/src/main/java/com/ject/vs/user/port/UserQueryService.java
@@ -6,6 +6,7 @@ import com.ject.vs.user.domain.UserRepository;
 import com.ject.vs.user.exception.UserErrorCode;
 import com.ject.vs.user.port.in.UserQueryUseCase;
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,7 +18,7 @@ public class UserQueryService implements UserQueryUseCase {
     private final UserRepository userRepository;
 
     @Override
-    public User getUser(Long userId) {
+    public @NonNull User getUser(Long userId) {
         return userRepository.findById(userId).orElseThrow(
                 () -> new BusinessException(UserErrorCode.USER_NOT_FOUND)
         );

--- a/src/main/java/com/ject/vs/user/port/UserQueryService.java
+++ b/src/main/java/com/ject/vs/user/port/UserQueryService.java
@@ -1,0 +1,23 @@
+package com.ject.vs.user.port;
+
+import com.ject.vs.user.domain.User;
+import com.ject.vs.user.domain.UserRepository;
+import com.ject.vs.user.port.in.UserQueryUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserQueryService implements UserQueryUseCase {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public Optional<User> findById(Long userId) {
+        return userRepository.findById(userId);
+    }
+}

--- a/src/main/java/com/ject/vs/user/port/UserQueryService.java
+++ b/src/main/java/com/ject/vs/user/port/UserQueryService.java
@@ -1,13 +1,13 @@
 package com.ject.vs.user.port;
 
+import com.ject.vs.common.exception.BusinessException;
 import com.ject.vs.user.domain.User;
 import com.ject.vs.user.domain.UserRepository;
+import com.ject.vs.user.exception.UserErrorCode;
 import com.ject.vs.user.port.in.UserQueryUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,7 +17,9 @@ public class UserQueryService implements UserQueryUseCase {
     private final UserRepository userRepository;
 
     @Override
-    public Optional<User> findById(Long userId) {
-        return userRepository.findById(userId);
+    public User getUser(Long userId) {
+        return userRepository.findById(userId).orElseThrow(
+                () -> new BusinessException(UserErrorCode.USER_NOT_FOUND)
+        );
     }
 }

--- a/src/main/java/com/ject/vs/user/port/in/UserQueryUseCase.java
+++ b/src/main/java/com/ject/vs/user/port/in/UserQueryUseCase.java
@@ -1,0 +1,10 @@
+package com.ject.vs.user.port.in;
+
+import com.ject.vs.user.domain.User;
+
+import java.util.Optional;
+
+public interface UserQueryUseCase {
+
+    Optional<User> findById(Long userId);
+}

--- a/src/main/java/com/ject/vs/user/port/in/UserQueryUseCase.java
+++ b/src/main/java/com/ject/vs/user/port/in/UserQueryUseCase.java
@@ -1,9 +1,11 @@
 package com.ject.vs.user.port.in;
 
 import com.ject.vs.user.domain.User;
+import org.springframework.lang.NonNull;
 
 import java.util.Optional;
 
 public interface UserQueryUseCase {
+    @NonNull
     User getUser(Long userId);
 }

--- a/src/main/java/com/ject/vs/user/port/in/UserQueryUseCase.java
+++ b/src/main/java/com/ject/vs/user/port/in/UserQueryUseCase.java
@@ -5,6 +5,5 @@ import com.ject.vs.user.domain.User;
 import java.util.Optional;
 
 public interface UserQueryUseCase {
-
-    Optional<User> findById(Long userId);
+    User getUser(Long userId);
 }

--- a/src/main/java/com/ject/vs/vote/domain/Vote.java
+++ b/src/main/java/com/ject/vs/vote/domain/Vote.java
@@ -2,6 +2,7 @@ package com.ject.vs.vote.domain;
 
 import com.ject.vs.common.domain.BaseTimeEntity;
 import com.ject.vs.vote.exception.ImageRequiredException;
+import com.ject.vs.vote.exception.VoteOptionNotFoundException;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -62,7 +63,9 @@ public class Vote extends BaseTimeEntity {
         return vote;
     }
 
-    /** 진실의 원천: endAt만 본다. status 컬럼은 보지 않는다. */
+    /**
+     * 진실의 원천: endAt만 본다. status 컬럼은 보지 않는다.
+     */
     public boolean isOngoing(Clock clock) {
         return Instant.now(clock).isBefore(endAt);
     }
@@ -75,30 +78,31 @@ public class Vote extends BaseTimeEntity {
         return isOngoing(clock) ? VoteStatus.ONGOING : VoteStatus.ENDED;
     }
 
-    public VoteStatus getStatus(){
+    public VoteStatus getStatus() {
         return getStatus(Clock.systemUTC());
     }
 
-    public String getOptionALabel() {
-        return getOptionLabel(0).orElse(null);
+    public VoteOption getOptionA() {
+        return getOption(VoteOptionCode.A)
+                .orElseThrow(VoteOptionNotFoundException::new);
     }
 
-    public String getOptionBLabel() {
-        return getOptionLabel(1).orElse(null);
+    public VoteOption getOptionB() {
+        return getOption(VoteOptionCode.B)
+                .orElseThrow(VoteOptionNotFoundException::new);
     }
 
-    public Optional<VoteOptionCode> getOptionCode(Long optionId) {
-        if (optionId == null) {
-            return Optional.empty();
-        }
+    public VoteOption getOption(Long optionId) {
+        return orderedOptions().stream()
+                .filter(opt -> opt.isIdEqualTo(optionId))
+                .findFirst()
+                .orElseThrow(VoteOptionNotFoundException::new);
+    }
 
-        List<VoteOption> orderedOptions = orderedOptions();
-        for (int i = 0; i < orderedOptions.size(); i++) {
-            if (optionId.equals(orderedOptions.get(i).getId())) {
-                return Optional.of(i == 0 ? VoteOptionCode.A : VoteOptionCode.B);
-            }
-        }
-        return Optional.empty();
+    private Optional<VoteOption> getOption(VoteOptionCode code) {
+        return orderedOptions().stream()
+                .filter(opt -> opt.isCodeEqualTo(code))
+                .findFirst();
     }
 
     private Optional<String> getOptionLabel(int index) {

--- a/src/main/java/com/ject/vs/vote/domain/Vote.java
+++ b/src/main/java/com/ject/vs/vote/domain/Vote.java
@@ -9,6 +9,10 @@ import lombok.NoArgsConstructor;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -32,12 +36,12 @@ public class Vote extends BaseTimeEntity {
 
     private String imageUrl;
 
-//    @Enumerated(EnumType.STRING)
-//    @Column(nullable = false)
-//    private VoteStatus status;
-
     @Column(nullable = false)
     private Instant endAt;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "vote_id", insertable = false, updatable = false)
+    private List<VoteOption> options = new ArrayList<>();
 
     private String aiInsightHeadline;
     private String aiInsightBody;
@@ -54,7 +58,6 @@ public class Vote extends BaseTimeEntity {
         vote.content = content;
         vote.thumbnailUrl = thumbnailUrl;
         vote.imageUrl = imageUrl;
-//        vote.status = VoteStatus.ONGOING;
         vote.endAt = Instant.now(clock).plus(validityPeriod);
         return vote;
     }
@@ -76,10 +79,41 @@ public class Vote extends BaseTimeEntity {
         return getStatus(Clock.systemUTC());
     }
 
-//    /** 스케줄러용 — status 컬럼을 ENDED로 마킹 (캐시 갱신) */
-//    public void markEnded() {
-//        this.status = VoteStatus.ENDED;
-//    }
+    public String getOptionALabel() {
+        return getOptionLabel(0).orElse(null);
+    }
+
+    public String getOptionBLabel() {
+        return getOptionLabel(1).orElse(null);
+    }
+
+    public Optional<VoteOptionCode> getOptionCode(Long optionId) {
+        if (optionId == null) {
+            return Optional.empty();
+        }
+
+        List<VoteOption> orderedOptions = orderedOptions();
+        for (int i = 0; i < orderedOptions.size(); i++) {
+            if (optionId.equals(orderedOptions.get(i).getId())) {
+                return Optional.of(i == 0 ? VoteOptionCode.A : VoteOptionCode.B);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<String> getOptionLabel(int index) {
+        List<VoteOption> orderedOptions = orderedOptions();
+        if (orderedOptions.size() <= index) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(orderedOptions.get(index).getLabel());
+    }
+
+    private List<VoteOption> orderedOptions() {
+        return options.stream()
+                .sorted(Comparator.comparingInt(VoteOption::getPosition))
+                .toList();
+    }
 
     public void cacheAiInsight(String headline, String body) {
         this.aiInsightHeadline = headline;

--- a/src/main/java/com/ject/vs/vote/domain/VoteOption.java
+++ b/src/main/java/com/ject/vs/vote/domain/VoteOption.java
@@ -1,9 +1,7 @@
 package com.ject.vs.vote.domain;
 
 import com.ject.vs.common.domain.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,9 +12,9 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 public class VoteOption extends BaseEntity {
-
-    @Column(nullable = false)
-    private Long voteId;
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "vote_id", nullable = false, updatable = false)
+    private Vote vote;
 
     @Column(nullable = false)
     private String label;
@@ -24,9 +22,9 @@ public class VoteOption extends BaseEntity {
     @Column(nullable = false)
     private int position;
 
-    public static VoteOption of(Long voteId, String label, int position) {
+    public static VoteOption of(Vote vote, String label, int position) {
         VoteOption option = new VoteOption();
-        option.voteId = voteId;
+        option.vote = vote;
         option.label = label;
         option.position = position;
         return option;

--- a/src/main/java/com/ject/vs/vote/domain/VoteOption.java
+++ b/src/main/java/com/ject/vs/vote/domain/VoteOption.java
@@ -29,4 +29,12 @@ public class VoteOption extends BaseEntity {
         option.position = position;
         return option;
     }
+
+    public VoteOptionCode getCode() {
+        return position == 0 ? VoteOptionCode.A : VoteOptionCode.B;
+    }
+
+    public Boolean isCodeEqualTo(VoteOptionCode code) {
+        return getCode().equals(code);
+    }
 }

--- a/src/main/java/com/ject/vs/vote/domain/VoteOptionCode.java
+++ b/src/main/java/com/ject/vs/vote/domain/VoteOptionCode.java
@@ -1,0 +1,6 @@
+package com.ject.vs.vote.domain;
+
+public enum VoteOptionCode {
+    A,
+    B
+}

--- a/src/main/java/com/ject/vs/vote/exception/VoteErrorCode.java
+++ b/src/main/java/com/ject/vs/vote/exception/VoteErrorCode.java
@@ -15,7 +15,8 @@ public enum VoteErrorCode implements ErrorCode {
     INVALID_EMOJI("유효하지 않은 이모지입니다.", 400),
     UNAUTHORIZED("인증이 필요합니다.", 401),
     IMAGE_REQUIRED("몰입형 투표에는 이미지가 필요합니다.", 400),
-    INVALID_DURATION("유효하지 않은 시간입니다.", 400);
+    INVALID_DURATION("유효하지 않은 시간입니다.", 400),
+    VOTE_OPTION_NOT_FOUND("투표 선택지가 존재하지 않습니다.", 404);
 
     private final String message;
     private final Integer statusCode;

--- a/src/main/java/com/ject/vs/vote/exception/VoteOptionNotFoundException.java
+++ b/src/main/java/com/ject/vs/vote/exception/VoteOptionNotFoundException.java
@@ -1,0 +1,9 @@
+package com.ject.vs.vote.exception;
+
+import com.ject.vs.common.exception.BusinessException;
+
+public class VoteOptionNotFoundException extends BusinessException {
+    public VoteOptionNotFoundException() {
+        super(VoteErrorCode.VOTE_OPTION_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/ject/vs/vote/port/VoteCommandService.java
+++ b/src/main/java/com/ject/vs/vote/port/VoteCommandService.java
@@ -33,8 +33,8 @@ public class VoteCommandService implements VoteCommandUseCase {
                 clock
         );
         Vote saved = voteRepository.save(vote);
-        voteOptionRepository.save(VoteOption.of(saved.getId(), cmd.optionA(), 0));
-        voteOptionRepository.save(VoteOption.of(saved.getId(), cmd.optionB(), 1));
+        voteOptionRepository.save(VoteOption.of(saved, cmd.optionA(), 0));
+        voteOptionRepository.save(VoteOption.of(saved, cmd.optionB(), 1));
         return VoteCreateResult.from(saved, clock);
     }
 

--- a/src/main/java/com/ject/vs/vote/port/VoteQueryService.java
+++ b/src/main/java/com/ject/vs/vote/port/VoteQueryService.java
@@ -49,8 +49,8 @@ public class VoteQueryService implements VoteQueryUseCase, VoteParticipationQuer
                 vote.getThumbnailUrl(),
                 vote.getStatus(clock),
                 vote.getEndAt(),
-                vote.getOptionALabel(),
-                vote.getOptionBLabel()
+                vote.getOptionA().getLabel(),
+                vote.getOptionB().getLabel()
         );
     }
 
@@ -65,14 +65,11 @@ public class VoteQueryService implements VoteQueryUseCase, VoteParticipationQuer
     }
 
     @Override
-    public Optional<VoteOptionCode> getSelectedOptionCode(Long voteId, Long userId) {
+    public VoteOption getSelectedOption(Long voteId, Long userId) {
         Optional<Long> selectedOptionId = getSelectedOptionId(voteId, userId);
-        if (selectedOptionId.isEmpty()) {
-            return Optional.empty();
-        }
 
         Vote vote = voteRepository.findById(voteId).orElseThrow(VoteNotFoundException::new);
-        return vote.getOptionCode(selectedOptionId.get());
+        return vote.getOption(selectedOptionId.get());
     }
 
     @Override

--- a/src/main/java/com/ject/vs/vote/port/VoteQueryService.java
+++ b/src/main/java/com/ject/vs/vote/port/VoteQueryService.java
@@ -40,6 +40,21 @@ public class VoteQueryService implements VoteQueryUseCase, VoteParticipationQuer
     }
 
     @Override
+    public VoteChatSummary getVoteChatSummary(Long voteId) {
+        Vote vote = voteRepository.findById(voteId).orElseThrow(VoteNotFoundException::new);
+
+        return new VoteChatSummary(
+                vote.getId(),
+                vote.getTitle(),
+                vote.getThumbnailUrl(),
+                vote.getStatus(clock),
+                vote.getEndAt(),
+                vote.getOptionALabel(),
+                vote.getOptionBLabel()
+        );
+    }
+
+    @Override
     public VoteRatio getRatio(Long voteId) {
         List<VoteOption> options = voteOptionRepository.findByVoteIdOrderByPosition(voteId);
         if (options.size() != 2) throw new IllegalStateException("Vote must have exactly 2 options");
@@ -47,6 +62,17 @@ public class VoteQueryService implements VoteQueryUseCase, VoteParticipationQuer
         long aCount = voteParticipationRepository.countByVoteIdAndOptionId(voteId, options.get(0).getId());
         int aRatio = total == 0 ? 0 : (int) Math.round(aCount * 100.0 / total);
         return new VoteRatio(aRatio, 100 - aRatio, (int) total);
+    }
+
+    @Override
+    public Optional<VoteOptionCode> getSelectedOptionCode(Long voteId, Long userId) {
+        Optional<Long> selectedOptionId = getSelectedOptionId(voteId, userId);
+        if (selectedOptionId.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Vote vote = voteRepository.findById(voteId).orElseThrow(VoteNotFoundException::new);
+        return vote.getOptionCode(selectedOptionId.get());
     }
 
     @Override

--- a/src/main/java/com/ject/vs/vote/port/in/VoteQueryUseCase.java
+++ b/src/main/java/com/ject/vs/vote/port/in/VoteQueryUseCase.java
@@ -1,5 +1,6 @@
 package com.ject.vs.vote.port.in;
 
+import com.ject.vs.vote.domain.VoteOption;
 import com.ject.vs.vote.domain.VoteStatus;
 import com.ject.vs.vote.domain.VoteOptionCode;
 
@@ -19,7 +20,7 @@ public interface VoteQueryUseCase {
 
     VoteRatio getRatio(Long voteId);
 
-    Optional<VoteOptionCode> getSelectedOptionCode(Long voteId, Long userId);
+    VoteOption getSelectedOption(Long voteId, Long userId);
 
     int getParticipantCount(Long voteId);
 

--- a/src/main/java/com/ject/vs/vote/port/in/VoteQueryUseCase.java
+++ b/src/main/java/com/ject/vs/vote/port/in/VoteQueryUseCase.java
@@ -1,6 +1,7 @@
 package com.ject.vs.vote.port.in;
 
 import com.ject.vs.vote.domain.VoteStatus;
+import com.ject.vs.vote.domain.VoteOptionCode;
 
 import java.time.Instant;
 import java.util.List;
@@ -14,7 +15,11 @@ public interface VoteQueryUseCase {
 
     VoteSummary getVoteSummary(Long voteId);
 
+    VoteChatSummary getVoteChatSummary(Long voteId);
+
     VoteRatio getRatio(Long voteId);
+
+    Optional<VoteOptionCode> getSelectedOptionCode(Long voteId, Long userId);
 
     int getParticipantCount(Long voteId);
 
@@ -22,6 +27,17 @@ public interface VoteQueryUseCase {
     List<Long> findAllVoteIdsByStatus(List<Long> voteIds, VoteStatus status);
 
     record VoteSummary(Long voteId, String title, VoteStatus status, Instant endAt) {
+    }
+
+    record VoteChatSummary(
+            Long voteId,
+            String title,
+            String thumbnailUrl,
+            VoteStatus status,
+            Instant endAt,
+            String optionA,
+            String optionB
+    ) {
     }
 
     record VoteRatio(int optionARatio, int optionBRatio, int participantCount) {

--- a/src/main/resources/db/migration/V6__add_vote_option_vote_fk.sql
+++ b/src/main/resources/db/migration/V6__add_vote_option_vote_fk.sql
@@ -1,0 +1,10 @@
+-- vote_option.vote_id → vote(id) 외래키 제약조건 명시적 추가
+-- V3에서 CREATE TABLE 시 inline REFERENCES로 unnamed FK(vote_option_vote_id_fkey)가 이미 생성됨
+-- 기존 unnamed 제약을 제거하고, 프로젝트 네이밍 컨벤션(fk_<table>_<ref_table>)에 맞춰 재생성
+
+ALTER TABLE vote_option
+    DROP CONSTRAINT IF EXISTS vote_option_vote_id_fkey;
+
+ALTER TABLE vote_option
+    ADD CONSTRAINT fk_vote_option_vote
+    FOREIGN KEY (vote_id) REFERENCES vote (id);

--- a/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
@@ -7,9 +7,13 @@ import com.ject.vs.chat.domain.ChatRoomUnreadRepository;
 import com.ject.vs.chat.domain.event.ChatMessageSentEvent;
 import com.ject.vs.chat.port.in.dto.MessageResult;
 import com.ject.vs.chat.port.in.dto.UnreadPayload;
+import com.ject.vs.user.domain.ImageColor;
+import com.ject.vs.user.domain.User;
 import com.ject.vs.user.port.in.UserQueryUseCase;
 import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
 import com.ject.vs.vote.port.in.VoteQueryUseCase;
+
+import static org.mockito.Mockito.mock;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,6 +63,7 @@ class ChatMessageEventListenerTest {
         void 메시지를_채팅방_토픽으로_broadcast한다() {
             // given
             ChatMessage message = ChatMessage.of(1L, 2L, "hello");
+            given(userQueryUseCase.getUser(2L)).willReturn(mock(User.class));
             given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(1L)).willReturn(List.of());
             given(chatMessageRepository.countByVoteId(1L)).willReturn(0L);
 
@@ -73,7 +78,12 @@ class ChatMessageEventListenerTest {
         void 채팅_broadcast_payload는_메시지_정보를_담고_수신자_관점_isMine은_false다() {
             // given
             ChatMessage message = ChatMessage.of(7L, 2L, "hello payload");
-            given(userQueryUseCase.findById(2L)).willReturn(Optional.empty());
+
+            User sender = mock(User.class);
+            given(sender.getNickname()).willReturn("슈퍼강아지_485");
+            given(sender.getImageColor()).willReturn(ImageColor.GREEN);
+            given(userQueryUseCase.getUser(2L)).willReturn(sender);
+
             given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(7L)).willReturn(List.of());
             given(chatMessageRepository.countByVoteId(7L)).willReturn(0L);
 
@@ -85,7 +95,7 @@ class ChatMessageEventListenerTest {
             verify(messagingTemplate).convertAndSend(eq("/topic/chat/7"), captor.capture());
             MessageResult payload = captor.getValue();
             assertThat(payload.content()).isEqualTo("hello payload");
-            assertThat(payload.senderNickname()).isEqualTo("User#2");
+            assertThat(payload.senderNickname()).isEqualTo("슈퍼강아지_485");
             assertThat(payload.isMine()).isFalse();
         }
 
@@ -93,6 +103,7 @@ class ChatMessageEventListenerTest {
         void voteId별로_다른_topic에_broadcast한다() {
             // given
             ChatMessage message = ChatMessage.of(2L, 9L, "vote 2 message");
+            given(userQueryUseCase.getUser(9L)).willReturn(mock(User.class));
             given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(2L)).willReturn(List.of());
             given(chatMessageRepository.countByVoteId(2L)).willReturn(0L);
 
@@ -104,22 +115,6 @@ class ChatMessageEventListenerTest {
             verify(messagingTemplate, never()).convertAndSend(eq("/topic/chat/1"), any(Object.class));
         }
 
-        @Test
-        void 닉네임은_userId_기반_플레이스홀더로_설정된다() {
-            // given
-            ChatMessage message = ChatMessage.of(1L, 2L, "hello");
-            given(userQueryUseCase.findById(2L)).willReturn(Optional.empty());
-            given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(1L)).willReturn(List.of());
-            given(chatMessageRepository.countByVoteId(1L)).willReturn(0L);
-
-            // when
-            listener.handle(new ChatMessageSentEvent(message));
-
-            // then
-            ArgumentCaptor<MessageResult> captor = ArgumentCaptor.forClass(MessageResult.class);
-            verify(messagingTemplate).convertAndSend(eq("/topic/chat/1"), captor.capture());
-            assertThat(captor.getValue().senderNickname()).isEqualTo("User#2");
-        }
     }
 
     @Nested
@@ -129,6 +124,7 @@ class ChatMessageEventListenerTest {
         void 읽음_기록이_없는_참여자에게는_전체_메시지_수를_전송한다() {
             // given
             ChatMessage message = ChatMessage.of(1L, 2L, "hello");
+            given(userQueryUseCase.getUser(2L)).willReturn(mock(User.class));
             given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(1L)).willReturn(List.of(3L));
             given(chatRoomUnreadRepository.findByIdUserIdAndIdVoteId(3L, 1L)).willReturn(Optional.empty());
             given(chatMessageRepository.countByVoteId(1L)).willReturn(5L);
@@ -146,6 +142,7 @@ class ChatMessageEventListenerTest {
         void 읽음_기록이_있으면_lastReadMessageId_이후_메시지_수를_전송한다() {
             // given
             ChatMessage message = ChatMessage.of(1L, 2L, "hello");
+            given(userQueryUseCase.getUser(2L)).willReturn(mock(User.class));
             given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(1L)).willReturn(List.of(3L));
             ChatRoomUnread unread = ChatRoomUnread.of(3L, 1L, 10L);
             given(chatRoomUnreadRepository.findByIdUserIdAndIdVoteId(3L, 1L)).willReturn(Optional.of(unread));

--- a/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
@@ -7,7 +7,9 @@ import com.ject.vs.chat.domain.ChatRoomUnreadRepository;
 import com.ject.vs.chat.domain.event.ChatMessageSentEvent;
 import com.ject.vs.chat.port.in.dto.MessageResult;
 import com.ject.vs.chat.port.in.dto.UnreadPayload;
+import com.ject.vs.user.domain.UserRepository;
 import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
+import com.ject.vs.vote.port.in.VoteQueryUseCase;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,10 +41,16 @@ class ChatMessageEventListenerTest {
     private VoteParticipationQueryUseCase voteParticipationQueryUseCase;
 
     @Mock
+    private VoteQueryUseCase voteQueryUseCase;
+
+    @Mock
     private ChatMessageRepository chatMessageRepository;
 
     @Mock
     private ChatRoomUnreadRepository chatRoomUnreadRepository;
+
+    @Mock
+    private UserRepository userRepository;
 
     @Nested
     class handle {

--- a/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
@@ -10,10 +10,14 @@ import com.ject.vs.chat.port.in.dto.UnreadPayload;
 import com.ject.vs.user.domain.ImageColor;
 import com.ject.vs.user.domain.User;
 import com.ject.vs.user.port.in.UserQueryUseCase;
+import com.ject.vs.vote.domain.VoteOption;
+import com.ject.vs.vote.domain.VoteOptionCode;
 import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
 import com.ject.vs.vote.port.in.VoteQueryUseCase;
 
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,6 +60,15 @@ class ChatMessageEventListenerTest {
     @Mock
     private UserQueryUseCase userQueryUseCase;
 
+    @BeforeEach
+    void setUpDefaults() {
+        lenient().when(userQueryUseCase.getUser(any())).thenReturn(mock(User.class));
+
+        VoteOption dummyOption = mock(VoteOption.class);
+        lenient().when(dummyOption.getCode()).thenReturn(VoteOptionCode.A);
+        lenient().when(voteQueryUseCase.getSelectedOption(anyLong(), anyLong())).thenReturn(dummyOption);
+    }
+
     @Nested
     class handle {
 
@@ -63,7 +76,7 @@ class ChatMessageEventListenerTest {
         void 메시지를_채팅방_토픽으로_broadcast한다() {
             // given
             ChatMessage message = ChatMessage.of(1L, 2L, "hello");
-            given(userQueryUseCase.getUser(2L)).willReturn(mock(User.class));
+            given(userQueryUseCase.getUser(any())).willReturn(mock(User.class));
             given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(1L)).willReturn(List.of());
             given(chatMessageRepository.countByVoteId(1L)).willReturn(0L);
 
@@ -103,7 +116,7 @@ class ChatMessageEventListenerTest {
         void voteId별로_다른_topic에_broadcast한다() {
             // given
             ChatMessage message = ChatMessage.of(2L, 9L, "vote 2 message");
-            given(userQueryUseCase.getUser(9L)).willReturn(mock(User.class));
+            given(userQueryUseCase.getUser(any())).willReturn(mock(User.class));
             given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(2L)).willReturn(List.of());
             given(chatMessageRepository.countByVoteId(2L)).willReturn(0L);
 
@@ -124,7 +137,7 @@ class ChatMessageEventListenerTest {
         void 읽음_기록이_없는_참여자에게는_전체_메시지_수를_전송한다() {
             // given
             ChatMessage message = ChatMessage.of(1L, 2L, "hello");
-            given(userQueryUseCase.getUser(2L)).willReturn(mock(User.class));
+            given(userQueryUseCase.getUser(any())).willReturn(mock(User.class));
             given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(1L)).willReturn(List.of(3L));
             given(chatRoomUnreadRepository.findByIdUserIdAndIdVoteId(3L, 1L)).willReturn(Optional.empty());
             given(chatMessageRepository.countByVoteId(1L)).willReturn(5L);
@@ -142,7 +155,7 @@ class ChatMessageEventListenerTest {
         void 읽음_기록이_있으면_lastReadMessageId_이후_메시지_수를_전송한다() {
             // given
             ChatMessage message = ChatMessage.of(1L, 2L, "hello");
-            given(userQueryUseCase.getUser(2L)).willReturn(mock(User.class));
+            given(userQueryUseCase.getUser(any())).willReturn(mock(User.class));
             given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(1L)).willReturn(List.of(3L));
             ChatRoomUnread unread = ChatRoomUnread.of(3L, 1L, 10L);
             given(chatRoomUnreadRepository.findByIdUserIdAndIdVoteId(3L, 1L)).willReturn(Optional.of(unread));
@@ -162,7 +175,7 @@ class ChatMessageEventListenerTest {
         void 참여자가_여러_명이면_각_user_destination으로_개별_unreadCount를_전송한다() {
             // given
             ChatMessage message = ChatMessage.of(1L, 2L, "hello");
-            given(userQueryUseCase.getUser(2L)).willReturn(mock(User.class));
+            given(userQueryUseCase.getUser(any())).willReturn(mock(User.class));
             given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(1L)).willReturn(List.of(3L, 4L));
             given(chatMessageRepository.countByVoteId(1L)).willReturn(7L);
             given(chatRoomUnreadRepository.findByIdUserIdAndIdVoteId(3L, 1L)).willReturn(Optional.empty());
@@ -190,7 +203,7 @@ class ChatMessageEventListenerTest {
         void 참여자가_없으면_개인_unreadCount는_전송하지_않는다() {
             // given
             ChatMessage message = ChatMessage.of(1L, 2L, "hello");
-            given(userQueryUseCase.getUser(2L)).willReturn(mock(User.class));
+            given(userQueryUseCase.getUser(any())).willReturn(mock(User.class));
             given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(1L)).willReturn(List.of());
             given(chatMessageRepository.countByVoteId(1L)).willReturn(0L);
 

--- a/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
@@ -162,6 +162,7 @@ class ChatMessageEventListenerTest {
         void 참여자가_여러_명이면_각_user_destination으로_개별_unreadCount를_전송한다() {
             // given
             ChatMessage message = ChatMessage.of(1L, 2L, "hello");
+            given(userQueryUseCase.getUser(2L)).willReturn(mock(User.class));
             given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(1L)).willReturn(List.of(3L, 4L));
             given(chatMessageRepository.countByVoteId(1L)).willReturn(7L);
             given(chatRoomUnreadRepository.findByIdUserIdAndIdVoteId(3L, 1L)).willReturn(Optional.empty());
@@ -189,6 +190,7 @@ class ChatMessageEventListenerTest {
         void 참여자가_없으면_개인_unreadCount는_전송하지_않는다() {
             // given
             ChatMessage message = ChatMessage.of(1L, 2L, "hello");
+            given(userQueryUseCase.getUser(2L)).willReturn(mock(User.class));
             given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(1L)).willReturn(List.of());
             given(chatMessageRepository.countByVoteId(1L)).willReturn(0L);
 

--- a/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
@@ -7,7 +7,7 @@ import com.ject.vs.chat.domain.ChatRoomUnreadRepository;
 import com.ject.vs.chat.domain.event.ChatMessageSentEvent;
 import com.ject.vs.chat.port.in.dto.MessageResult;
 import com.ject.vs.chat.port.in.dto.UnreadPayload;
-import com.ject.vs.user.domain.UserRepository;
+import com.ject.vs.user.port.in.UserQueryUseCase;
 import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
 import com.ject.vs.vote.port.in.VoteQueryUseCase;
 import org.junit.jupiter.api.Nested;
@@ -50,7 +50,7 @@ class ChatMessageEventListenerTest {
     private ChatRoomUnreadRepository chatRoomUnreadRepository;
 
     @Mock
-    private UserRepository userRepository;
+    private UserQueryUseCase userQueryUseCase;
 
     @Nested
     class handle {
@@ -73,6 +73,7 @@ class ChatMessageEventListenerTest {
         void 채팅_broadcast_payload는_메시지_정보를_담고_수신자_관점_isMine은_false다() {
             // given
             ChatMessage message = ChatMessage.of(7L, 2L, "hello payload");
+            given(userQueryUseCase.findById(2L)).willReturn(Optional.empty());
             given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(7L)).willReturn(List.of());
             given(chatMessageRepository.countByVoteId(7L)).willReturn(0L);
 
@@ -107,6 +108,7 @@ class ChatMessageEventListenerTest {
         void 닉네임은_userId_기반_플레이스홀더로_설정된다() {
             // given
             ChatMessage message = ChatMessage.of(1L, 2L, "hello");
+            given(userQueryUseCase.findById(2L)).willReturn(Optional.empty());
             given(voteParticipationQueryUseCase.findAllUserIdsByVoteId(1L)).willReturn(List.of());
             given(chatMessageRepository.countByVoteId(1L)).willReturn(0L);
 

--- a/src/test/java/com/ject/vs/chat/adapter/event/ChatWebSocketE2ETest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/event/ChatWebSocketE2ETest.java
@@ -110,7 +110,7 @@ class ChatWebSocketE2ETest {
         MessageResult chatPayload = chatMessages.poll(5, TimeUnit.SECONDS);
         assertThat(chatPayload).isNotNull();
         assertThat(chatPayload.content()).isEqualTo("hello e2e websocket");
-        assertThat(chatPayload.senderNickname()).isEqualTo("User#" + fixture.senderId());
+        assertThat(chatPayload.senderNickname()).isEqualTo(""); // 프로필 미설정 사용자 (정식 스펙상 User# 플레이스홀더 없음)
         assertThat(chatPayload.isMine()).isFalse();
 
         UnreadPayload unreadPayload = unreadMessages.poll(5, TimeUnit.SECONDS);
@@ -121,7 +121,7 @@ class ChatWebSocketE2ETest {
         User sender = userRepository.saveAndFlush(User.createWithEmail("e2e-sender-" + System.nanoTime() + "@test.com"));
         User receiver = userRepository.saveAndFlush(User.createWithEmail("e2e-receiver-" + System.nanoTime() + "@test.com"));
         Vote vote = voteRepository.saveAndFlush(Vote.create(VoteType.GENERAL, "e2e chat vote", null, "thumb", null, Duration.ofHours(1), Clock.systemUTC()));
-        VoteOption option = voteOptionRepository.saveAndFlush(VoteOption.of(vote.getId(), "A", 1));
+        VoteOption option = voteOptionRepository.saveAndFlush(VoteOption.of(vote, "A", 1));
         voteParticipationRepository.saveAndFlush(VoteParticipation.ofMember(vote.getId(), sender.getId(), option.getId()));
         voteParticipationRepository.saveAndFlush(VoteParticipation.ofMember(vote.getId(), receiver.getId(), option.getId()));
         return new TestFixture(vote.getId(), sender.getId(), receiver.getId());

--- a/src/test/java/com/ject/vs/chat/adapter/event/ChatWebSocketIntegrationTest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/event/ChatWebSocketIntegrationTest.java
@@ -103,7 +103,7 @@ class ChatWebSocketIntegrationTest {
         assertThat(received).isNotNull();
         assertThat(received.messageId()).isEqualTo(message.getId());
         assertThat(received.content()).isEqualTo("hello websocket");
-        assertThat(received.senderNickname()).isEqualTo("User#" + fixture.senderId());
+        assertThat(received.senderNickname()).isEqualTo(""); // 프로필 미설정 사용자 (정식 스펙상 User# 플레이스홀더 없음)
         assertThat(received.isMine()).isFalse();
     }
 
@@ -156,7 +156,7 @@ class ChatWebSocketIntegrationTest {
         User sender = userRepository.saveAndFlush(User.createWithEmail("sender-" + System.nanoTime() + "@test.com"));
         User receiver = userRepository.saveAndFlush(User.createWithEmail("receiver-" + System.nanoTime() + "@test.com"));
         Vote vote = voteRepository.saveAndFlush(Vote.create(VoteType.GENERAL, "chat vote", null, "thumb", null, Duration.ofHours(1), Clock.systemUTC()));
-        VoteOption option = voteOptionRepository.saveAndFlush(VoteOption.of(vote.getId(), "A", 1));
+        VoteOption option = voteOptionRepository.saveAndFlush(VoteOption.of(vote, "A", 1));
         voteParticipationRepository.saveAndFlush(VoteParticipation.ofMember(vote.getId(), sender.getId(), option.getId()));
         voteParticipationRepository.saveAndFlush(VoteParticipation.ofMember(vote.getId(), receiver.getId(), option.getId()));
         return new TestFixture(vote.getId(), sender.getId(), receiver.getId());

--- a/src/test/java/com/ject/vs/chat/adapter/web/ChatControllerTest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/web/ChatControllerTest.java
@@ -10,6 +10,7 @@ import com.ject.vs.config.OAuth2LoginSuccessHandler;
 import com.ject.vs.auth.port.CustomOAuth2UserService;
 import com.ject.vs.config.TestPropertiesConfig;
 import org.springframework.context.annotation.Import;
+import com.ject.vs.vote.domain.VoteOptionCode;
 import com.ject.vs.vote.domain.VoteStatus;
 import com.ject.vs.util.CookieUtil;
 import com.ject.vs.util.JwtProvider;
@@ -144,7 +145,7 @@ class ChatControllerTest {
         @WithMockUser
         void 정상이면_201을_반환한다() throws Exception {
             // given
-            MessageResult result = new MessageResult(1L, "hello", Instant.now(), "nick", null, "A", true);
+            MessageResult result = new MessageResult(1L, "hello", Instant.now(), "nick", null, VoteOptionCode.A, true);
             given(chatCommandUseCase.sendMessage(any(SendMessageCommand.class))).willReturn(result);
 
             // when & then

--- a/src/test/java/com/ject/vs/chat/port/ChatServiceTest.java
+++ b/src/test/java/com/ject/vs/chat/port/ChatServiceTest.java
@@ -10,9 +10,15 @@ import com.ject.vs.chat.port.in.dto.MarkAsReadCommand;
 import com.ject.vs.chat.port.in.dto.MessagePageResult;
 import com.ject.vs.chat.port.in.dto.MessageResult;
 import com.ject.vs.chat.port.in.dto.SendMessageCommand;
-import com.ject.vs.user.domain.UserRepository;
+import com.ject.vs.user.domain.ImageColor;
+import com.ject.vs.user.domain.User;
+import com.ject.vs.user.port.in.UserQueryUseCase;
+import com.ject.vs.vote.domain.VoteOption;
+import com.ject.vs.vote.domain.VoteOptionCode;
 import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
 import com.ject.vs.vote.port.in.VoteQueryUseCase;
+
+import static org.mockito.Mockito.mock;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,7 +56,10 @@ class ChatServiceTest {
     private ChatRoomUnreadRepository chatRoomUnreadRepository;
 
     @Mock
-    private UserRepository userRepository;
+    private UserQueryUseCase userQueryUseCase;
+
+    @Mock
+    private VoteOption selectedOption;
 
     @Nested
     class sendMessage {
@@ -82,13 +91,21 @@ class ChatServiceTest {
             ChatMessage savedMessage = ChatMessage.of(1L, 2L, "hello");
             given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
 
+            User sender = mock(User.class);
+            given(sender.getNickname()).willReturn("테스트유저");
+            given(sender.getImageColor()).willReturn(ImageColor.GREEN);
+            given(userQueryUseCase.getUser(2L)).willReturn(sender);
+            given(voteQueryUseCase.getSelectedOption(1L, 2L)).willReturn(selectedOption);
+            given(selectedOption.getCode()).willReturn(VoteOptionCode.A);
+
             // when
             MessageResult result = chatService.sendMessage(new SendMessageCommand(1L, 2L, "hello"));
 
             // then
             assertThat(result).isNotNull();
             assertThat(result.content()).isEqualTo("hello");
-            assertThat(result.senderNickname()).isEqualTo("User#2");
+            assertThat(result.senderNickname()).isEqualTo("테스트유저");
+            assertThat(result.senderVoteOption()).isEqualTo(VoteOptionCode.A);
             verify(chatMessageRepository).save(any(ChatMessage.class));
         }
     }
@@ -131,6 +148,9 @@ class ChatServiceTest {
             ChatMessage msg = ChatMessage.of(1L, 2L, "hello");
             given(chatMessageRepository.findAllByVoteIdOrderByIdDesc(eq(1L), any(PageRequest.class)))
                     .willReturn(List.of(msg));
+            given(userQueryUseCase.getUser(2L)).willReturn(null);
+            given(voteQueryUseCase.getSelectedOption(1L, 2L)).willReturn(selectedOption);
+            given(selectedOption.getCode()).willReturn(null);
 
             // when
             MessagePageResult result = chatService.getMessages(1L, 2L, null, 30);
@@ -147,6 +167,9 @@ class ChatServiceTest {
             ChatMessage msg = ChatMessage.of(1L, 2L, "hello");
             given(chatMessageRepository.findAllByVoteIdAndIdLessThanOrderByIdDesc(eq(1L), eq(100L), any(PageRequest.class)))
                     .willReturn(List.of(msg));
+            given(userQueryUseCase.getUser(2L)).willReturn(null);
+            given(voteQueryUseCase.getSelectedOption(1L, 2L)).willReturn(selectedOption);
+            given(selectedOption.getCode()).willReturn(null);
 
             // when
             MessagePageResult result = chatService.getMessages(1L, 2L, 100L, 30);

--- a/src/test/java/com/ject/vs/chat/port/ChatServiceTest.java
+++ b/src/test/java/com/ject/vs/chat/port/ChatServiceTest.java
@@ -148,7 +148,10 @@ class ChatServiceTest {
             ChatMessage msg = ChatMessage.of(1L, 2L, "hello");
             given(chatMessageRepository.findAllByVoteIdOrderByIdDesc(eq(1L), any(PageRequest.class)))
                     .willReturn(List.of(msg));
-            given(userQueryUseCase.getUser(2L)).willReturn(null);
+            User sender = mock(User.class);
+            given(sender.getNickname()).willReturn("");
+            given(sender.getImageColor()).willReturn(ImageColor.GREEN);
+            given(userQueryUseCase.getUser(2L)).willReturn(sender);
             given(voteQueryUseCase.getSelectedOption(1L, 2L)).willReturn(selectedOption);
             given(selectedOption.getCode()).willReturn(null);
 
@@ -167,7 +170,10 @@ class ChatServiceTest {
             ChatMessage msg = ChatMessage.of(1L, 2L, "hello");
             given(chatMessageRepository.findAllByVoteIdAndIdLessThanOrderByIdDesc(eq(1L), eq(100L), any(PageRequest.class)))
                     .willReturn(List.of(msg));
-            given(userQueryUseCase.getUser(2L)).willReturn(null);
+            User sender = mock(User.class);
+            given(sender.getNickname()).willReturn("");
+            given(sender.getImageColor()).willReturn(ImageColor.GREEN);
+            given(userQueryUseCase.getUser(2L)).willReturn(sender);
             given(voteQueryUseCase.getSelectedOption(1L, 2L)).willReturn(selectedOption);
             given(selectedOption.getCode()).willReturn(null);
 

--- a/src/test/java/com/ject/vs/chat/port/ChatServiceTest.java
+++ b/src/test/java/com/ject/vs/chat/port/ChatServiceTest.java
@@ -10,6 +10,7 @@ import com.ject.vs.chat.port.in.dto.MarkAsReadCommand;
 import com.ject.vs.chat.port.in.dto.MessagePageResult;
 import com.ject.vs.chat.port.in.dto.MessageResult;
 import com.ject.vs.chat.port.in.dto.SendMessageCommand;
+import com.ject.vs.user.domain.UserRepository;
 import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
 import com.ject.vs.vote.port.in.VoteQueryUseCase;
 import org.junit.jupiter.api.Nested;
@@ -47,6 +48,9 @@ class ChatServiceTest {
 
     @Mock
     private ChatRoomUnreadRepository chatRoomUnreadRepository;
+
+    @Mock
+    private UserRepository userRepository;
 
     @Nested
     class sendMessage {

--- a/src/test/java/com/ject/vs/vote/domain/VoteParticipationRepositoryTest.java
+++ b/src/test/java/com/ject/vs/vote/domain/VoteParticipationRepositoryTest.java
@@ -48,8 +48,8 @@ class VoteParticipationRepositoryTest {
                 Vote.create(VoteType.GENERAL, "테스트 투표", null, "thumb", null,
                         Duration.ofHours(24), FIXED_CLOCK)
         );
-        optionA = voteOptionRepository.save(VoteOption.of(vote.getId(), "A", 0));
-        voteOptionRepository.save(VoteOption.of(vote.getId(), "B", 1));
+        optionA = voteOptionRepository.save(VoteOption.of(vote, "A", 0));
+        voteOptionRepository.save(VoteOption.of(vote, "B", 1));
     }
 
     @Nested

--- a/src/test/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
+++ b/src/test/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
@@ -23,6 +23,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.ject.vs.vote.domain.Vote;
 
 @ExtendWith(MockitoExtension.class)
 class ImmersiveVoteQueryServiceTest {
@@ -141,8 +144,10 @@ class ImmersiveVoteQueryServiceTest {
 
         @Test
         void 참여자_없으면_비율_0() {
-            VoteOption optA = VoteOption.of(1L, "A", 1);
-            VoteOption optB = VoteOption.of(1L, "B", 2);
+            Vote dummyVote = mock(Vote.class);
+            given(dummyVote.getId()).willReturn(1L);
+            VoteOption optA = VoteOption.of(dummyVote, "A", 1);
+            VoteOption optB = VoteOption.of(dummyVote, "B", 2);
             given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of(optA, optB));
             given(voteParticipationRepository.countByVoteId(1L)).willReturn(0L);
 
@@ -155,8 +160,10 @@ class ImmersiveVoteQueryServiceTest {
 
         @Test
         void A_3표_B_1표이면_A비율_75_B비율_25() {
-            VoteOption optA = VoteOption.of(1L, "A", 1);
-            VoteOption optB = VoteOption.of(1L, "B", 2);
+            Vote dummyVote = mock(Vote.class);
+            given(dummyVote.getId()).willReturn(1L);
+            VoteOption optA = VoteOption.of(dummyVote, "A", 1);
+            VoteOption optB = VoteOption.of(dummyVote, "B", 2);
             given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of(optA, optB));
             given(voteParticipationRepository.countByVoteId(1L)).willReturn(4L);
             given(voteParticipationRepository.countByVoteIdAndOptionId(eq(1L), any())).willReturn(3L);

--- a/src/test/java/com/ject/vs/vote/port/VoteCommandServiceTest.java
+++ b/src/test/java/com/ject/vs/vote/port/VoteCommandServiceTest.java
@@ -64,8 +64,8 @@ class VoteCommandServiceTest {
             Vote fakeVote = Vote.create(VoteType.GENERAL, "제목", null, "thumb", null,
                     Duration.ofHours(24), FIXED_CLOCK);
             given(voteRepository.save(any())).willReturn(fakeVote);
-            VoteOption optA = VoteOption.of(1L, "A", 0);
-            VoteOption optB = VoteOption.of(1L, "B", 1);
+            VoteOption optA = VoteOption.of(fakeVote, "A", 0);
+            VoteOption optB = VoteOption.of(fakeVote, "B", 1);
             given(voteOptionRepository.save(any())).willReturn(optA, optB);
 
             VoteCreateResult result = service.create(cmd);

--- a/src/test/java/com/ject/vs/vote/port/VoteQueryServiceTest.java
+++ b/src/test/java/com/ject/vs/vote/port/VoteQueryServiceTest.java
@@ -21,6 +21,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.ject.vs.vote.domain.Vote;
 
 @ExtendWith(MockitoExtension.class)
 class VoteQueryServiceTest {
@@ -112,8 +115,10 @@ class VoteQueryServiceTest {
 
         @Test
         void 옵션_비율을_올바르게_계산한다() {
-            VoteOption optA = VoteOption.of(1L, "A", 0);
-            VoteOption optB = VoteOption.of(1L, "B", 1);
+            Vote dummyVote = mock(Vote.class);
+            given(dummyVote.getId()).willReturn(1L);
+            VoteOption optA = VoteOption.of(dummyVote, "A", 0);
+            VoteOption optB = VoteOption.of(dummyVote, "B", 1);
             given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of(optA, optB));
             given(voteParticipationRepository.countByVoteId(1L)).willReturn(4L);
             given(voteParticipationRepository.countByVoteIdAndOptionId(1L, optA.getId())).willReturn(3L);
@@ -127,8 +132,10 @@ class VoteQueryServiceTest {
 
         @Test
         void 참여자_없으면_비율_0() {
-            VoteOption optA = VoteOption.of(1L, "A", 0);
-            VoteOption optB = VoteOption.of(1L, "B", 1);
+            Vote dummyVote = mock(Vote.class);
+            given(dummyVote.getId()).willReturn(1L);
+            VoteOption optA = VoteOption.of(dummyVote, "A", 0);
+            VoteOption optB = VoteOption.of(dummyVote, "B", 1);
             given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of(optA, optB));
             given(voteParticipationRepository.countByVoteId(1L)).willReturn(0L);
             given(voteParticipationRepository.countByVoteIdAndOptionId(1L, optA.getId())).willReturn(0L);


### PR DESCRIPTION
## 작업 내용
- 채팅방 목록(`ChatListItemResult`)과 채팅방 상세(`ChatRoomResult`)에 Vote 실제 데이터 연동
  - 기존 TODO로 비워져 있던 `title`, `optionA`, `optionB`, `endAt`, `status`, `thumbnailUrl` 채움
- 채팅 메시지 전송 시 발신자가 선택한 투표 옵션(A/B) 정보 포함 (`senderVoteOption`)
- `Vote` 엔티티에 `VoteOption` 양방향 매핑 추가 및 편의 메서드 제공
- `VoteOptionCode` enum (A, B) 신규 추가
- `VoteQueryUseCase`에 채팅 전용 요약 조회 메서드 추가 (`getVoteChatSummary`, `getSelectedOption`)
- `VoteOption`을 `@ManyToOne(Vote)` 관계로 리팩토링
- DB 마이그레이션 V6: `vote_option.vote_id`에 명시적 FK 제약 추가

## 주요 API 스펙 변경 (최종)
### MessageResponse
- `senderProfileIcon`: `ImageColor` enum (`GREEN`, `RED`, `BLUE`, `YELLOW`) — 기존 String(URL)에서 변경
- `senderVoteOption`: `VoteOptionCode` enum (`A`/`B`) — OpenAPI에서 enum 타입으로 명확히 노출

### 기타
- `UserQueryUseCase.getUser(@NonNull Long)` 도입
- `getNickname()` 직접 사용 (기존 `getUserNameOrEmpty()` 제거)
- Chat layer에서 불필요한 resolve helper 제거, 직접 UseCase 호출로 단순화

## 변경 파일
- `MessageResponse`, `MessageResult`
- `Vote`, `VoteOption`, `VoteOptionCode`
- `VoteQueryUseCase`, `VoteQueryService`
- `ChatService`, `ChatMessageEventListener`
- `UserQueryUseCase`, `UserQueryService`
- 관련 테스트 및 V6 마이그레이션

## 참고
- Base branch: `develop`
- Notion API 스펙 페이지에도 반영 완료
