### PR TITLE
fix: openapi swagger 추출 시 서버 시작 실패 수정

### DIFF
--- a/buildSrc/src/main/kotlin/apiclient/ExtractSwaggerTask.kt
+++ b/buildSrc/src/main/kotlin/apiclient/ExtractSwaggerTask.kt
@@ -43,7 +43,7 @@ abstract class ExtractSwaggerTask : DefaultTask() {
     }
 
     private fun waitForServer() {
-        repeat(30) {
+        repeat(60) {
             try {
                 URI("$serverUrl$apiDocsPath").toURL().readText()
                 return
@@ -51,6 +51,6 @@ abstract class ExtractSwaggerTask : DefaultTask() {
                 Thread.sleep(2000)
             }
         }
-        throw RuntimeException("Server did not start within 60 seconds")
+        throw RuntimeException("Server did not start within 120 seconds")
     }
 }

--- a/src/main/resources/application-openapi.yaml
+++ b/src/main/resources/application-openapi.yaml
@@ -34,6 +34,9 @@ app:
   cookie:
     secure: false
 
+gemini:
+  enabled: false
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## 🔍 작업 내용
  openapi 프로파일에서 Gemini 초기화 실패로 서버가 시작되지 않는 문제 수정

  ## 📝 변경 사항
  - application-openapi.yaml에 gemini.enabled: false 추가
  - ExtractSwaggerTask 타임아웃 60초 → 120초 증가

  ## 💬 리뷰어에게
  CI 환경에서 extractSwagger 실패 문제 해결입니다."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 서버 초기화 대기 시간이 60초에서 120초로 연장되어 안정성이 개선되었습니다.

* **기타**
  * Gemini 기능이 비활성화 상태로 설정되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JECT-Study/JECT2-4th-Server/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->