### PR TITLE
fix: make local tests pass without external services

### DIFF
--- a/src/main/java/com/ject/vs/config/FirebaseConfig.java
+++ b/src/main/java/com/ject/vs/config/FirebaseConfig.java
@@ -5,6 +5,7 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.ResourceUtils;
@@ -13,6 +14,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 
 @Configuration
+@ConditionalOnExpression("'${firebase.service-account-path:}' != ''")
 public class FirebaseConfig {
 
     @Value("${firebase.service-account-path}")

--- a/src/main/java/com/ject/vs/notification/adapter/out/fcm/FcmSenderAdapter.java
+++ b/src/main/java/com/ject/vs/notification/adapter/out/fcm/FcmSenderAdapter.java
@@ -5,12 +5,14 @@ import com.ject.vs.notification.port.out.FcmPayload;
 import com.ject.vs.notification.port.out.PushSenderPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Component
+@ConditionalOnBean(FirebaseMessaging.class)
 @RequiredArgsConstructor
 @Slf4j
 public class FcmSenderAdapter implements PushSenderPort {

--- a/src/main/java/com/ject/vs/notification/adapter/out/fcm/NoOpPushSenderAdapter.java
+++ b/src/main/java/com/ject/vs/notification/adapter/out/fcm/NoOpPushSenderAdapter.java
@@ -1,0 +1,21 @@
+package com.ject.vs.notification.adapter.out.fcm;
+
+import com.ject.vs.notification.port.out.FcmPayload;
+import com.ject.vs.notification.port.out.PushSenderPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@ConditionalOnExpression("'${firebase.service-account-path:}' == ''")
+@Slf4j
+public class NoOpPushSenderAdapter implements PushSenderPort {
+
+    @Override
+    public List<String> sendMulticast(List<String> tokens, FcmPayload payload) {
+        log.debug("FCM is disabled; skipping push notification payload={}", payload.type());
+        return List.of();
+    }
+}

--- a/src/main/resources/db/migration/V7__notification_schema.sql
+++ b/src/main/resources/db/migration/V7__notification_schema.sql
@@ -14,8 +14,8 @@ CREATE TABLE notification (
     sent_at       TIMESTAMP WITH TIME ZONE
 );
 CREATE INDEX idx_notification_user_created ON notification (user_id, created_at DESC);
-CREATE INDEX idx_notification_user_unread  ON notification (user_id) WHERE is_read = false;
-CREATE INDEX idx_notification_unsent       ON notification (id) WHERE sent = false;
+CREATE INDEX idx_notification_user_unread  ON notification (user_id, is_read);
+CREATE INDEX idx_notification_unsent       ON notification (sent, id);
 
 -- 알림 설정
 CREATE TABLE notification_setting (
@@ -31,8 +31,10 @@ CREATE TABLE notification_setting (
 
 -- 기존 회원에 대해 NotificationSetting row 생성
 INSERT INTO notification_setting (user_id)
-SELECT id FROM users
-ON CONFLICT (user_id) DO NOTHING;
+SELECT u.id FROM users u
+WHERE NOT EXISTS (
+    SELECT 1 FROM notification_setting ns WHERE ns.user_id = u.id
+);
 
 -- Web Push 구독
 CREATE TABLE push_subscription (


### PR DESCRIPTION
## Summary

로컬/테스트 환경에서 Firebase 인증 파일 없이도 Spring Context와 전체 테스트가 정상 실행되도록 수정했습니다.

## Problem

`./gradlew test` 실행 시 다음 두 가지 이유로 ApplicationContext 초기화가 실패했습니다.

1. `V7__notification_schema.sql`에 PostgreSQL 전용 문법이 포함되어 H2 테스트 DB에서 Flyway migration 실패
   - partial index: `CREATE INDEX ... WHERE ...`
   - `ON CONFLICT ... DO NOTHING`
2. `firebase.service-account-path`가 비어 있어도 Firebase bean을 무조건 생성하면서 `FileNotFoundException` 발생

## Changes

- H2 호환을 위해 Flyway V7 migration 문법 수정
  - partial index를 일반 composite index로 변경
  - `ON CONFLICT DO NOTHING`을 `WHERE NOT EXISTS` 방식으로 변경
- Firebase 설정 경로가 있을 때만 `FirebaseConfig` 활성화
- Firebase 설정 경로가 없을 때 사용하는 `NoOpPushSenderAdapter` 추가
  - 로컬/테스트에서는 FCM 발송을 skip
  - 운영처럼 서비스 계정 경로가 설정된 환경에서는 기존 FCM 발송 로직 사용

## Verification

```bash
./gradlew test
```

결과: PASS

## Notes

운영 환경에서는 `firebase.service-account-path`가 설정되어 있으면 기존처럼 Firebase 기반 PushSender가 동작합니다.
