### PR TITLE
feat: 오늘의 추천 투표 설정 API 구현

### DIFF
--- a/src/main/java/com/ject/vs/config/AdminConfig.java
+++ b/src/main/java/com/ject/vs/config/AdminConfig.java
@@ -1,0 +1,9 @@
+package com.ject.vs.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(AdminProperties.class)
+public class AdminConfig {
+}

--- a/src/main/java/com/ject/vs/config/AdminProperties.java
+++ b/src/main/java/com/ject/vs/config/AdminProperties.java
@@ -1,0 +1,11 @@
+package com.ject.vs.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "admin")
+public record AdminProperties(
+        List<Long> userIds
+) {
+}

--- a/src/main/java/com/ject/vs/recommendation/adapter/web/RecommendationController.java
+++ b/src/main/java/com/ject/vs/recommendation/adapter/web/RecommendationController.java
@@ -1,0 +1,30 @@
+package com.ject.vs.recommendation.adapter.web;
+
+import com.ject.vs.recommendation.port.in.RecommendationCommandUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "추천 투표", description = "오늘의 추천 투표 관리 API")
+@RestController
+@RequestMapping("/api/recommendations")
+@RequiredArgsConstructor
+public class RecommendationController {
+
+    private final RecommendationCommandUseCase recommendationCommandUseCase;
+
+    @Operation(summary = "오늘의 추천 투표 설정", description = "운영진이 오늘의 추천 투표를 설정합니다.")
+    @PostMapping
+    public void setTodayRecommendations(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody SetRecommendationRequest request
+    ) {
+        recommendationCommandUseCase.setTodayRecommendations(userId, request.voteIds());
+    }
+
+    public record SetRecommendationRequest(List<Long> voteIds) {}
+}

--- a/src/main/java/com/ject/vs/recommendation/port/RecommendationCommandService.java
+++ b/src/main/java/com/ject/vs/recommendation/port/RecommendationCommandService.java
@@ -1,0 +1,71 @@
+package com.ject.vs.recommendation.port;
+
+import com.ject.vs.config.AdminProperties;
+import com.ject.vs.recommendation.port.in.RecommendationCommandUseCase;
+import com.ject.vs.vote.domain.RecommendedVote;
+import com.ject.vs.vote.domain.RecommendedVoteRepository;
+import com.ject.vs.vote.domain.Vote;
+import com.ject.vs.vote.domain.VoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendationCommandService implements RecommendationCommandUseCase {
+
+    private final AdminProperties adminProperties;
+    private final RecommendedVoteRepository recommendedVoteRepository;
+    private final VoteRepository voteRepository;
+
+    @Override
+    @Transactional
+    public void setTodayRecommendations(Long adminUserId, List<Long> voteIds) {
+        validateAdmin(adminUserId);
+        validateVotes(voteIds);
+
+        LocalDate today = LocalDate.now();
+
+        // 기존 오늘 추천 삭제
+        recommendedVoteRepository.deleteAllByRecommendedDate(today);
+
+        // 새로운 추천 저장 (순서대로 displayOrder 부여)
+        List<RecommendedVote> recommendations = IntStream.range(0, voteIds.size())
+                .mapToObj(i -> RecommendedVote.create(voteIds.get(i), i + 1, today))
+                .toList();
+
+        recommendedVoteRepository.saveAll(recommendations);
+    }
+
+    private void validateAdmin(Long adminUserId) {
+        if (adminProperties.userIds() == null || !adminProperties.userIds().contains(adminUserId)) {
+            throw new IllegalArgumentException("추천 투표 설정 권한이 없습니다.");
+        }
+    }
+
+    private void validateVotes(List<Long> voteIds) {
+        if (voteIds == null || voteIds.isEmpty()) {
+            throw new IllegalArgumentException("추천할 투표를 하나 이상 지정해야 합니다.");
+        }
+
+        // 중복 체크
+        Set<Long> uniqueIds = Set.copyOf(voteIds);
+        if (uniqueIds.size() != voteIds.size()) {
+            throw new IllegalArgumentException("중복된 투표 ID가 있습니다.");
+        }
+
+        // 존재 여부 및 진행 중 여부 체크
+        List<Vote> votes = voteRepository.findAllById(voteIds);
+        if (votes.size() != voteIds.size()) {
+            throw new IllegalArgumentException("존재하지 않는 투표가 있습니다.");
+        }
+
+        // TODO: 진행 중인 투표만 허용하는 로직 추가 가능 (endAt > now)
+    }
+}

--- a/src/main/java/com/ject/vs/recommendation/port/in/RecommendationCommandUseCase.java
+++ b/src/main/java/com/ject/vs/recommendation/port/in/RecommendationCommandUseCase.java
@@ -1,0 +1,13 @@
+package com.ject.vs.recommendation.port.in;
+
+import java.util.List;
+
+public interface RecommendationCommandUseCase {
+
+    /**
+     * 오늘의 추천 투표를 설정한다.
+     * @param adminUserId 호출한 사용자 ID (admin 체크용)
+     * @param voteIds 추천할 투표 ID 목록 (순서대로 displayOrder 부여)
+     */
+    void setTodayRecommendations(Long adminUserId, List<Long> voteIds);
+}

--- a/src/main/java/com/ject/vs/vote/domain/RecommendedVoteRepository.java
+++ b/src/main/java/com/ject/vs/vote/domain/RecommendedVoteRepository.java
@@ -21,4 +21,6 @@ public interface RecommendedVoteRepository extends JpaRepository<RecommendedVote
             @Param("date") LocalDate date,
             @Param("now") Instant now
     );
+
+    void deleteAllByRecommendedDate(LocalDate recommendedDate);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,8 @@ gemini:
   location: ${GEMINI_LOCATION:asia-northeast3}
   model: ${GEMINI_MODEL:gemini-1.5-flash}
   enabled: ${GEMINI_ENABLED:false}
+
+# 오늘의 추천 투표 설정 권한 (운영진 user id 목록)
+admin:
+  user-ids:
+    - 7

--- a/src/unitTest/java/com/ject/vs/recommendation/port/RecommendationCommandServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/recommendation/port/RecommendationCommandServiceTest.java
@@ -1,0 +1,135 @@
+package com.ject.vs.recommendation.port;
+
+import com.ject.vs.config.AdminProperties;
+import com.ject.vs.vote.domain.RecommendedVoteRepository;
+import com.ject.vs.vote.domain.Vote;
+import com.ject.vs.vote.domain.VoteRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationCommandServiceTest {
+
+    @InjectMocks
+    private RecommendationCommandService service;
+
+    @Mock
+    private AdminProperties adminProperties;
+
+    @Mock
+    private RecommendedVoteRepository recommendedVoteRepository;
+
+    @Mock
+    private VoteRepository voteRepository;
+
+    private final Long ADMIN_USER_ID = 1L;
+    private final Long NORMAL_USER_ID = 2L;
+
+    @BeforeEach
+    void setUp() {
+        given(adminProperties.userIds()).willReturn(List.of(ADMIN_USER_ID));
+    }
+
+    @Nested
+    @DisplayName("관리자 권한 검증")
+    class AdminValidation {
+
+        @Test
+        @DisplayName("관리자 사용자는 추천을 설정할 수 있다")
+        void admin_can_set_recommendations() {
+            List<Long> voteIds = List.of(10L, 20L);
+            given(voteRepository.findAllById(voteIds))
+                    .willReturn(List.of(mock(Vote.class), mock(Vote.class)));
+
+            service.setTodayRecommendations(ADMIN_USER_ID, voteIds);
+
+            verify(recommendedVoteRepository).deleteAllByRecommendedDate(any());
+            verify(recommendedVoteRepository).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("일반 사용자는 추천 설정이 불가능하다")
+        void non_admin_cannot_set_recommendations() {
+            assertThatThrownBy(() ->
+                    service.setTodayRecommendations(NORMAL_USER_ID, List.of(10L))
+            ).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("권한이 없습니다");
+        }
+    }
+
+    @Nested
+    @DisplayName("입력값 검증")
+    class InputValidation {
+
+        @Test
+        @DisplayName("voteIds가 null이거나 비어있으면 예외가 발생한다")
+        void empty_voteIds_throws_exception() {
+            assertThatThrownBy(() ->
+                    service.setTodayRecommendations(ADMIN_USER_ID, List.of())
+            ).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("하나 이상 지정");
+
+            assertThatThrownBy(() ->
+                    service.setTodayRecommendations(ADMIN_USER_ID, null)
+            ).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("중복된 voteId가 있으면 예외가 발생한다")
+        void duplicate_voteIds_throws_exception() {
+            assertThatThrownBy(() ->
+                    service.setTodayRecommendations(ADMIN_USER_ID, List.of(10L, 10L, 20L))
+            ).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("중복");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 voteId가 있으면 예외가 발생한다")
+        void non_existing_vote_throws_exception() {
+            given(voteRepository.findAllById(List.of(10L, 99L)))
+                    .willReturn(List.of(mock(Vote.class))); // 99L은 없음
+
+            assertThatThrownBy(() ->
+                    service.setTodayRecommendations(ADMIN_USER_ID, List.of(10L, 99L))
+            ).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("존재하지 않는");
+        }
+    }
+
+    @Nested
+    @DisplayName("추천 저장 로직")
+    class SaveLogic {
+
+        @Test
+        @DisplayName("기존 추천을 삭제하고 새로운 추천을 저장한다")
+        void replaces_existing_recommendations() {
+            List<Long> voteIds = List.of(100L, 200L, 300L);
+            given(voteRepository.findAllById(voteIds))
+                    .willReturn(List.of(mock(Vote.class), mock(Vote.class), mock(Vote.class)));
+
+            service.setTodayRecommendations(ADMIN_USER_ID, voteIds);
+
+            verify(recommendedVoteRepository).deleteAllByRecommendedDate(any());
+            verify(recommendedVoteRepository).saveAll(argThat(list -> {
+                List<com.ject.vs.vote.domain.RecommendedVote> recommendations = (List<com.ject.vs.vote.domain.RecommendedVote>) list;
+                return recommendations.size() == 3
+                        && recommendations.get(0).getDisplayOrder() == 1
+                        && recommendations.get(1).getDisplayOrder() == 2
+                        && recommendations.get(2).getDisplayOrder() == 3;
+            }));
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- closes #

## 🔍 작업 내용
운영진이 오늘의 추천 투표를 설정할 수 있는 관리자용 API를 구현했습니다.

- `POST /api/recommendations` 엔드포인트 추가
- `AdminProperties`를 통해 `application.yml` (또는 환경 변수)로 여러 명의 관리자 user ID를 유연하게 관리
- 오늘 추천 설정 시 기존 데이터를 삭제하고 새로운 vote ID 목록을 `displayOrder`와 함께 저장
- 홈 화면 `GET /api/home/recommendations`에서 해당 추천 투표가 노출되는 기존 기능과 연동

## 📝 변경 사항
- `AdminConfig`, `AdminProperties` 신규 추가 (`admin.user-ids` ConfigurationProperties)
- `recommendation` 패키지 하위에 UseCase / CommandService / Controller 신규 구현
- `RecommendedVoteRepository`에 `deleteAllByRecommendedDate(LocalDate)` 메서드 추가
- `application.yml`에 기본 admin user ID(`7`) 설정 추가
- `RecommendationCommandServiceTest` 단위 테스트 작성 (관리자 권한 검증, 입력값 검증, 저장 로직 검증)

## 💬 리뷰어에게
- 현재는 서비스 계층에서 admin user ID 화이트리스트로 권한을 체크하고 있습니다. Security FilterChain이나 메서드 보안으로 옮기는 게 좋을지 의견 부탁드립니다.
- `validateVotes` 내부에 "진행 중인 투표만 추천 가능" 로직이 TODO로 남아있습니다. (현재는 ID 존재 여부만 확인)
- `application-prod.yml` 등 배포 환경에서 `admin.user-ids`를 어떻게 오버라이드할지 논의 필요 (Spring relaxed binding으로 `APP_ADMIN_USER_IDS` 형태 지원)
