### PR TITLE
fix: 몰입형 피드 버그 수정 및 전체 응답 voteType 추가

### DIFF
--- a/scripts/qa-cleanup.sql
+++ b/scripts/qa-cleanup.sql
@@ -1,0 +1,80 @@
+-- =============================================================================
+--  QA 더미 데이터 정리(삭제) 스크립트  — scripts/qa-seed.sql 짝꿍
+-- =============================================================================
+--  qa-seed.sql 로 심은 데이터만 정확히 회수한다.
+--  앵커(식별 기준):
+--    - 더미 투표 : qa_seed_vote 추적 테이블에 기록된 id
+--    - 더미 유저 : users.sub LIKE 'qa-dummy-%'
+--    - 더미 게스트: guest_free_vote.anonymous_id LIKE 'qa-guest-%'
+--
+--  FK 제약 때문에 자식 → 부모 순서로 삭제한다.
+--  한 트랜잭션으로 실행 → 중간 에러 시 전체 롤백.
+-- =============================================================================
+
+BEGIN;
+
+-- 추적 테이블이 없으면(이미 정리됨) 빈 결과로 동작하도록 보장
+CREATE TABLE IF NOT EXISTS qa_seed_vote (id BIGINT PRIMARY KEY, seq INT, kind TEXT);
+
+-- 1) 채팅 읽음 상태
+DELETE FROM chat_room_unread
+WHERE vote_id IN (SELECT id FROM qa_seed_vote)
+   OR user_id IN (SELECT id FROM users WHERE sub LIKE 'qa-dummy-%');
+
+-- 2) 채팅 메시지
+DELETE FROM chat_message
+WHERE vote_id IN (SELECT id FROM qa_seed_vote)
+   OR sender_id IN (SELECT id FROM users WHERE sub LIKE 'qa-dummy-%');
+
+-- 3) 이모지 반응
+DELETE FROM vote_emoji_reaction
+WHERE vote_id IN (SELECT id FROM qa_seed_vote)
+   OR user_id IN (SELECT id FROM users WHERE sub LIKE 'qa-dummy-%');
+
+-- 4) 알림 (vote_id FK → vote 이므로 vote 삭제 전에)
+DELETE FROM notification
+WHERE vote_id IN (SELECT id FROM qa_seed_vote)
+   OR user_id IN (SELECT id FROM users WHERE sub LIKE 'qa-dummy-%');
+
+-- 5) 투표 참여 (option_id FK → vote_option 이므로 option 삭제 전에)
+DELETE FROM vote_participation
+WHERE vote_id IN (SELECT id FROM qa_seed_vote)
+   OR user_id IN (SELECT id FROM users WHERE sub LIKE 'qa-dummy-%');
+
+-- 6) 오늘의 추천
+DELETE FROM recommended_vote
+WHERE vote_id IN (SELECT id FROM qa_seed_vote);
+
+-- 7) 조회수 통계
+DELETE FROM vote_statistics
+WHERE vote_id IN (SELECT id FROM qa_seed_vote);
+
+-- 8) 선택지
+DELETE FROM vote_option
+WHERE vote_id IN (SELECT id FROM qa_seed_vote);
+
+-- 9) 투표 본체
+DELETE FROM vote
+WHERE id IN (SELECT id FROM qa_seed_vote);
+
+-- 10) 더미 유저 부속 데이터 (혹시 생성됐을 경우 대비)
+DELETE FROM push_subscription WHERE user_id IN (SELECT id FROM users WHERE sub LIKE 'qa-dummy-%');
+DELETE FROM push_token        WHERE user_id IN (SELECT id FROM users WHERE sub LIKE 'qa-dummy-%');
+DELETE FROM token             WHERE user_id IN (SELECT id FROM users WHERE sub LIKE 'qa-dummy-%');
+DELETE FROM notification_setting WHERE user_id IN (SELECT id FROM users WHERE sub LIKE 'qa-dummy-%');
+
+-- 11) 더미 유저
+DELETE FROM users WHERE sub LIKE 'qa-dummy-%';
+
+-- 12) 더미 게스트
+DELETE FROM guest_free_vote WHERE anonymous_id LIKE 'qa-guest-%';
+
+-- 13) 추적 테이블 제거
+DROP TABLE IF EXISTS qa_seed_vote;
+
+COMMIT;
+
+-- =============================================================================
+--  주의: 테스트(본인) 계정 자체는 삭제하지 않는다. 본인 계정이 더미 투표에
+--        남긴 참여/알림/채팅은 위 vote_id 기준 삭제로 함께 회수된다.
+-- =============================================================================

--- a/scripts/qa-seed.sql
+++ b/scripts/qa-seed.sql
@@ -1,0 +1,270 @@
+-- =============================================================================
+--  QA 더미 데이터 시드 스크립트  (운영 DB / PostgreSQL · Neon)
+-- =============================================================================
+--  실행 전 필수:
+--   1) 아래 __MY_USER_ID__ 를 본인 user id 숫자로 전부 치환 (찾는 법: 파일 하단 주석)
+--   2) 가능하면 Neon에서 브랜치/스냅샷 한 번 떠두고 실행
+--   3) 한 트랜잭션으로 실행됨 → 중간 에러 시 전체 롤백
+--
+--  정리(삭제)는 짝꿍 스크립트 scripts/qa-cleanup.sql 로 수행.
+--  심는 데이터는 모두 식별자가 박혀 있어 안전하게 회수 가능:
+--    - 더미 유저 : users.sub LIKE 'qa-dummy-%'
+--    - 더미 투표 : qa_seed_vote 추적 테이블에 id 기록
+--    - 더미 게스트: guest_free_vote.anonymous_id LIKE 'qa-guest-%'
+-- =============================================================================
+
+BEGIN;
+
+-- 진행/종료는 status 컬럼이 아니라 end_at vs now() 로만 판정됨(코드 확인). end_at만 잘 잡으면 됨.
+
+-- 0) 더미 투표 id 추적 테이블 -------------------------------------------------
+CREATE TABLE IF NOT EXISTS qa_seed_vote (
+    id   BIGINT PRIMARY KEY,
+    seq  INT,
+    kind TEXT          -- 'ongoing' | 'ended'
+);
+
+-- 1) 더미 유저 60명 (성별/연령 다양) -----------------------------------------
+INSERT INTO users (sub, nickname, profile_icon_url, birth_year, gender, image_color, email, user_status)
+SELECT
+    'qa-dummy-' || g,
+    'QA유저' || lpad(g::text, 2, '0'),
+    NULL,
+    1975 + (g % 35),                                              -- 1975 ~ 2009 분포
+    CASE WHEN g % 2 = 0 THEN 'MALE' ELSE 'FEMALE' END,
+    (ARRAY['GREEN','RED','BLUE','YELLOW'])[1 + (g % 4)],
+    'qa-dummy-' || g || '@example.com',
+    'REGISTER'
+FROM generate_series(1, 60) AS g;
+
+-- 더미 유저 알림설정 row (push 기본 off)
+INSERT INTO notification_setting (user_id)
+SELECT id FROM users WHERE sub LIKE 'qa-dummy-%'
+ON CONFLICT (user_id) DO NOTHING;
+
+-- 2) 진행 중 투표 50개 --------------------------------------------------------
+--    seq 1  : 종료 임박 1h
+--    seq 2  : 종료 임박 12h
+--    seq 10,11,12 : 참여자 최다(60명)+조회수 높음 → 핫토픽 TOP3 후보
+--    seq 49 : 참여자 0명
+--    seq 5,6,7 : 오늘의 추천 대상
+WITH new_votes AS (
+    INSERT INTO vote (type, title, content, thumbnail_url, image_url, status, end_at, created_at, updated_at, ai_insight_headline, ai_insight_body)
+    SELECT
+        'GENERAL',
+        'QA 진행중 투표 #' || g,
+        '진행 중 투표 본문입니다. 번호 ' || g,
+        'https://picsum.photos/seed/qa-on-' || g || '/400/300',
+        NULL,
+        'ONGOING',
+        CASE
+            WHEN g = 1 THEN now() + interval '1 hour'      -- 종료 임박 1h
+            WHEN g = 2 THEN now() + interval '12 hours'    -- 종료 임박 12h
+            ELSE now() + (((g % 10) + 1) || ' days')::interval
+        END,
+        now() - ((g % 48 + 1) || ' hours')::interval,
+        now(),
+        NULL, NULL
+    FROM generate_series(1, 50) AS g
+    RETURNING id, title
+)
+INSERT INTO qa_seed_vote (id, seq, kind)
+SELECT id, split_part(title, '#', 2)::int, 'ongoing' FROM new_votes;
+
+-- 3) 종료된 투표 7개 ----------------------------------------------------------
+--    seq 1 : 테스트계정 참여O + 채팅 5건
+--    seq 2 : 테스트계정 참여O + 채팅 300건 초과
+--    seq 3 : 테스트계정 참여X (다른 유저는 참여)
+--    seq 4 : 성별/연령 분포 다양 (도넛·막대 차트용, 50명 참여)
+--    seq 5 : AI 인사이트 생성 완료
+--    seq 6 : 어제 종료
+--    seq 7 : 일주일 전 종료
+WITH new_votes AS (
+    INSERT INTO vote (type, title, content, thumbnail_url, image_url, status, end_at, created_at, updated_at, ai_insight_headline, ai_insight_body)
+    SELECT
+        'GENERAL',
+        'QA 종료 투표 #' || g,
+        '종료된 투표 본문입니다. 번호 ' || g,
+        'https://picsum.photos/seed/qa-end-' || g || '/400/300',
+        NULL,
+        'ENDED',
+        CASE
+            WHEN g = 6 THEN now() - interval '1 day'       -- 어제 종료
+            WHEN g = 7 THEN now() - interval '7 days'      -- 일주일 전 종료
+            ELSE now() - ((g + 1) || ' days')::interval    -- 2~6일 전
+        END,
+        now() - interval '14 days',
+        now(),
+        CASE WHEN g = 5 THEN '응답자의 68%가 찬성했어요' ELSE NULL END,
+        CASE WHEN g = 5 THEN '20대 여성층의 찬성 비율이 특히 높았고, 연령이 높아질수록 반대 의견이 늘어나는 경향을 보였습니다. 전체적으로 활발한 참여가 이루어진 투표였어요.' ELSE NULL END
+    FROM generate_series(1, 7) AS g
+    RETURNING id, title
+)
+INSERT INTO qa_seed_vote (id, seq, kind)
+SELECT id, split_part(title, '#', 2)::int, 'ended' FROM new_votes;
+
+-- 4) 모든 투표에 선택지 2개 ---------------------------------------------------
+INSERT INTO vote_option (vote_id, label, position)
+SELECT v.id, opt.label, opt.position
+FROM qa_seed_vote v
+CROSS JOIN (VALUES ('찬성', 0), ('반대', 1)) AS opt(label, position);
+
+-- 5) 더미 유저 참여 (진행중) --------------------------------------------------
+INSERT INTO vote_participation (vote_id, user_id, anonymous_id, option_id, created_at, updated_at)
+SELECT
+    v.id,
+    u.id,
+    NULL,
+    (SELECT o.id FROM vote_option o WHERE o.vote_id = v.id ORDER BY o.position LIMIT 1 OFFSET (u.rn % 2)),
+    now() - (u.rn || ' minutes')::interval,
+    now()
+FROM qa_seed_vote v
+JOIN (
+    SELECT id, row_number() OVER (ORDER BY id) AS rn
+    FROM users WHERE sub LIKE 'qa-dummy-%'
+) u
+  ON u.rn <= CASE
+                WHEN v.seq IN (10, 11, 12) THEN 60     -- 핫토픽 후보: 최다
+                WHEN v.seq = 49            THEN 0      -- 참여자 0명
+                ELSE (v.seq % 25) + 3                  -- 3 ~ 27명 다양
+             END
+WHERE v.kind = 'ongoing';
+
+-- 6) 더미 유저 참여 (종료) ----------------------------------------------------
+INSERT INTO vote_participation (vote_id, user_id, anonymous_id, option_id, created_at, updated_at)
+SELECT
+    v.id,
+    u.id,
+    NULL,
+    (SELECT o.id FROM vote_option o WHERE o.vote_id = v.id ORDER BY o.position LIMIT 1 OFFSET (u.rn % 2)),
+    now() - interval '8 days' - (u.rn || ' minutes')::interval,
+    now()
+FROM qa_seed_vote v
+JOIN (
+    SELECT id, row_number() OVER (ORDER BY id) AS rn
+    FROM users WHERE sub LIKE 'qa-dummy-%'
+) u
+  ON u.rn <= CASE
+                WHEN v.seq = 4 THEN 50                 -- 성별/연령 차트용 50명
+                ELSE 20                                -- 결과 페이지용 기본 20명
+             END
+WHERE v.kind = 'ended';
+
+-- 7) 테스트(본인) 계정 참여 --------------------------------------------------
+--    진행중 일부 + 종료 seq 1,2,4,5,6,7 (seq 3 은 일부러 미참여)
+INSERT INTO vote_participation (vote_id, user_id, anonymous_id, option_id, created_at, updated_at)
+SELECT
+    v.id,
+    __MY_USER_ID__,
+    NULL,
+    (SELECT o.id FROM vote_option o WHERE o.vote_id = v.id ORDER BY o.position LIMIT 1),
+    v_created.ts,
+    now()
+FROM qa_seed_vote v
+CROSS JOIN LATERAL (SELECT now() - interval '6 days' AS ts) v_created
+WHERE (v.kind = 'ended'   AND v.seq IN (1, 2, 4, 5, 6, 7))
+   OR (v.kind = 'ongoing' AND v.seq IN (3, 11, 20));
+
+-- 8) 채팅 메시지 -------------------------------------------------------------
+-- 8-1) 진행중 seq 10 : 채팅 활발 (35건)
+INSERT INTO chat_message (vote_id, sender_id, content, created_at, updated_at)
+SELECT
+    v.id,
+    (SELECT id FROM users WHERE sub = 'qa-dummy-' || (1 + (n % 60))),
+    'QA 실시간 채팅 메시지 ' || n,
+    now() - (n || ' minutes')::interval,
+    now()
+FROM qa_seed_vote v
+CROSS JOIN generate_series(1, 35) AS n
+WHERE v.kind = 'ongoing' AND v.seq = 10;
+
+-- 8-2) 종료 seq 1 : 채팅 5건
+INSERT INTO chat_message (vote_id, sender_id, content, created_at, updated_at)
+SELECT
+    v.id,
+    (SELECT id FROM users WHERE sub = 'qa-dummy-' || (1 + (n % 60))),
+    'QA 종료투표 채팅 ' || n,
+    now() - interval '8 days' + (n || ' minutes')::interval,
+    now()
+FROM qa_seed_vote v
+CROSS JOIN generate_series(1, 5) AS n
+WHERE v.kind = 'ended' AND v.seq = 1;
+
+-- 8-3) 종료 seq 2 : 채팅 320건 (300+ 뱃지)
+INSERT INTO chat_message (vote_id, sender_id, content, created_at, updated_at)
+SELECT
+    v.id,
+    (SELECT id FROM users WHERE sub = 'qa-dummy-' || (1 + (n % 60))),
+    'QA 대량 채팅 메시지 ' || n,
+    now() - interval '9 days' + (n || ' seconds')::interval,
+    now()
+FROM qa_seed_vote v
+CROSS JOIN generate_series(1, 320) AS n
+WHERE v.kind = 'ended' AND v.seq = 2;
+
+-- 9) 조회수 통계 (핫토픽 점수 = 참여*0.7 + 조회*0.3) --------------------------
+INSERT INTO vote_statistics (vote_id, view_count)
+SELECT
+    v.id,
+    CASE
+        WHEN v.kind = 'ongoing' AND v.seq = 10 THEN 5000
+        WHEN v.kind = 'ongoing' AND v.seq = 11 THEN 3500
+        WHEN v.kind = 'ongoing' AND v.seq = 12 THEN 2500
+        ELSE (v.seq * 37) % 800                          -- 그 외 잡다한 조회수
+    END
+FROM qa_seed_vote v;
+
+-- 10) 오늘의 추천 3개 (진행중 투표만 / 운영진 선정 처리됨) ---------------------
+INSERT INTO recommended_vote (vote_id, display_order, recommended_date, created_at, updated_at)
+SELECT
+    v.id,
+    row_number() OVER (ORDER BY v.seq),
+    CURRENT_DATE,
+    now(),
+    now()
+FROM qa_seed_vote v
+WHERE v.kind = 'ongoing' AND v.seq IN (5, 6, 7);
+
+-- 11) 알림 3건 (테스트 계정, 모두 미읽음) ------------------------------------
+INSERT INTO notification (user_id, type, vote_id, title, body, thumbnail_url, is_read, created_at, sent, sent_at)
+VALUES
+    (__MY_USER_ID__, 'VOTE_ENDED',
+     (SELECT id FROM qa_seed_vote WHERE kind='ended' AND seq=6),
+     '참여하신 투표가 종료되었어요', '결과를 확인해보세요! (24시간 이내 알림)',
+     NULL, FALSE, now() - interval '3 hours',  TRUE, now() - interval '3 hours'),
+    (__MY_USER_ID__, 'VOTE_ENDED',
+     (SELECT id FROM qa_seed_vote WHERE kind='ended' AND seq=7),
+     '참여하신 투표가 종료되었어요', '결과를 확인해보세요! (7일 이내 알림)',
+     NULL, FALSE, now() - interval '3 days',   TRUE, now() - interval '3 days'),
+    (__MY_USER_ID__, 'VOTE_ENDED',
+     (SELECT id FROM qa_seed_vote WHERE kind='ended' AND seq=4),
+     '참여하신 투표가 종료되었어요', '결과를 확인해보세요! (7일 초과 알림)',
+     NULL, FALSE, now() - interval '10 days',  TRUE, now() - interval '10 days');
+
+-- 12) 비회원 무료 투표 잔여 횟수 조정 (MAX=5) --------------------------------
+--     remaining = 5 - consumed_count.  잔여 1회로 세팅하려면 consumed_count = 4.
+INSERT INTO guest_free_vote (anonymous_id, consumed_count, last_consumed_at, created_at, updated_at)
+VALUES
+    ('qa-guest-1', 4, now() - interval '1 hour', now(), now()),   -- 잔여 1회
+    ('qa-guest-2', 0, NULL,                      now(), now());   -- 잔여 5회(풀)
+-- 운영 중 임의 조정 예시:  UPDATE guest_free_vote SET consumed_count = 4 WHERE anonymous_id = '<실제 anonymousId>';
+
+-- 결과 요약 ------------------------------------------------------------------
+SELECT 'dummy_users'  AS item, count(*) FROM users           WHERE sub LIKE 'qa-dummy-%'
+UNION ALL SELECT 'dummy_votes',   count(*) FROM qa_seed_vote
+UNION ALL SELECT 'participations', count(*) FROM vote_participation WHERE vote_id IN (SELECT id FROM qa_seed_vote)
+UNION ALL SELECT 'chat_messages',  count(*) FROM chat_message       WHERE vote_id IN (SELECT id FROM qa_seed_vote)
+UNION ALL SELECT 'notifications',  count(*) FROM notification        WHERE vote_id IN (SELECT id FROM qa_seed_vote);
+
+COMMIT;
+
+-- =============================================================================
+--  본인 user id 찾는 법
+--   방법1) SELECT id, email, nickname FROM users WHERE email = 'cjunk0304@gmail.com';
+--   방법2) 액세스 토큰을 jwt.io 에 붙여넣고 sub 클레임 숫자 확인
+--  → 찾은 숫자로 이 파일의 __MY_USER_ID__ 를 전부 치환 후 실행.
+--
+--  주의: '오늘의 추천 어드민 API' 자체를 테스트하려면 application.yml 의
+--        admin.user-ids 목록(현재 [7])에 본인 id가 있어야 함. 위 시드는 추천
+--        데이터를 DB에 직접 넣으므로 그 설정 없이도 추천 목록은 노출됨.
+-- =============================================================================

--- a/src/main/java/com/ject/vs/home/adapter/web/dto/HomeHotTopicResponse.java
+++ b/src/main/java/com/ject/vs/home/adapter/web/dto/HomeHotTopicResponse.java
@@ -1,6 +1,7 @@
 package com.ject.vs.home.adapter.web.dto;
 
 import com.ject.vs.home.port.in.HomeVoteQueryUseCase.HotTopicResult;
+import com.ject.vs.vote.domain.VoteType;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -13,6 +14,7 @@ public record HomeHotTopicResponse(List<HotTopicItem> hotTopics) {
             int rank,
             Long voteId,
             String thumbnailUrl,
+            VoteType voteType,
             String title,
             String content,
             long participantCount,
@@ -30,6 +32,7 @@ public record HomeHotTopicResponse(List<HotTopicItem> hotTopics) {
                         i.rank(),
                         i.voteId(),
                         i.thumbnailUrl(),
+                        i.voteType(),
                         i.title(),
                         i.content(),
                         i.participantCount(),

--- a/src/main/java/com/ject/vs/home/adapter/web/dto/HomeRecommendationResponse.java
+++ b/src/main/java/com/ject/vs/home/adapter/web/dto/HomeRecommendationResponse.java
@@ -1,6 +1,7 @@
 package com.ject.vs.home.adapter.web.dto;
 
 import com.ject.vs.home.port.in.HomeVoteQueryUseCase.RecommendationResult;
+import com.ject.vs.vote.domain.VoteType;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -12,6 +13,7 @@ public record HomeRecommendationResponse(List<RecommendationItem> recommendation
     public record RecommendationItem(
             Long voteId,
             String thumbnailUrl,
+            VoteType voteType,
             String title,
             String content,
             OffsetDateTime endAt
@@ -27,6 +29,7 @@ public record HomeRecommendationResponse(List<RecommendationItem> recommendation
                 .map(i -> new RecommendationItem(
                         i.voteId(),
                         i.thumbnailUrl(),
+                        i.voteType(),
                         i.title(),
                         i.content(),
                         toKst(i.endAt())

--- a/src/main/java/com/ject/vs/home/adapter/web/dto/HomeVoteListResponse.java
+++ b/src/main/java/com/ject/vs/home/adapter/web/dto/HomeVoteListResponse.java
@@ -2,6 +2,7 @@ package com.ject.vs.home.adapter.web.dto;
 
 import com.ject.vs.home.port.in.HomeVoteQueryUseCase.VoteListResult;
 import com.ject.vs.vote.domain.VoteStatus;
+import com.ject.vs.vote.domain.VoteType;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -18,6 +19,7 @@ public record HomeVoteListResponse(
             Long voteId,
             String thumbnailUrl,
             VoteStatus status,
+            VoteType voteType,
             String title,
             String content,
             OffsetDateTime endAt
@@ -34,6 +36,7 @@ public record HomeVoteListResponse(
                         i.voteId(),
                         i.thumbnailUrl(),
                         i.status(),
+                        i.voteType(),
                         i.title(),
                         i.content(),
                         toKst(i.endAt())

--- a/src/main/java/com/ject/vs/home/port/HomeVoteQueryService.java
+++ b/src/main/java/com/ject/vs/home/port/HomeVoteQueryService.java
@@ -162,6 +162,7 @@ public class HomeVoteQueryService implements HomeVoteQueryUseCase {
                         vote.getId(),
                         vote.getThumbnailUrl(),
                         vote.getStatus(clock),
+                        vote.getType(),
                         vote.getTitle(),
                         vote.getContent(),
                         vote.getEndAt()

--- a/src/main/java/com/ject/vs/home/port/HomeVoteQueryService.java
+++ b/src/main/java/com/ject/vs/home/port/HomeVoteQueryService.java
@@ -44,6 +44,7 @@ public class HomeVoteQueryService implements HomeVoteQueryUseCase {
                     return new RecommendationItem(
                             vote.getId(),
                             vote.getThumbnailUrl(),
+                            vote.getType(),
                             vote.getTitle(),
                             vote.getContent(),
                             vote.getEndAt()
@@ -112,6 +113,7 @@ public class HomeVoteQueryService implements HomeVoteQueryUseCase {
                     i + 1,
                     vote.getId(),
                     vote.getThumbnailUrl(),
+                    vote.getType(),
                     vote.getTitle(),
                     vote.getContent(),
                     participantCounts.getOrDefault(vote.getId(), 0L),
@@ -225,9 +227,10 @@ public class HomeVoteQueryService implements HomeVoteQueryUseCase {
         return switch (sortType) {
             case LATEST -> String.valueOf(last.getId());
             case POPULAR -> {
-                // VoteStatistics를 조회해서 viewCount를 가져와야 정확함.
-                // 현재 구조에서는 간단히 ID로 fallback (추후 개선)
-                yield String.valueOf(last.getId());
+                Long viewCount = voteStatisticsRepository.findByVoteId(last.getId())
+                        .map(VoteStatistics::getViewCount)
+                        .orElse(0L);
+                yield viewCount + ":" + last.getId();
             }
             case ENDING_SOON -> {
                 long endAtMillis = last.getEndAt().toEpochMilli();

--- a/src/main/java/com/ject/vs/home/port/in/HomeVoteQueryUseCase.java
+++ b/src/main/java/com/ject/vs/home/port/in/HomeVoteQueryUseCase.java
@@ -27,6 +27,7 @@ public interface HomeVoteQueryUseCase {
     record RecommendationItem(
             Long voteId,
             String thumbnailUrl,
+            VoteType voteType,
             String title,
             String content,
             Instant endAt
@@ -41,6 +42,7 @@ public interface HomeVoteQueryUseCase {
             int rank,
             Long voteId,
             String thumbnailUrl,
+            VoteType voteType,
             String title,
             String content,
             long participantCount,

--- a/src/main/java/com/ject/vs/home/port/in/HomeVoteQueryUseCase.java
+++ b/src/main/java/com/ject/vs/home/port/in/HomeVoteQueryUseCase.java
@@ -1,6 +1,7 @@
 package com.ject.vs.home.port.in;
 
 import com.ject.vs.vote.domain.VoteStatus;
+import com.ject.vs.vote.domain.VoteType;
 
 import java.time.Instant;
 import java.util.List;
@@ -59,6 +60,7 @@ public interface HomeVoteQueryUseCase {
             Long voteId,
             String thumbnailUrl,
             VoteStatus status,
+            VoteType voteType,
             String title,
             String content,
             Instant endAt

--- a/src/main/java/com/ject/vs/vote/adapter/web/ImmersiveVoteController.java
+++ b/src/main/java/com/ject/vs/vote/adapter/web/ImmersiveVoteController.java
@@ -29,14 +29,15 @@ public class ImmersiveVoteController {
     private final ImmersiveVoteQueryUseCase immersiveVoteQueryUseCase;
     private final VoteResultQueryUseCase voteResultQueryUseCase;
 
-    @Operation(summary = "몰입형 투표 피드 조회", description = "스와이프 형식의 몰입형 투표 피드를 조회합니다. 커서 기반 페이지네이션을 지원합니다.")
+    @Operation(summary = "몰입형 투표 피드 조회", description = "스와이프 형식의 몰입형 투표 피드를 조회합니다. 커서 기반 페이지네이션을 지원합니다. startVoteId를 지정하면 해당 투표부터 피드가 시작됩니다.")
     @GetMapping
     public ImmersiveFeedResponse getFeed(
             @RequestParam(required = false) Long cursor,
+            @RequestParam(required = false) Long startVoteId,
             @RequestParam(defaultValue = "10") int size,
             @AuthenticationPrincipal Long userId,
             @Parameter(hidden = true) @AnonymousId String anonymousId) {
-        return ImmersiveFeedResponse.from(immersiveVoteQueryUseCase.getFeed(cursor, size, userId, anonymousId));
+        return ImmersiveFeedResponse.from(immersiveVoteQueryUseCase.getFeed(cursor, startVoteId, size, userId, anonymousId));
     }
 
     @Operation(summary = "투표 참여/취소", description = "투표에 참여하거나 같은 옵션 재클릭 시 취소합니다. 비회원은 5회까지 무료 투표 가능합니다.")

--- a/src/main/java/com/ject/vs/vote/adapter/web/dto/MyParticipatedVoteResponse.java
+++ b/src/main/java/com/ject/vs/vote/adapter/web/dto/MyParticipatedVoteResponse.java
@@ -1,5 +1,7 @@
 package com.ject.vs.vote.adapter.web.dto;
 
+import com.ject.vs.vote.domain.VoteType;
+
 import java.time.Instant;
 import java.util.List;
 
@@ -9,6 +11,7 @@ public record MyParticipatedVoteResponse(
 ) {
     public record VoteElement(
             Long id,
+            VoteType voteType,
             String title,
             String content,
             String thumbnailUrl,

--- a/src/main/java/com/ject/vs/vote/adapter/web/dto/VoteDetailResponse.java
+++ b/src/main/java/com/ject/vs/vote/adapter/web/dto/VoteDetailResponse.java
@@ -1,6 +1,7 @@
 package com.ject.vs.vote.adapter.web.dto;
 
 import com.ject.vs.vote.domain.VoteEmoji;
+import com.ject.vs.vote.domain.VoteType;
 import com.ject.vs.vote.port.VoteDetailQueryService.VoteDetailResult;
 
 import java.time.Instant;
@@ -11,6 +12,7 @@ import java.util.Map;
 
 public record VoteDetailResponse(
         Long voteId,
+        VoteType voteType,
         String title,
         OffsetDateTime createdAt,
         String content,
@@ -62,6 +64,7 @@ public record VoteDetailResponse(
 
         return new VoteDetailResponse(
                 result.voteId(),
+                result.type(),
                 result.title(),
                 toKst(result.createdAt()),
                 result.content(),

--- a/src/main/java/com/ject/vs/vote/domain/VoteRepository.java
+++ b/src/main/java/com/ject/vs/vote/domain/VoteRepository.java
@@ -22,6 +22,12 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
 
     Slice<Vote> findByTypeAndIdLessThanOrderByEndAtDesc(VoteType type, Long cursor, Pageable pageable);
 
+    @Query("SELECT v FROM Vote v WHERE v.type = :type AND v.endAt > :now ORDER BY v.id DESC")
+    Slice<Vote> findByTypeAndEndAtAfterOrderByIdDesc(@Param("type") VoteType type, @Param("now") Instant now, Pageable pageable);
+
+    @Query("SELECT v FROM Vote v WHERE v.type = :type AND v.id < :cursor AND v.endAt > :now ORDER BY v.id DESC")
+    Slice<Vote> findByTypeAndIdLessThanAndEndAtAfterOrderByIdDesc(@Param("type") VoteType type, @Param("cursor") Long cursor, @Param("now") Instant now, Pageable pageable);
+
     @Query("select v from Vote v join VoteParticipation vp on vp.voteId = v.id " +
             "where vp.userId = :userId and v.endAt > current_timestamp " +
             "order by v.createdAt desc")

--- a/src/main/java/com/ject/vs/vote/domain/VoteStatisticsRepository.java
+++ b/src/main/java/com/ject/vs/vote/domain/VoteStatisticsRepository.java
@@ -3,8 +3,11 @@ package com.ject.vs.vote.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface VoteStatisticsRepository extends JpaRepository<VoteStatistics, Long> {
 
     List<VoteStatistics> findAllByVoteIdIn(List<Long> voteIds);
+
+    Optional<VoteStatistics> findByVoteId(Long voteId);
 }

--- a/src/main/java/com/ject/vs/vote/port/ImmersiveVoteQueryService.java
+++ b/src/main/java/com/ject/vs/vote/port/ImmersiveVoteQueryService.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -27,22 +29,43 @@ public class ImmersiveVoteQueryService implements ImmersiveVoteQueryUseCase {
     private final Clock clock;
 
     @Override
-    public ImmersiveFeedResult getFeed(Long cursor, int size, Long userId, String anonymousId) {
-        PageRequest pageable = PageRequest.of(0, size);
+    public ImmersiveFeedResult getFeed(Long cursor, Long startVoteId, int size, Long userId, String anonymousId) {
+        Instant now = Instant.now(clock);
 
-        Slice<Vote> slice = cursor == null
-                ? voteRepository.findByTypeOrderByEndAtDesc(VoteType.IMMERSIVE, pageable)
-                : voteRepository.findByTypeAndIdLessThanOrderByEndAtDesc(VoteType.IMMERSIVE, cursor, pageable);
+        List<ImmersiveFeedItem> items;
+        boolean hasNext;
 
-        List<ImmersiveFeedItem> items = slice.getContent().stream()
-                .map(vote -> toFeedItem(vote, userId, anonymousId))
-                .toList();
+        if (cursor != null) {
+            PageRequest pageable = PageRequest.of(0, size);
+            Slice<Vote> slice = voteRepository.findByTypeAndIdLessThanAndEndAtAfterOrderByIdDesc(
+                    VoteType.IMMERSIVE, cursor, now, pageable);
+            items = slice.getContent().stream().map(v -> toFeedItem(v, userId, anonymousId)).toList();
+            hasNext = slice.hasNext();
+        } else if (startVoteId != null) {
+            Vote startVote = voteRepository.findById(startVoteId).orElse(null);
+            if (startVote != null && !startVote.isEnded(clock) && startVote.getType() == VoteType.IMMERSIVE) {
+                Slice<Vote> rest = voteRepository.findByTypeAndIdLessThanAndEndAtAfterOrderByIdDesc(
+                        VoteType.IMMERSIVE, startVoteId, now, PageRequest.of(0, size - 1));
+                List<ImmersiveFeedItem> combined = new ArrayList<>();
+                combined.add(toFeedItem(startVote, userId, anonymousId));
+                rest.getContent().stream().map(v -> toFeedItem(v, userId, anonymousId)).forEach(combined::add);
+                items = combined;
+                hasNext = rest.hasNext();
+            } else {
+                Slice<Vote> slice = voteRepository.findByTypeAndEndAtAfterOrderByIdDesc(
+                        VoteType.IMMERSIVE, now, PageRequest.of(0, size));
+                items = slice.getContent().stream().map(v -> toFeedItem(v, userId, anonymousId)).toList();
+                hasNext = slice.hasNext();
+            }
+        } else {
+            Slice<Vote> slice = voteRepository.findByTypeAndEndAtAfterOrderByIdDesc(
+                    VoteType.IMMERSIVE, now, PageRequest.of(0, size));
+            items = slice.getContent().stream().map(v -> toFeedItem(v, userId, anonymousId)).toList();
+            hasNext = slice.hasNext();
+        }
 
-        Long nextCursor = slice.hasNext()
-                ? items.get(items.size() - 1).voteId()
-                : null;
-
-        return new ImmersiveFeedResult(items, nextCursor, slice.hasNext());
+        Long nextCursor = hasNext && !items.isEmpty() ? items.get(items.size() - 1).voteId() : null;
+        return new ImmersiveFeedResult(items, nextCursor, hasNext);
     }
 
     @Override

--- a/src/main/java/com/ject/vs/vote/port/VoteEmojiCommandService.java
+++ b/src/main/java/com/ject/vs/vote/port/VoteEmojiCommandService.java
@@ -1,11 +1,14 @@
 package com.ject.vs.vote.port;
 
 import com.ject.vs.vote.domain.*;
+import com.ject.vs.vote.exception.VoteEndedException;
+import com.ject.vs.vote.exception.VoteNotFoundException;
 import com.ject.vs.vote.port.in.VoteEmojiCommandUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -17,9 +20,13 @@ import java.util.stream.Collectors;
 public class VoteEmojiCommandService implements VoteEmojiCommandUseCase {
 
     private final VoteEmojiReactionRepository reactionRepository;
+    private final VoteRepository voteRepository;
+    private final Clock clock;
 
     @Override
     public EmojiResult reactAsMember(Long voteId, Long userId, VoteEmoji emoji) {
+        Vote vote = voteRepository.findById(voteId).orElseThrow(VoteNotFoundException::new);
+        if (vote.isEnded(clock)) throw new VoteEndedException();
         Optional<VoteEmojiReaction> existing = reactionRepository.findByVoteIdAndUserId(voteId, userId);
         VoteEmojiReaction resultEmoji = applyReaction(existing, emoji != null ? VoteEmojiReaction.ofMember(voteId, userId, emoji) : null);
         return buildResult(voteId, resultEmoji != null ? resultEmoji.getEmoji() : null);
@@ -27,6 +34,8 @@ public class VoteEmojiCommandService implements VoteEmojiCommandUseCase {
 
     @Override
     public EmojiResult reactAsGuest(Long voteId, String anonymousId, VoteEmoji emoji) {
+        Vote vote = voteRepository.findById(voteId).orElseThrow(VoteNotFoundException::new);
+        if (vote.isEnded(clock)) throw new VoteEndedException();
         Optional<VoteEmojiReaction> existing = reactionRepository.findByVoteIdAndAnonymousId(voteId, anonymousId);
         VoteEmojiReaction resultEmoji = applyReaction(
                 existing,

--- a/src/main/java/com/ject/vs/vote/port/VoteQueryService.java
+++ b/src/main/java/com/ject/vs/vote/port/VoteQueryService.java
@@ -134,6 +134,7 @@ public class VoteQueryService implements VoteQueryUseCase, VoteParticipationQuer
         List<MyParticipatedVoteResponse.VoteElement> elementList = list.stream()
                 .map(v -> new MyParticipatedVoteResponse.VoteElement(
                         v.getId(),
+                        v.getType(),
                         v.getTitle(),
                         v.getContent(),
                         v.getThumbnailUrl(),
@@ -158,6 +159,7 @@ public class VoteQueryService implements VoteQueryUseCase, VoteParticipationQuer
         List<MyParticipatedVoteResponse.VoteElement> elementList = list.stream()
                 .map(v -> new MyParticipatedVoteResponse.VoteElement(
                         v.getId(),
+                        v.getType(),
                         v.getTitle(),
                         v.getContent(),
                         v.getThumbnailUrl(),

--- a/src/main/java/com/ject/vs/vote/port/VoteResultQueryService.java
+++ b/src/main/java/com/ject/vs/vote/port/VoteResultQueryService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -226,22 +225,33 @@ public class VoteResultQueryService implements VoteResultQueryUseCase {
         return buildAgeDistributionsWithMajority(userIds);
     }
 
+    // 10대 → 20대, 50대+ → 40대로 병합 (UI 표시 그룹: 20s, 30s, 40s)
+    private static final List<AgeGroup> DISPLAY_AGE_GROUPS = List.of(
+            AgeGroup.TWENTIES, AgeGroup.THIRTIES, AgeGroup.FORTIES);
+
+    private AgeGroup normalizeAgeGroup(AgeGroup group) {
+        if (group == AgeGroup.TEENS) return AgeGroup.TWENTIES;
+        if (group == AgeGroup.FIFTIES_PLUS) return AgeGroup.FORTIES;
+        return group;
+    }
+
     private List<AgeDistribution> buildAgeDistributions(List<Long> userIds, AgeGroup myGroup) {
         List<User> users = userRepository.findAllById(userIds);
 
         Map<AgeGroup, Long> groupCounts = users.stream()
                 .filter(u -> u.getBirthYear() != null)
                 .collect(Collectors.groupingBy(
-                        u -> AgeGroup.fromBirthYear(u.getBirthYear(), clock),
+                        u -> normalizeAgeGroup(AgeGroup.fromBirthYear(u.getBirthYear(), clock)),
                         Collectors.counting()));
 
         long total = groupCounts.values().stream().mapToLong(Long::longValue).sum();
+        AgeGroup myDisplayGroup = myGroup != null ? normalizeAgeGroup(myGroup) : null;
 
-        return Arrays.stream(AgeGroup.values())
+        return DISPLAY_AGE_GROUPS.stream()
                 .map(group -> {
                     long count = groupCounts.getOrDefault(group, 0L);
                     int ratio = total == 0 ? 0 : (int) Math.round(count * 100.0 / total);
-                    return new AgeDistribution(group.getLabel(), ratio, group == myGroup);
+                    return new AgeDistribution(group.getLabel(), ratio, group == myDisplayGroup);
                 })
                 .toList();
     }
@@ -252,22 +262,17 @@ public class VoteResultQueryService implements VoteResultQueryUseCase {
         Map<AgeGroup, Long> groupCounts = users.stream()
                 .filter(u -> u.getBirthYear() != null)
                 .collect(Collectors.groupingBy(
-                        u -> AgeGroup.fromBirthYear(u.getBirthYear(), clock),
+                        u -> normalizeAgeGroup(AgeGroup.fromBirthYear(u.getBirthYear(), clock)),
                         Collectors.counting()));
 
         long total = groupCounts.values().stream().mapToLong(Long::longValue).sum();
 
-        // 다수 연령대 찾기
-        AgeGroup majorityGroup = groupCounts.entrySet().stream()
-                .max(Map.Entry.comparingByValue())
-                .map(Map.Entry::getKey)
-                .orElse(null);
-
-        return Arrays.stream(AgeGroup.values())
+        // 비참여자는 "내 그룹"이 없으므로 isHighlighted 항상 false
+        return DISPLAY_AGE_GROUPS.stream()
                 .map(group -> {
                     long count = groupCounts.getOrDefault(group, 0L);
                     int ratio = total == 0 ? 0 : (int) Math.round(count * 100.0 / total);
-                    return new AgeDistribution(group.getLabel(), ratio, group == majorityGroup);
+                    return new AgeDistribution(group.getLabel(), ratio, false);
                 })
                 .toList();
     }

--- a/src/main/java/com/ject/vs/vote/port/in/ImmersiveVoteQueryUseCase.java
+++ b/src/main/java/com/ject/vs/vote/port/in/ImmersiveVoteQueryUseCase.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public interface ImmersiveVoteQueryUseCase {
 
-    ImmersiveFeedResult getFeed(Long cursor, int size, Long userId, String anonymousId);
+    ImmersiveFeedResult getFeed(Long cursor, Long startVoteId, int size, Long userId, String anonymousId);
 
     ImmersiveLiveResult getLive(Long voteId);
 

--- a/src/main/java/com/ject/vs/vote/port/in/VoteResultQueryUseCase.java
+++ b/src/main/java/com/ject/vs/vote/port/in/VoteResultQueryUseCase.java
@@ -61,10 +61,10 @@ public interface VoteResultQueryUseCase {
     }
 
     /**
-     * 연령대 분포 정보
-     * @param ageGroup 연령대 레이블 (10s, 20s, 30s, 40s, 50s_PLUS)
+     * 연령대 분포 정보 (20s, 30s, 40s 3그룹으로 표시; 10대는 20s, 50대+는 40s에 합산)
+     * @param ageGroup 연령대 레이블 (20s, 30s, 40s)
      * @param ratio 해당 연령대 비율 (%)
-     * @param isHighlighted 강조 여부 (참여자: 내 그룹 여부, 미참여자: 다수 그룹 여부)
+     * @param isHighlighted 참여자: 내 연령대이면 true, 미참여자: 항상 false
      */
     record AgeDistribution(String ageGroup, int ratio, boolean isHighlighted) {
     }

--- a/src/unitTest/java/com/ject/vs/vote/adapter/web/ImmersiveVoteControllerTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/adapter/web/ImmersiveVoteControllerTest.java
@@ -71,7 +71,7 @@ class ImmersiveVoteControllerTest {
         @Test
         @WithMockUser
         void 피드_목록_200_반환() throws Exception {
-            given(immersiveVoteQueryUseCase.getFeed(any(), anyInt(), any(), any()))
+            given(immersiveVoteQueryUseCase.getFeed(any(), any(), anyInt(), any(), any()))
                     .willReturn(new ImmersiveFeedResult(List.of(), null, false));
 
             mockMvc.perform(get("/api/immersive-votes"))
@@ -239,7 +239,7 @@ class ImmersiveVoteControllerTest {
                     Instant.parse("2025-04-27T14:59:00Z"), options, true, 10L,
                     emojiSummary, 20L, VoteEmoji.LIKE, 5, 13
             );
-            given(immersiveVoteQueryUseCase.getFeed(eq(100L), eq(10), any(), any()))
+            given(immersiveVoteQueryUseCase.getFeed(eq(100L), isNull(), eq(10), any(), any()))
                     .willReturn(new ImmersiveFeedResult(List.of(item), 80L, true));
 
             mockMvc.perform(get("/api/immersive-votes")
@@ -258,7 +258,7 @@ class ImmersiveVoteControllerTest {
         @Test
         @WithMockUser
         void 마지막_페이지_hasNext_false() throws Exception {
-            given(immersiveVoteQueryUseCase.getFeed(isNull(), eq(10), any(), any()))
+            given(immersiveVoteQueryUseCase.getFeed(isNull(), isNull(), eq(10), any(), any()))
                     .willReturn(new ImmersiveFeedResult(List.of(), null, false));
 
             mockMvc.perform(get("/api/immersive-votes"))

--- a/src/unitTest/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
@@ -53,7 +53,6 @@ class ImmersiveVoteQueryServiceTest {
         @BeforeEach
         void setUp() {
             given(clock.instant()).willReturn(FIXED_CLOCK.instant());
-            given(clock.getZone()).willReturn(FIXED_CLOCK.getZone());
         }
 
         @Test

--- a/src/unitTest/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
@@ -3,6 +3,7 @@ package com.ject.vs.vote.port;
 import com.ject.vs.vote.domain.*;
 import com.ject.vs.vote.port.in.ImmersiveVoteQueryUseCase.ImmersiveFeedResult;
 import com.ject.vs.vote.port.in.ImmersiveVoteQueryUseCase.ImmersiveLiveResult;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +43,12 @@ class ImmersiveVoteQueryServiceTest {
     @Mock private VoteEmojiReactionRepository emojiReactionRepository;
     @Mock private Clock clock;
 
+    @BeforeEach
+    void setUp() {
+        given(clock.instant()).willReturn(FIXED_CLOCK.instant());
+        given(clock.getZone()).willReturn(FIXED_CLOCK.getZone());
+    }
+
     private Vote makeVote(Duration duration) {
         return Vote.create(VoteType.IMMERSIVE, "몰입", null, "t", "img.png", duration, FIXED_CLOCK);
     }
@@ -52,13 +59,13 @@ class ImmersiveVoteQueryServiceTest {
         @Test
         void cursor_없을때_타입_정렬_쿼리_사용() {
             Vote vote = makeVote(Duration.ofHours(24));
-            given(voteRepository.findByTypeOrderByEndAtDesc(eq(VoteType.IMMERSIVE), any()))
+            given(voteRepository.findByTypeAndEndAtAfterOrderByIdDesc(eq(VoteType.IMMERSIVE), any(), any()))
                     .willReturn(new SliceImpl<>(List.of(vote), PageRequest.of(0, 10), false));
             given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
             given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());
             given(voteParticipationRepository.countByVoteId(any())).willReturn(5L);
 
-            ImmersiveFeedResult result = service.getFeed(null, 10, null, null);
+            ImmersiveFeedResult result = service.getFeed(null, null, 10, null, null);
 
             assertThat(result.items()).hasSize(1);
             assertThat(result.hasNext()).isFalse();
@@ -68,14 +75,14 @@ class ImmersiveVoteQueryServiceTest {
         @Test
         void cursor_있을때_cursor_기반_쿼리_사용() {
             Vote vote = makeVote(Duration.ofHours(24));
-            given(voteRepository.findByTypeAndIdLessThanOrderByEndAtDesc(
-                    eq(VoteType.IMMERSIVE), eq(100L), any()))
+            given(voteRepository.findByTypeAndIdLessThanAndEndAtAfterOrderByIdDesc(
+                    eq(VoteType.IMMERSIVE), eq(100L), any(), any()))
                     .willReturn(new SliceImpl<>(List.of(vote), PageRequest.of(0, 10), false));
             given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
             given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());
             given(voteParticipationRepository.countByVoteId(any())).willReturn(3L);
 
-            ImmersiveFeedResult result = service.getFeed(100L, 10, null, null);
+            ImmersiveFeedResult result = service.getFeed(100L, null, 10, null, null);
 
             assertThat(result.items()).hasSize(1);
             assertThat(result.hasNext()).isFalse();
@@ -85,13 +92,13 @@ class ImmersiveVoteQueryServiceTest {
         void hasNext_true이면_nextCursor_반환() {
             Vote v1 = makeVote(Duration.ofHours(24));
             Vote v2 = makeVote(Duration.ofHours(23));
-            given(voteRepository.findByTypeOrderByEndAtDesc(eq(VoteType.IMMERSIVE), any()))
+            given(voteRepository.findByTypeAndEndAtAfterOrderByIdDesc(eq(VoteType.IMMERSIVE), any(), any()))
                     .willReturn(new SliceImpl<>(List.of(v1, v2), PageRequest.of(0, 2), true));
             given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
             given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());
             given(voteParticipationRepository.countByVoteId(any())).willReturn(0L);
 
-            ImmersiveFeedResult result = service.getFeed(null, 2, null, null);
+            ImmersiveFeedResult result = service.getFeed(null, null, 2, null, null);
 
             assertThat(result.hasNext()).isTrue();
             assertThat(result.nextCursor()).isEqualTo(result.items().get(1).voteId());
@@ -100,7 +107,7 @@ class ImmersiveVoteQueryServiceTest {
         @Test
         void 회원_userId로_mySelectedOptionId_조회() {
             Vote vote = makeVote(Duration.ofHours(24));
-            given(voteRepository.findByTypeOrderByEndAtDesc(eq(VoteType.IMMERSIVE), any()))
+            given(voteRepository.findByTypeAndEndAtAfterOrderByIdDesc(eq(VoteType.IMMERSIVE), any(), any()))
                     .willReturn(new SliceImpl<>(List.of(vote), PageRequest.of(0, 10), false));
             given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
             given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());
@@ -110,7 +117,7 @@ class ImmersiveVoteQueryServiceTest {
             given(voteParticipationRepository.findByVoteIdAndUserId(any(), eq(42L)))
                     .willReturn(Optional.of(participation));
 
-            ImmersiveFeedResult result = service.getFeed(null, 10, 42L, null);
+            ImmersiveFeedResult result = service.getFeed(null, null, 10, 42L, null);
 
             assertThat(result.items().get(0).mySelectedOptionId()).isEqualTo(99L);
         }
@@ -118,7 +125,7 @@ class ImmersiveVoteQueryServiceTest {
         @Test
         void 비회원_anonymousId로_mySelectedOptionId_조회() {
             Vote vote = makeVote(Duration.ofHours(24));
-            given(voteRepository.findByTypeOrderByEndAtDesc(eq(VoteType.IMMERSIVE), any()))
+            given(voteRepository.findByTypeAndEndAtAfterOrderByIdDesc(eq(VoteType.IMMERSIVE), any(), any()))
                     .willReturn(new SliceImpl<>(List.of(vote), PageRequest.of(0, 10), false));
             given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
             given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());
@@ -128,7 +135,7 @@ class ImmersiveVoteQueryServiceTest {
             given(voteParticipationRepository.findByVoteIdAndAnonymousId(any(), eq("anon")))
                     .willReturn(Optional.of(participation));
 
-            ImmersiveFeedResult result = service.getFeed(null, 10, null, "anon");
+            ImmersiveFeedResult result = service.getFeed(null, null, 10, null, "anon");
 
             assertThat(result.items().get(0).mySelectedOptionId()).isEqualTo(77L);
         }
@@ -136,13 +143,13 @@ class ImmersiveVoteQueryServiceTest {
         @Test
         void 미참여시_mySelectedOptionId_null() {
             Vote vote = makeVote(Duration.ofHours(24));
-            given(voteRepository.findByTypeOrderByEndAtDesc(eq(VoteType.IMMERSIVE), any()))
+            given(voteRepository.findByTypeAndEndAtAfterOrderByIdDesc(eq(VoteType.IMMERSIVE), any(), any()))
                     .willReturn(new SliceImpl<>(List.of(vote), PageRequest.of(0, 10), false));
             given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
             given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());
             given(voteParticipationRepository.countByVoteId(any())).willReturn(0L);
 
-            ImmersiveFeedResult result = service.getFeed(null, 10, null, null);
+            ImmersiveFeedResult result = service.getFeed(null, null, 10, null, null);
 
             assertThat(result.items().get(0).mySelectedOptionId()).isNull();
         }

--- a/src/unitTest/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
@@ -43,18 +43,18 @@ class ImmersiveVoteQueryServiceTest {
     @Mock private VoteEmojiReactionRepository emojiReactionRepository;
     @Mock private Clock clock;
 
-    @BeforeEach
-    void setUp() {
-        given(clock.instant()).willReturn(FIXED_CLOCK.instant());
-        given(clock.getZone()).willReturn(FIXED_CLOCK.getZone());
-    }
-
     private Vote makeVote(Duration duration) {
         return Vote.create(VoteType.IMMERSIVE, "몰입", null, "t", "img.png", duration, FIXED_CLOCK);
     }
 
     @Nested
     class getFeed {
+
+        @BeforeEach
+        void setUp() {
+            given(clock.instant()).willReturn(FIXED_CLOCK.instant());
+            given(clock.getZone()).willReturn(FIXED_CLOCK.getZone());
+        }
 
         @Test
         void cursor_없을때_타입_정렬_쿼리_사용() {

--- a/src/unitTest/java/com/ject/vs/vote/port/VoteEmojiCommandServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/port/VoteEmojiCommandServiceTest.java
@@ -1,9 +1,12 @@
 package com.ject.vs.vote.port;
 
+import com.ject.vs.vote.domain.Vote;
 import com.ject.vs.vote.domain.VoteEmoji;
 import com.ject.vs.vote.domain.VoteEmojiReaction;
 import com.ject.vs.vote.domain.VoteEmojiReactionRepository;
+import com.ject.vs.vote.domain.VoteRepository;
 import com.ject.vs.vote.port.in.VoteEmojiCommandUseCase.EmojiResult;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,12 +14,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,6 +32,19 @@ class VoteEmojiCommandServiceTest {
 
     @Mock
     private VoteEmojiReactionRepository reactionRepository;
+
+    @Mock
+    private VoteRepository voteRepository;
+
+    @Mock
+    private Clock clock;
+
+    @BeforeEach
+    void setUp() {
+        Vote mockVote = mock(Vote.class);
+        given(voteRepository.findById(any())).willReturn(Optional.of(mockVote));
+        given(mockVote.isEnded(any())).willReturn(false);
+    }
 
     private void stubEmptySummary(Long voteId) {
         given(reactionRepository.countByEmojiForVote(voteId)).willReturn(List.of());


### PR DESCRIPTION
## 📌 관련 이슈
- closes #

## 🔍 작업 내용
몰입형 투표 피드 관련 버그 수정 및 프론트엔드 요청사항 대응

## 📝 변경 사항
- **[immersive]** `GET /api/immersive-votes`에 `startVoteId` 쿼리 파라미터 추가 — 지정한 투표가 피드의 첫 번째 아이템으로 반환됨
- **[immersive]** 커서 페이지네이션 버그 수정 — 정렬 기준(`id DESC`)과 커서 기준 불일치로 일부 투표가 누락되던 문제 해결
- **[immersive]** 종료된 투표가 피드에 포함되던 문제 수정 — `endAt > 현재 시각` 조건 추가
- **[emoji]** 종료된 투표에 이모지 반응 시도 시 에러 반환 처리 추가
- **[home]** 홈 투표 목록(`GET /api/home/votes`) 응답에 `voteType` 필드 추가
- **[home]** 인기순 커서 페이지네이션 복합 커서(`viewCount:id`) 인코딩 버그 수정
- **[voteType]** 핫토픽, 오늘의 추천, 투표 상세(`GET /api/votes/{id}`), 내 참여 목록 응답에도 `voteType` 필드 추가
- **[result]** 연령대 분포를 20s / 30s / 40s 3그룹으로 통합 (10대 → 20s, 50대+ → 40s 합산)
- **[result]** 미참여자의 `ageDistribution.isMyGroup` 항상 `false`로 수정

## 💬 리뷰어에게
- `voteType` 필드는 프론트엔드에서 투표 카드 클릭 시 일반형/몰입형 화면으로 라우팅하는 데 필요합니다. `GENERAL`이면 `/votes/{id}`, `IMMERSIVE`이면 몰입형 피드(`startVoteId` 파라미터 포함)로 이동하면 됩니다.
- 연령대 3그룹 통합은 도메인 `AgeGroup` enum은 그대로 유지하고, 서비스 레이어에서만 집계 시 병합합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새 기능**
  * 투표 유형 정보를 홈화면, 추천, 인기 투표 목록에 표시
  * 몰입형 투표 피드에서 특정 투표부터 시작 가능

* **버그 수정**
  * 종료된 투표에 이모지 반응 추가 불가

* **개선**
  * 연령대 분포 표시를 20대/30대/40대 3그룹으로 단순화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JECT-Study/JECT2-4th-Server/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->