### PR TITLE
fix: aiInsightExecutor 스레드 풀을 1개로 제한

### DIFF
--- a/src/main/java/com/ject/vs/config/AsyncConfig.java
+++ b/src/main/java/com/ject/vs/config/AsyncConfig.java
@@ -25,9 +25,9 @@ public class AsyncConfig {
     @Bean("aiInsightExecutor")
     public Executor aiInsightExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(2);
-        executor.setMaxPoolSize(4);
-        executor.setQueueCapacity(50);
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setQueueCapacity(200);
         executor.setThreadNamePrefix("ai-insight-");
         executor.initialize();
         return executor;


### PR DESCRIPTION
## 배경

기존 `aiInsightExecutor` 설정:
- Core: 2, Max: 4, Queue: 50

이 설정 때문에 cron이나 이벤트로 여러 `VoteEndedEvent`가 동시에 발행되면, AI insight 생성 작업이 동시에 여러 스레드에서 실행되었습니다.

특히:
- 서버 재시작 직후 (이전 PR로 startup compensation은 제거했지만)
- 정기 cron 실행 시 한 번에 여러 투표가 만료된 경우

Vertex AI 호출(네트워크 + LLM inference)이 동시에 여러 개 발생하면서:
- 전체 리소스 사용량 급증
- DB 커넥션/스레드 경합
- readiness probe 지연 → 배포 실패 유발 가능성

## 변경 사항

`aiInsightExecutor` 설정 변경:
- CorePoolSize: 1
- MaxPoolSize: 1
- QueueCapacity: 200

이제 AI insight 생성 작업은 **항상 1개의 스레드**에서만 순차적으로 실행됩니다.
작업이 몰려도 큐에 쌓여 하나씩 처리되므로 과도한 동시 리소스 사용을 방지할 수 있습니다.

## 영향

- AI insight 생성이 직렬화되어 안정성 향상
- 특정 시점(특히 배포 직후)에 과도한 Vertex AI 호출 방지
- 전체 시스템 리소스 사용량 예측 가능성 증가