### PR TITLE
fix: Dockerfile에 wget 명시적 설치 추가 (HEALTHCHECK 안정화)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@
 FROM eclipse-temurin:25-jre
 WORKDIR /app
 
+# HEALTHCHECK에서 wget을 사용하므로 명시적으로 설치
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && rm -rf /var/lib/apt/lists/*
+
 ARG JAR_FILE=build/libs/app.jar
 COPY ${JAR_FILE} app.jar
 


### PR DESCRIPTION
## 배경

현재 프로덕션 배포된 이미지(`v2026.0525.3` 등)에서 Docker HEALTHCHECK가 계속 실패하고 있습니다.

원인:
- `HEALTHCHECK` 명령어에 `wget`을 사용하고 있음
- `eclipse-temurin:25-jre` (또는 이전 Alpine 이미지)에서 `wget`이 누락된 경우가 발생
- Healthcheck가 "wget: not found"로 실패하면서 Docker status가 영원히 `starting` 상태로 머무름
- `deploy.sh`가 "healthy"를 인식하지 못해 `docker network connect --alias app`이 실행되지 않음
- 결과적으로 Caddy가 upstream을 찾지 못해 503 반환

## 변경 사항

Dockerfile에 wget을 명시적으로 설치하는 단계 추가:

```dockerfile
RUN apt-get update \
    && apt-get install -y --no-install-recommends wget \
    && rm -rf /var/lib/apt/lists/*
```

이 변경으로 HEALTHCHECK가 항상 정상적으로 실행될 수 있게 보장합니다.

## 영향

- 배포 직후 컨테이너가 "health: healthy"에 빠르게 도달
- `deploy.sh`가 network alias를 정상적으로 붙여줄 수 있게 됨
- 서비스 복구 시간 단축