### PR TITLE
fix: make uploaded images publicly readable on S3

### DIFF
--- a/src/main/java/com/ject/vs/image/port/ImageService.java
+++ b/src/main/java/com/ject/vs/image/port/ImageService.java
@@ -9,6 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
@@ -34,6 +35,7 @@ public class ImageService {
                     .bucket(s3Properties.bucket())
                     .key(key)
                     .contentType(file.getContentType())
+                    .acl(ObjectCannedACL.PUBLIC_READ)   // 공개 읽기 권한 부여
                     .build();
 
             s3Client.putObject(request, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));


### PR DESCRIPTION
## Summary

Uploaded images via `/api/images` were returning URLs that resulted in `Access Denied` (S3 XML error).

Root cause: `PutObjectRequest` did not specify any ACL, and the bucket does not have a permissive policy for the `images/` prefix by default.

## Changes
- Added `ObjectCannedACL.PUBLIC_READ` when uploading objects in `ImageService`.
- This ensures the returned S3 URL (e.g. `https://ject-vs-images.s3...`) is publicly accessible.

## Notes
- This is a quick mitigation. Long-term, we should consider using CloudFront + OAC or a proper bucket policy instead of object ACLs (ACLs are being deprecated in many S3 setups).
- If the bucket has "Block all public access" enabled at the account level, this change alone may still fail. In that case, a bucket policy allowing `s3:GetObject` on `images/*` is required.

## Testing
- Manual upload via the image endpoint now returns a publicly accessible URL.
- Verified with the Google Sheets automation script that was hitting this endpoint.

Fixes the image upload flow for vote thumbnails and immersive images.