### PR TITLE
fix: ignore CSRF for /auth/reissue to support refresh token rotation

### DIFF
--- a/src/main/java/com/ject/vs/config/SecurityConfig.java
+++ b/src/main/java/com/ject/vs/config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf
                         .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
                         .csrfTokenRequestHandler(requestHandler)
-                        .ignoringRequestMatchers("/api/**")
+                        .ignoringRequestMatchers("/api/**", "/auth/reissue")
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(SecurityPaths.PUBLIC_ENDPOINTS.toArray(String[]::new)).permitAll()


### PR DESCRIPTION
## Problem

Calling `POST /auth/reissue` from non-browser clients (e.g. Google Apps Script) was returning 403 Forbidden.

Root cause: The endpoint was `permitAll()` for authentication, but Spring Security's CSRF filter was still enforcing token validation on POST requests. Apps Script (and similar tools) do not send `X-XSRF-TOKEN`.

This blocked the new refresh token rotation flow that allows users to store only a long-lived refresh token.

## Solution

Added `/auth/reissue` to `.ignoringRequestMatchers()` for CSRF, consistent with the earlier change for `/api/**`.

```java
.ignoringRequestMatchers("/api/**", "/auth/reissue")
```

## Impact

- Refresh token-based authentication from the spreadsheet automation now works end-to-end.
- Existing browser clients are unaffected.
- This is a safe exception because the reissue endpoint already validates the refresh token itself.

## Testing

- Apps Script successfully calls reissue using only the refresh token cookie.
- New access token is returned and subsequent API calls succeed.

Related to the ongoing work to make the Google Sheets automation more robust with refresh token support.