### PR TITLE
refactor(api): MessageResponse의 senderVoteOption을 VoteOptionCode enum으로 변경

### DIFF
--- a/src/main/java/com/ject/vs/chat/adapter/web/dto/MessageResponse.java
+++ b/src/main/java/com/ject/vs/chat/adapter/web/dto/MessageResponse.java
@@ -2,6 +2,7 @@ package com.ject.vs.chat.adapter.web.dto;
 
 import com.ject.vs.chat.port.in.dto.MessageResult;
 import com.ject.vs.user.domain.ImageColor;
+import com.ject.vs.vote.domain.VoteOptionCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.Instant;
@@ -24,20 +25,19 @@ public record MessageResponse(
         ImageColor senderProfileIcon,
 
         @Schema(description = "메시지를 보낸 사용자가 선택한 투표 선택지", example = "A", allowableValues = {"A", "B"}, nullable = true)
-        String senderVoteOption,
+        VoteOptionCode senderVoteOption,
 
         @Schema(description = "현재 로그인 사용자가 보낸 메시지인지 여부", example = "false")
         boolean isMine
 ) {
     public static MessageResponse from(MessageResult result) {
-        String voteOption = result.senderVoteOption() != null ? result.senderVoteOption().name() : null;
         return new MessageResponse(
                 result.messageId(),
                 result.content(),
                 result.sentAt(),
                 result.senderNickname(),
                 result.senderProfileIcon(),
-                voteOption,
+                result.senderVoteOption(),
                 result.isMine()
         );
     }

--- a/src/test/java/com/ject/vs/chat/adapter/event/ChatWebSocketE2ETest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/event/ChatWebSocketE2ETest.java
@@ -110,7 +110,7 @@ class ChatWebSocketE2ETest {
         MessageResult chatPayload = chatMessages.poll(5, TimeUnit.SECONDS);
         assertThat(chatPayload).isNotNull();
         assertThat(chatPayload.content()).isEqualTo("hello e2e websocket");
-        assertThat(chatPayload.senderNickname()).isEqualTo(""); // 프로필 미설정 사용자 (정식 스펙상 User# 플레이스홀더 없음)
+        assertThat(chatPayload.senderNickname()).isNull(); // 프로필 미설정 사용자는 null
         assertThat(chatPayload.isMine()).isFalse();
 
         UnreadPayload unreadPayload = unreadMessages.poll(5, TimeUnit.SECONDS);

--- a/src/test/java/com/ject/vs/chat/adapter/event/ChatWebSocketIntegrationTest.java
+++ b/src/test/java/com/ject/vs/chat/adapter/event/ChatWebSocketIntegrationTest.java
@@ -103,7 +103,7 @@ class ChatWebSocketIntegrationTest {
         assertThat(received).isNotNull();
         assertThat(received.messageId()).isEqualTo(message.getId());
         assertThat(received.content()).isEqualTo("hello websocket");
-        assertThat(received.senderNickname()).isEqualTo(""); // 프로필 미설정 사용자 (정식 스펙상 User# 플레이스홀더 없음)
+        assertThat(received.senderNickname()).isNull(); // 프로필 미설정 사용자는 null
         assertThat(received.isMine()).isFalse();
     }
 

--- a/src/test/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
+++ b/src/test/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
@@ -145,7 +145,6 @@ class ImmersiveVoteQueryServiceTest {
         @Test
         void 참여자_없으면_비율_0() {
             Vote dummyVote = mock(Vote.class);
-            given(dummyVote.getId()).willReturn(1L);
             VoteOption optA = VoteOption.of(dummyVote, "A", 1);
             VoteOption optB = VoteOption.of(dummyVote, "B", 2);
             given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of(optA, optB));
@@ -161,7 +160,6 @@ class ImmersiveVoteQueryServiceTest {
         @Test
         void A_3표_B_1표이면_A비율_75_B비율_25() {
             Vote dummyVote = mock(Vote.class);
-            given(dummyVote.getId()).willReturn(1L);
             VoteOption optA = VoteOption.of(dummyVote, "A", 1);
             VoteOption optB = VoteOption.of(dummyVote, "B", 2);
             given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of(optA, optB));

--- a/src/test/java/com/ject/vs/vote/port/VoteQueryServiceTest.java
+++ b/src/test/java/com/ject/vs/vote/port/VoteQueryServiceTest.java
@@ -116,7 +116,6 @@ class VoteQueryServiceTest {
         @Test
         void 옵션_비율을_올바르게_계산한다() {
             Vote dummyVote = mock(Vote.class);
-            given(dummyVote.getId()).willReturn(1L);
             VoteOption optA = VoteOption.of(dummyVote, "A", 0);
             VoteOption optB = VoteOption.of(dummyVote, "B", 1);
             given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of(optA, optB));
@@ -133,7 +132,6 @@ class VoteQueryServiceTest {
         @Test
         void 참여자_없으면_비율_0() {
             Vote dummyVote = mock(Vote.class);
-            given(dummyVote.getId()).willReturn(1L);
             VoteOption optA = VoteOption.of(dummyVote, "A", 0);
             VoteOption optB = VoteOption.of(dummyVote, "B", 1);
             given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of(optA, optB));


### PR DESCRIPTION


- senderProfileIcon: ImageColor (기존)
- senderVoteOption: VoteOptionCode enum으로 통일
- OpenAPI 스펙에서 enum 타입으로 명확하게 노출되도록 개선

## 📌 관련 이슈
- closes #

## 🔍 작업 내용
<!-- 어떤 변경을 했는지 간단히 설명해주세요 -->

## 📝 변경 사항
<!-- 주요 변경 사항을 작성해주세요 -->
- 



## 💬 리뷰어에게
<!-- 리뷰 시 집중적으로 봐줬으면 하는 부분이 있다면 작성해주세요 -->