### PR TITLE
fix: API 스펙에 맞게 투표 및 알림 응답 형식 수정

### DIFF
--- a/src/main/java/com/ject/vs/notification/domain/Notification.java
+++ b/src/main/java/com/ject/vs/notification/domain/Notification.java
@@ -38,8 +38,8 @@ public class Notification extends BaseEntity {
         n.userId = userId;
         n.type = NotificationType.VOTE_ENDED;
         n.voteId = voteId;
-        n.title = voteTitle;
-        n.body = "투표 결과가 공개됐어요";
+        n.title = "투표 결과가 공개됐어요";
+        n.body = "[" + voteTitle + "] 결과 보러가기";
         n.thumbnailUrl = thumbnailUrl;
         n.isRead = false;
         n.createdAt = Instant.now(clock);

--- a/src/main/java/com/ject/vs/notification/event/PushNotificationSender.java
+++ b/src/main/java/com/ject/vs/notification/event/PushNotificationSender.java
@@ -72,8 +72,8 @@ public class PushNotificationSender {
 
             FcmPayload payload = new FcmPayload(
                     notification.getType(),
-                    notification.getBody(),
                     notification.getTitle(),
+                    notification.getBody(),
                     notification.getId(),
                     notification.getVoteId(),
                     notification.getThumbnailUrl(),

--- a/src/main/java/com/ject/vs/notification/port/NotificationCommandService.java
+++ b/src/main/java/com/ject/vs/notification/port/NotificationCommandService.java
@@ -3,7 +3,6 @@ package com.ject.vs.notification.port;
 import com.ject.vs.notification.domain.Notification;
 import com.ject.vs.notification.domain.NotificationRepository;
 import com.ject.vs.notification.domain.NotificationType;
-import com.ject.vs.notification.exception.NotificationAccessDeniedException;
 import com.ject.vs.notification.exception.NotificationNotFoundException;
 import com.ject.vs.notification.port.in.NotificationCommandUseCase;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +25,7 @@ public class NotificationCommandService implements NotificationCommandUseCase {
     public void markAsRead(Long notificationId, Long userId) {
         Notification n = notificationRepository.findById(notificationId)
                 .orElseThrow(NotificationNotFoundException::new);
-        if (!n.isOwnedBy(userId)) throw new NotificationAccessDeniedException();
+        if (!n.isOwnedBy(userId)) throw new NotificationNotFoundException();
         n.markRead(clock);
     }
 

--- a/src/main/java/com/ject/vs/vote/adapter/web/ImmersiveVoteController.java
+++ b/src/main/java/com/ject/vs/vote/adapter/web/ImmersiveVoteController.java
@@ -32,7 +32,7 @@ public class ImmersiveVoteController {
         return ImmersiveFeedResponse.from(immersiveVoteQueryUseCase.getFeed(cursor, size, userId, anonymousId));
     }
 
-    @PutMapping("/{voteId}/participate")
+    @PostMapping("/{voteId}/participate")
     public ImmersiveParticipateResponse participateOrCancel(
             @PathVariable Long voteId,
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/ject/vs/vote/adapter/web/dto/ImmersiveParticipateResponse.java
+++ b/src/main/java/com/ject/vs/vote/adapter/web/dto/ImmersiveParticipateResponse.java
@@ -11,7 +11,7 @@ public record ImmersiveParticipateResponse(
         List<OptionItem> options,
         Integer remainingFreeVotes
 ) {
-    public record OptionItem(Long optionId, String label, long voteCount, Integer ratio) {
+    public record OptionItem(Long optionId, String label, Long voteCount, Integer ratio) {
     }
 
     public static ImmersiveParticipateResponse from(ImmersiveParticipateResult result) {

--- a/src/main/java/com/ject/vs/vote/adapter/web/dto/ParticipateResponse.java
+++ b/src/main/java/com/ject/vs/vote/adapter/web/dto/ParticipateResponse.java
@@ -11,7 +11,7 @@ public record ParticipateResponse(
         int participantCount,
         Integer remainingFreeVotes
 ) {
-    public record OptionItem(Long optionId, String label, long voteCount, Integer ratio) {
+    public record OptionItem(Long optionId, String label, Long voteCount, Integer ratio) {
     }
 
     public static ParticipateResponse from(ParticipateResult result) {

--- a/src/main/java/com/ject/vs/vote/port/ImmersiveVoteCommandService.java
+++ b/src/main/java/com/ject/vs/vote/port/ImmersiveVoteCommandService.java
@@ -65,8 +65,16 @@ public class ImmersiveVoteCommandService implements ImmersiveVoteCommandUseCase 
     private ImmersiveParticipateResult buildResult(Long voteId, ImmersiveVoteAction action,
                                                     Long selectedOptionId, Integer remainingFreeVotes) {
         List<VoteOption> options = voteOptionRepository.findByVoteIdOrderByPosition(voteId);
-        long total = voteParticipationRepository.countByVoteId(voteId);
 
+        // CANCELED 시 voteCount/ratio를 null로 반환
+        if (action == ImmersiveVoteAction.CANCELED) {
+            List<OptionResult> optionResults = options.stream()
+                    .map(opt -> new OptionResult(opt.getId(), opt.getLabel(), null, null))
+                    .toList();
+            return new ImmersiveParticipateResult(voteId, action, selectedOptionId, optionResults, remainingFreeVotes);
+        }
+
+        long total = voteParticipationRepository.countByVoteId(voteId);
         List<OptionResult> optionResults = options.stream().map(opt -> {
             long count = voteParticipationRepository.countByVoteIdAndOptionId(voteId, opt.getId());
             int ratio = total == 0 ? 0 : (int) Math.round(count * 100.0 / total);

--- a/src/main/java/com/ject/vs/vote/port/in/VoteCommandUseCase.java
+++ b/src/main/java/com/ject/vs/vote/port/in/VoteCommandUseCase.java
@@ -46,6 +46,6 @@ public interface VoteCommandUseCase {
     ) {
     }
 
-    record OptionResult(Long optionId, String label, long voteCount, Integer ratio) {
+    record OptionResult(Long optionId, String label, Long voteCount, Integer ratio) {
     }
 }

--- a/src/test/java/com/ject/vs/vote/adapter/web/ImmersiveVoteControllerTest.java
+++ b/src/test/java/com/ject/vs/vote/adapter/web/ImmersiveVoteControllerTest.java
@@ -187,8 +187,8 @@ class ImmersiveVoteControllerTest {
         @WithMockUser
         void 옵션_변경은_무료투표_차감_안함() throws Exception {
             List<OptionResult> options = List.of(
-                    new OptionResult(10L, "스윙칩만 3달 먹기", 99, 76),
-                    new OptionResult(11L, "스윙스한테 30만원 주기", 32, 24)
+                    new OptionResult(10L, "스윙칩만 3달 먹기", 99L, 76),
+                    new OptionResult(11L, "스윙스한테 30만원 주기", 32L, 24)
             );
             given(immersiveVoteCommandUseCase.participateOrCancel(eq(1L), isNull(), any(), eq(11L)))
                     .willReturn(new ImmersiveParticipateResult(1L, ImmersiveVoteAction.VOTED, 11L, options, 2));

--- a/src/test/java/com/ject/vs/vote/adapter/web/ImmersiveVoteControllerTest.java
+++ b/src/test/java/com/ject/vs/vote/adapter/web/ImmersiveVoteControllerTest.java
@@ -88,7 +88,7 @@ class ImmersiveVoteControllerTest {
             given(immersiveVoteCommandUseCase.participateOrCancel(eq(1L), eq(1L), any(), eq(10L)))
                     .willReturn(new ImmersiveParticipateResult(1L, ImmersiveVoteAction.VOTED, 10L, List.of(), null));
 
-            mockMvc.perform(put("/api/immersive-votes/1/participate")
+            mockMvc.perform(post("/api/immersive-votes/1/participate")
                             .with(authentication(AUTH)).with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(new ParticipateRequest(10L))))
@@ -103,7 +103,7 @@ class ImmersiveVoteControllerTest {
             given(immersiveVoteCommandUseCase.participateOrCancel(eq(1L), isNull(), any(), eq(10L)))
                     .willReturn(new ImmersiveParticipateResult(1L, ImmersiveVoteAction.VOTED, 10L, List.of(), 4));
 
-            mockMvc.perform(put("/api/immersive-votes/1/participate")
+            mockMvc.perform(post("/api/immersive-votes/1/participate")
                             .with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(new ParticipateRequest(10L))))
@@ -156,7 +156,7 @@ class ImmersiveVoteControllerTest {
             given(immersiveVoteCommandUseCase.participateOrCancel(eq(1L), eq(1L), any(), eq(10L)))
                     .willReturn(new ImmersiveParticipateResult(1L, ImmersiveVoteAction.CANCELED, null, List.of(), null));
 
-            mockMvc.perform(put("/api/immersive-votes/1/participate")
+            mockMvc.perform(post("/api/immersive-votes/1/participate")
                             .with(authentication(AUTH)).with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(new ParticipateRequest(10L))))
@@ -175,7 +175,7 @@ class ImmersiveVoteControllerTest {
             given(immersiveVoteCommandUseCase.participateOrCancel(eq(1L), isNull(), any(), eq(10L)))
                     .willThrow(new VoteFreeLimitExceededException());
 
-            mockMvc.perform(put("/api/immersive-votes/1/participate")
+            mockMvc.perform(post("/api/immersive-votes/1/participate")
                             .with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(new ParticipateRequest(10L))))
@@ -193,7 +193,7 @@ class ImmersiveVoteControllerTest {
             given(immersiveVoteCommandUseCase.participateOrCancel(eq(1L), isNull(), any(), eq(11L)))
                     .willReturn(new ImmersiveParticipateResult(1L, ImmersiveVoteAction.VOTED, 11L, options, 2));
 
-            mockMvc.perform(put("/api/immersive-votes/1/participate")
+            mockMvc.perform(post("/api/immersive-votes/1/participate")
                             .with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(new ParticipateRequest(11L))))
@@ -212,7 +212,7 @@ class ImmersiveVoteControllerTest {
             given(immersiveVoteCommandUseCase.participateOrCancel(eq(1L), eq(1L), any(), eq(10L)))
                     .willThrow(new VoteEndedException());
 
-            mockMvc.perform(put("/api/immersive-votes/1/participate")
+            mockMvc.perform(post("/api/immersive-votes/1/participate")
                             .with(authentication(AUTH)).with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(new ParticipateRequest(10L))))

--- a/src/test/java/com/ject/vs/vote/adapter/web/VoteControllerTest.java
+++ b/src/test/java/com/ject/vs/vote/adapter/web/VoteControllerTest.java
@@ -195,8 +195,8 @@ class VoteControllerTest {
         @WithMockUser
         void 비회원_참여_성공_200_반환() throws Exception {
             List<OptionResult> options = List.of(
-                    new OptionResult(10L, "혼밥이 편하다", 22, 70),
-                    new OptionResult(11L, "같이 먹기", 9, 30)
+                    new OptionResult(10L, "혼밥이 편하다", 22L, 70),
+                    new OptionResult(11L, "같이 먹기", 9L, 30)
             );
             given(voteCommandUseCase.participateAsGuest(eq(1L), any(), eq(10L)))
                     .willReturn(new ParticipateResult(1L, 10L, options, 31, 4));

--- a/src/test/java/com/ject/vs/vote/adapter/web/VoteResultControllerTest.java
+++ b/src/test/java/com/ject/vs/vote/adapter/web/VoteResultControllerTest.java
@@ -138,8 +138,8 @@ class VoteResultControllerTest {
         @Test
         void 회원_참여O_MY_SELECTION_스코프() throws Exception {
             List<OptionResult> options = List.of(
-                    new OptionResult(10L, "혼밥이 편하다", 364, 70),
-                    new OptionResult(11L, "같이 먹기", 156, 30)
+                    new OptionResult(10L, "혼밥이 편하다", 364L, 70),
+                    new OptionResult(11L, "같이 먹기", 156L, 30)
             );
             Insight insight = new Insight(
                     false,
@@ -191,8 +191,8 @@ class VoteResultControllerTest {
         @Test
         void 회원_참여X_TOTAL_스코프() throws Exception {
             List<OptionResult> options = List.of(
-                    new OptionResult(10L, "혼밥이 편하다", 364, 70),
-                    new OptionResult(11L, "같이 먹기", 156, 30)
+                    new OptionResult(10L, "혼밥이 편하다", 364L, 70),
+                    new OptionResult(11L, "같이 먹기", 156L, 30)
             );
             Insight insight = new Insight(
                     false,
@@ -230,8 +230,8 @@ class VoteResultControllerTest {
         @WithMockUser
         void 비회원_insight_locked() throws Exception {
             List<OptionResult> options = List.of(
-                    new OptionResult(10L, "혼밥이 편하다", 364, 70),
-                    new OptionResult(11L, "같이 먹기", 156, 30)
+                    new OptionResult(10L, "혼밥이 편하다", 364L, 70),
+                    new OptionResult(11L, "같이 먹기", 156L, 30)
             );
             VoteResultDetail result = new VoteResultDetail(
                     1L, "직장인 점심시간 혼밥 vs 같이 먹기",

--- a/src/test/java/com/ject/vs/vote/port/ImmersiveVoteCommandServiceTest.java
+++ b/src/test/java/com/ject/vs/vote/port/ImmersiveVoteCommandServiceTest.java
@@ -50,14 +50,18 @@ class ImmersiveVoteCommandServiceTest {
                 Duration.ofHours(1), FIXED_CLOCK);
     }
 
-    private void stubOngoing(Long voteId) {
+    private void stubOngoingBase(Long voteId) {
         given(clock.instant()).willReturn(Instant.parse("2025-01-01T00:00:00Z"));
         given(voteRepository.findById(voteId)).willReturn(Optional.of(ongoingVote()));
-        given(voteOptionRepository.existsByIdAndVoteId(10L, voteId)).willReturn(true);
     }
 
-    private void stubOngoingForVoted(Long voteId) {
-        stubOngoing(voteId);
+    private void stubOngoing(Long voteId, Long optionId) {
+        stubOngoingBase(voteId);
+        given(voteOptionRepository.existsByIdAndVoteId(optionId, voteId)).willReturn(true);
+    }
+
+    private void stubOngoingForVoted(Long voteId, Long optionId) {
+        stubOngoing(voteId, optionId);
         given(voteOptionRepository.findByVoteIdOrderByPosition(voteId)).willReturn(List.of());
         given(voteParticipationRepository.countByVoteId(voteId)).willReturn(0L);
     }
@@ -67,7 +71,7 @@ class ImmersiveVoteCommandServiceTest {
 
         @Test
         void 신규_참여시_VOTED_반환() {
-            stubOngoingForVoted(1L);
+            stubOngoingForVoted(1L, 10L);
             given(voteParticipationRepository.findByVoteIdAndUserId(1L, 2L)).willReturn(Optional.empty());
             given(voteParticipationRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
 
@@ -81,8 +85,7 @@ class ImmersiveVoteCommandServiceTest {
 
         @Test
         void 다른_옵션_클릭시_VOTED_반환_및_옵션_변경() {
-            stubOngoingForVoted(1L);
-            given(voteOptionRepository.existsByIdAndVoteId(11L, 1L)).willReturn(true);
+            stubOngoingForVoted(1L, 11L);
             VoteParticipation existing = VoteParticipation.ofMember(1L, 2L, 10L);
             given(voteParticipationRepository.findByVoteIdAndUserId(1L, 2L)).willReturn(Optional.of(existing));
 
@@ -95,7 +98,7 @@ class ImmersiveVoteCommandServiceTest {
 
         @Test
         void 같은_옵션_재클릭시_CANCELED() {
-            stubOngoing(1L);
+            stubOngoing(1L, 10L);
             given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of());
             VoteParticipation existing = VoteParticipation.ofMember(1L, 2L, 10L);
             given(voteParticipationRepository.findByVoteIdAndUserId(1L, 2L)).willReturn(Optional.of(existing));
@@ -113,7 +116,7 @@ class ImmersiveVoteCommandServiceTest {
 
         @Test
         void 신규_비회원_참여시_차감_후_VOTED() {
-            stubOngoingForVoted(1L);
+            stubOngoingForVoted(1L, 10L);
             given(voteParticipationRepository.findByVoteIdAndAnonymousId(1L, "anon")).willReturn(Optional.empty());
             given(voteParticipationRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
             given(guestFreeVoteService.remaining("anon")).willReturn(4);
@@ -127,7 +130,7 @@ class ImmersiveVoteCommandServiceTest {
 
         @Test
         void 비회원_옵션_변경시_차감_없음() {
-            stubOngoingForVoted(1L);
+            stubOngoingForVoted(1L, 10L);
             VoteParticipation existing = VoteParticipation.ofGuest(1L, "anon", 20L);
             given(voteParticipationRepository.findByVoteIdAndAnonymousId(1L, "anon")).willReturn(Optional.of(existing));
             given(guestFreeVoteService.remaining("anon")).willReturn(3);

--- a/src/test/java/com/ject/vs/vote/port/ImmersiveVoteCommandServiceTest.java
+++ b/src/test/java/com/ject/vs/vote/port/ImmersiveVoteCommandServiceTest.java
@@ -54,6 +54,10 @@ class ImmersiveVoteCommandServiceTest {
         given(clock.instant()).willReturn(Instant.parse("2025-01-01T00:00:00Z"));
         given(voteRepository.findById(voteId)).willReturn(Optional.of(ongoingVote()));
         given(voteOptionRepository.existsByIdAndVoteId(10L, voteId)).willReturn(true);
+    }
+
+    private void stubOngoingForVoted(Long voteId) {
+        stubOngoing(voteId);
         given(voteOptionRepository.findByVoteIdOrderByPosition(voteId)).willReturn(List.of());
         given(voteParticipationRepository.countByVoteId(voteId)).willReturn(0L);
     }
@@ -63,7 +67,7 @@ class ImmersiveVoteCommandServiceTest {
 
         @Test
         void 신규_참여시_VOTED_반환() {
-            stubOngoing(1L);
+            stubOngoingForVoted(1L);
             given(voteParticipationRepository.findByVoteIdAndUserId(1L, 2L)).willReturn(Optional.empty());
             given(voteParticipationRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
 
@@ -77,18 +81,22 @@ class ImmersiveVoteCommandServiceTest {
 
         @Test
         void 다른_옵션_클릭시_VOTED_반환_및_옵션_변경() {
-            stubOngoing(1L);
+            stubOngoingForVoted(1L);
+            given(voteOptionRepository.existsByIdAndVoteId(11L, 1L)).willReturn(true);
             VoteParticipation existing = VoteParticipation.ofMember(1L, 2L, 10L);
             given(voteParticipationRepository.findByVoteIdAndUserId(1L, 2L)).willReturn(Optional.of(existing));
 
-            ImmersiveParticipateResult result = service.participateOrCancel(1L, 2L, null, 10L);
-            // same option → CANCELED
-            assertThat(result.action()).isEqualTo(ImmersiveVoteAction.CANCELED);
+            ImmersiveParticipateResult result = service.participateOrCancel(1L, 2L, null, 11L);
+
+            assertThat(result.action()).isEqualTo(ImmersiveVoteAction.VOTED);
+            assertThat(result.selectedOptionId()).isEqualTo(11L);
+            assertThat(existing.getOptionId()).isEqualTo(11L);
         }
 
         @Test
         void 같은_옵션_재클릭시_CANCELED() {
             stubOngoing(1L);
+            given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of());
             VoteParticipation existing = VoteParticipation.ofMember(1L, 2L, 10L);
             given(voteParticipationRepository.findByVoteIdAndUserId(1L, 2L)).willReturn(Optional.of(existing));
 
@@ -105,7 +113,7 @@ class ImmersiveVoteCommandServiceTest {
 
         @Test
         void 신규_비회원_참여시_차감_후_VOTED() {
-            stubOngoing(1L);
+            stubOngoingForVoted(1L);
             given(voteParticipationRepository.findByVoteIdAndAnonymousId(1L, "anon")).willReturn(Optional.empty());
             given(voteParticipationRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
             given(guestFreeVoteService.remaining("anon")).willReturn(4);
@@ -119,7 +127,7 @@ class ImmersiveVoteCommandServiceTest {
 
         @Test
         void 비회원_옵션_변경시_차감_없음() {
-            stubOngoing(1L);
+            stubOngoingForVoted(1L);
             VoteParticipation existing = VoteParticipation.ofGuest(1L, "anon", 20L);
             given(voteParticipationRepository.findByVoteIdAndAnonymousId(1L, "anon")).willReturn(Optional.of(existing));
             given(guestFreeVoteService.remaining("anon")).willReturn(3);

--- a/src/test/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
+++ b/src/test/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
@@ -153,6 +153,7 @@ class ImmersiveVoteQueryServiceTest {
 
         @Test
         void 참여자_없으면_비율_0() {
+            given(voteRepository.existsById(1L)).willReturn(true);
             Vote dummyVote = mock(Vote.class);
             VoteOption optA = VoteOption.of(dummyVote, "A", 1);
             VoteOption optB = VoteOption.of(dummyVote, "B", 2);
@@ -170,6 +171,7 @@ class ImmersiveVoteQueryServiceTest {
 
         @Test
         void A_3표_B_1표이면_A비율_75_B비율_25() {
+            given(voteRepository.existsById(1L)).willReturn(true);
             Vote dummyVote = mock(Vote.class);
             VoteOption optA = VoteOption.of(dummyVote, "A", 1);
             VoteOption optB = VoteOption.of(dummyVote, "B", 2);


### PR DESCRIPTION
## 📌 관련 이슈
  - closes #

  ## 🔍 작업 내용
  API 스펙 문서와 실제 구현 코드 간의 불일치 사항을 수정했습니다.

  ## 📝 변경 사항
  - 몰입형 투표 참여 API HTTP 메서드 `PUT` → `POST` 변경
  - 몰입형 투표 취소(CANCELED) 시 options의 `voteCount`/`ratio`를 `null`로 반환
  - 알림 `title`/`body` 값 교체 및 body 형식 `[투표제목] 결과 보러가기`로 변경
  - FCM 페이로드 title/body 순서 수정
  - 본인 소유 아닌 알림 접근 시 403 → 404 반환 (보안상 404 사용)

  ## 💬 리뷰어에게
  - API 스펙과 코드 간 불일치 사항을 전체 점검 후 수정한 PR입니다.