### PR TITLE
fix: Docker 베이스 이미지를 Alpine에서 Debian으로 변경 (Vertex AI 네이티브 크래시 해결)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # ===== 실행 스테이지 =====
-FROM eclipse-temurin:25-jre-alpine
+FROM eclipse-temurin:25-jre
 WORKDIR /app
 
 ARG JAR_FILE=build/libs/app.jar


### PR DESCRIPTION
## 배경

프로덕션에서 앱 컨테이너가 지속적으로 크래시나는 문제가 발생했습니다.

- 컨테이너 상태: `Exited (139)` (SIGSEGV)
- 최근 배포(`v2026.0525.1`) 후 40초 정도만에 JVM이 죽음
- Caddy는 정상 동작하지만 upstream(`app` alias)이 없어 서비스 불가

## 원인 분석

`google-cloud-vertexai:1.14.0` (Vertex AI / Gemini) 사용 시 내부적으로 `grpc-netty-shaded` + `netty-tcnative` (BoringSSL 네이티브 라이브러리)를 로드합니다.

이 라이브러리가 **Alpine Linux (musl libc)** 환경에서 `JNI_OnLoad` 단계에서 SIGSEGV를 발생시킵니다.

특히 다음 플로우에서 항상 재현:
1. 서버 시작
2. `ApplicationReadyEvent` → `VoteCloseScheduler.closeExpiredOnStartup()`
3. `VoteEndedEvent` 발행
4. `VoteAiInsightHandler` (@Async) 에서 `AiInsightService.generateVoteInsight()` 호출
5. Vertex AI gRPC 채널 초기화 → 네이티브 크래시 → JVM 종료

`deploy.sh`의 헬스체크는 readiness probe가 한 번 성공하는 순간 통과로 판단하기 때문에, GitHub Actions 배포는 항상 성공으로 표시됐지만 실제 서비스는 죽는 상황이었습니다.

## 변경 사항

- `Dockerfile`: `eclipse-temurin:25-jre-alpine` → `eclipse-temurin:25-jre` (Debian 기반, glibc)

## 영향

- Vertex AI, Firebase, 기타 Google Cloud Java 클라이언트와의 네이티브 호환성 확보
- 프로덕션 컨테이너 안정성 회복 기대
- 이미지 크기 증가 (약 80~100MB → 180~220MB compressed) — 백엔드 기준 수용 가능

## 테스트 계획

- [ ] 이 PR 머지 후 이미지 빌드
- [ ] 스테이징/프로덕션 배포
- [ ] 서버 재시작 후 AI insight 생성 로그 정상 확인 (VoteEndedEvent 처리)
- [ ] 기존 기능 회귀 테스트 (투표, 알림, 채팅 등)

## 참고

- 관련 이슈: 프로덕션 컨테이너 반복 재시작 (Exit 139)
- 조사 로그: `hs_err_pid1.log`의 `netty_internal_tcnative_SSLContext_JNI_OnLoad` 크래시 스택

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Docker 애플리케이션 실행 환경의 기본 이미지가 변경되었습니다. 컨테이너 런타임이 업데이트되어 배포 환경의 안정성이 강화되었습니다. 최종 사용자에게는 기능적 변화가 없습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JECT-Study/JECT2-4th-Server/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->