### PR TITLE
fix: ApplicationReadyEvent 기반 투표 마감 보정 로직 제거

### DIFF
--- a/src/main/java/com/ject/vs/vote/scheduler/VoteCloseScheduler.java
+++ b/src/main/java/com/ject/vs/vote/scheduler/VoteCloseScheduler.java
@@ -5,10 +5,7 @@ import com.ject.vs.vote.domain.VoteRepository;
 import com.ject.vs.vote.event.VoteEndedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,17 +33,5 @@ public class VoteCloseScheduler {
         if (!expired.isEmpty()) {
             log.info("Closed {} expired votes", expired.size());
         }
-    }
-
-    /**
-     * 서버 재시작 시 스케줄러가 돌기 전에 이미 만료된 투표를 보정한다.
-     * @PostConstruct는 ApplicationContext 초기화를 블록하므로
-     * ApplicationReadyEvent + @Async로 부팅 완료 후 백그라운드에서 실행.
-     */
-    @EventListener(ApplicationReadyEvent.class)
-    @Async("voteCloseExecutor")
-    public void closeExpiredOnStartup() {
-        log.info("Running startup vote close compensation");
-        closeExpiredVotes();
     }
 }


### PR DESCRIPTION
## 배경

배포 시 `app-v2026.0525.2` 컨테이너가 시작된 후 readiness probe(8081)가 계속 실패하여, 결국 `deploy.sh`가 컨테이너를 제거하는 문제가 반복되고 있습니다.

분석 결과, `ApplicationReadyEvent` 시점에 `closeExpiredOnStartup()`가 실행되면서:

- 다수의 `VoteEndedEvent`가 즉시 발행됨
- `VoteAiInsightHandler` (@Async)가 동시에 여러 건의 AI insight 생성을 시도 (Vertex AI 호출)
- 이로 인해 startup 단계에서 상당한 부하 + async 작업이 몰림
- Actuator readiness probe(8081)가 healthy 상태에 도달하는 데 지연되거나 실패

이 때문에 `deploy.sh`의 health wait (최대 180초)가 타임아웃되어 컨테이너가 롤백되는 상황이 발생했습니다.

## 변경 사항

- `VoteCloseScheduler`에서 `closeExpiredOnStartup()` 메서드 제거
- `ApplicationReadyEvent` 리스너 삭제
- 이제 만료된 투표 처리는 **기존 `@Scheduled` cron (매 1분)** 에만 의존하도록 변경

## 영향

- 애플리케이션 시작 직후 AI 호출 burst 제거 → readiness probe가 더 안정적으로 빨리 `UP` 될 것으로 기대
- 배포 성공률 및 컨테이너 안정성 개선
- Trade-off: 서버 재시작 후 최대 1분 정도까지 만료된 투표가 즉시 close되지 않을 수 있음 (cron 주기)

## 테스트

- [ ] develop 배포 후 startup 시 readiness probe 정상 통과 확인
- [ ] cron을 통한 투표 마감 + AI insight 생성이 정상 동작하는지 확인