### PR TITLE
fix: 비회원 접근 가능한 투표 API Security 경로 등록

### DIFF
--- a/src/main/java/com/ject/vs/config/SecurityPaths.java
+++ b/src/main/java/com/ject/vs/config/SecurityPaths.java
@@ -26,7 +26,13 @@ public class SecurityPaths {
      */
     public static final List<String> OPTIONAL_AUTH_ENDPOINTS = List.of(
             "/api/immersive-votes",
-            "/api/immersive-votes/**"
+            "/api/immersive-votes/**",
+            "/api/me/free-votes",
+            "/api/votes/*",
+            "/api/votes/*/participate",
+            "/api/votes/*/result",
+            "/api/votes/*/share",
+            "/api/votes/*/emoji"
     );
 
     public static final List<String> JWT_EXCLUDED_PATHS = createJwtExcludedPaths();


### PR DESCRIPTION
## Summary
- 비회원(미인증) 접근이 가능해야 하는 일반형 투표 API들이 401을 반환하는 문제 수정
- `SecurityPaths.OPTIONAL_AUTH_ENDPOINTS`에 누락된 경로 일괄 추가

## 원인
해당 엔드포인트들이 어떤 허용 목록에도 없어 `.anyRequest().authenticated()` 규칙에 걸려 401 반환

## 변경 내용
`SecurityPaths.java` — OPTIONAL_AUTH_ENDPOINTS에 하기 경로 추가
- `/api/votes/*` — 투표 상세 조회 (비회원도 조회 가능, anonymousId 기반)
- `/api/votes/*/participate` — 투표 참여 (비회원 5회 무료)
- `/api/votes/*/result` — 투표 결과 조회 (비회원은 insight 잠금)
- `/api/votes/*/share` — 공유 링크 생성
- `/api/votes/*/emoji` — 이모지 반응 (비회원 anonymousId 기반)

> `PUBLIC_ENDPOINTS`가 아닌 `OPTIONAL_AUTH_ENDPOINTS`에 추가한 이유:
> 토큰 존재 시 userId로, 없을 시 anonymousId로 동작해야 하므로 JwtAuthFilter가 실행되어야 함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 투표 결과 조회, 참여, 공유, 이모지 반응 등 주요 투표 관련 기능에 대한 선택적 인증 지원 추가
  * 비로그인 사용자도 일부 투표 기능에 접근할 수 있도록 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JECT-Study/JECT2-4th-Server/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->