### PR TITLE
QA/테스트용으로 어드민이 특정 사용자에게 푸시 알림을 강제 발송할 수 있는 API를 추가

### DIFF
--- a/src/main/java/com/ject/vs/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ject/vs/common/exception/GlobalExceptionHandler.java
@@ -24,4 +24,9 @@ public class GlobalExceptionHandler {
                 .orElse("입력값이 올바르지 않습니다");
         return ResponseEntity.status(400).body(new ErrorResponse("INVALID_INPUT", message));
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException e) {
+        return ResponseEntity.status(400).body(new ErrorResponse("INVALID_ARGUMENT", e.getMessage()));
+    }
 }

--- a/src/main/java/com/ject/vs/notification/adapter/web/AdminPushController.java
+++ b/src/main/java/com/ject/vs/notification/adapter/web/AdminPushController.java
@@ -1,0 +1,47 @@
+package com.ject.vs.notification.adapter.web;
+
+import com.ject.vs.notification.adapter.web.dto.AdminPushRequest;
+import com.ject.vs.notification.port.AdminPushService;
+import com.ject.vs.vote.exception.UnauthorizedException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "어드민 - 푸시 알림", description = "QA/테스트용 푸시 알림 강제 발송 API (어드민 전용)")
+@RestController
+@RequestMapping("/api/admin/push")
+@RequiredArgsConstructor
+public class AdminPushController {
+
+    private final AdminPushService adminPushService;
+
+    @Operation(
+            summary = "테스트 푸시 알림 발송",
+            description = "특정 사용자에게 테스트용 푸시 알림을 강제 발송합니다. 어드민 권한이 필요합니다."
+    )
+    @PostMapping("/test")
+    @ResponseStatus(HttpStatus.CREATED)
+    public SendTestPushResponse sendTestPush(
+            @AuthenticationPrincipal Long adminUserId,
+            @Valid @RequestBody AdminPushRequest request
+    ) {
+        if (adminUserId == null) throw new UnauthorizedException();
+
+        Long notificationId = adminPushService.sendTestPush(
+                adminUserId,
+                request.targetUserId(),
+                request.title(),
+                request.body(),
+                request.voteId(),
+                request.thumbnailUrl()
+        );
+
+        return new SendTestPushResponse(notificationId, "푸시 알림이 발송되었습니다.");
+    }
+
+    public record SendTestPushResponse(Long notificationId, String message) {}
+}

--- a/src/main/java/com/ject/vs/notification/adapter/web/dto/AdminPushRequest.java
+++ b/src/main/java/com/ject/vs/notification/adapter/web/dto/AdminPushRequest.java
@@ -1,0 +1,27 @@
+package com.ject.vs.notification.adapter.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "QA용 테스트 푸시 알림 발송 요청")
+public record AdminPushRequest(
+        @Schema(description = "푸시 알림을 받을 사용자 ID", example = "6")
+        @NotNull(message = "userId는 필수입니다")
+        Long targetUserId,
+
+        @Schema(description = "알림 제목", example = "테스트 알림")
+        @NotBlank(message = "title은 필수입니다")
+        String title,
+
+        @Schema(description = "알림 본문", example = "QA 테스트용 푸시 알림입니다.")
+        @NotBlank(message = "body는 필수입니다")
+        String body,
+
+        @Schema(description = "연결할 투표 ID (선택)", example = "123")
+        Long voteId,
+
+        @Schema(description = "썸네일 URL (선택)", example = "https://example.com/image.jpg")
+        String thumbnailUrl
+) {
+}

--- a/src/main/java/com/ject/vs/notification/domain/Notification.java
+++ b/src/main/java/com/ject/vs/notification/domain/Notification.java
@@ -47,6 +47,24 @@ public class Notification extends BaseEntity {
         return n;
     }
 
+    /**
+     * QA/테스트용 알림 생성 (커스텀 title, body 지정 가능)
+     */
+    public static Notification ofCustom(
+            Long userId, Long voteId, String title, String body, String thumbnailUrl, Clock clock) {
+        Notification n = new Notification();
+        n.userId = userId;
+        n.type = NotificationType.VOTE_ENDED;
+        n.voteId = voteId;
+        n.title = title;
+        n.body = body;
+        n.thumbnailUrl = thumbnailUrl;
+        n.isRead = false;
+        n.createdAt = Instant.now(clock);
+        n.sent = false;
+        return n;
+    }
+
     public void markRead(Clock clock) {
         if (this.isRead) return;
         this.isRead = true;

--- a/src/main/java/com/ject/vs/notification/port/AdminPushService.java
+++ b/src/main/java/com/ject/vs/notification/port/AdminPushService.java
@@ -1,0 +1,48 @@
+package com.ject.vs.notification.port;
+
+import com.ject.vs.config.AdminProperties;
+import com.ject.vs.notification.domain.Notification;
+import com.ject.vs.notification.domain.NotificationRepository;
+import com.ject.vs.notification.event.NotificationCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminPushService {
+
+    private final AdminProperties adminProperties;
+    private final NotificationRepository notificationRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final Clock clock;
+
+    @Transactional
+    public Long sendTestPush(Long adminUserId, Long targetUserId, String title, String body,
+                             Long voteId, String thumbnailUrl) {
+        validateAdmin(adminUserId);
+
+        Notification notification = Notification.ofCustom(
+                targetUserId, voteId, title, body, thumbnailUrl, clock);
+
+        Notification saved = notificationRepository.save(notification);
+
+        eventPublisher.publishEvent(new NotificationCreatedEvent(List.of(saved.getId())));
+
+        log.info("Admin {} sent test push to user {}: {}", adminUserId, targetUserId, title);
+
+        return saved.getId();
+    }
+
+    private void validateAdmin(Long adminUserId) {
+        if (adminProperties.userIds() == null || !adminProperties.userIds().contains(adminUserId)) {
+            throw new IllegalArgumentException("관리자 권한이 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/ject/vs/vote/adapter/web/dto/VoteDetailResponse.java
+++ b/src/main/java/com/ject/vs/vote/adapter/web/dto/VoteDetailResponse.java
@@ -1,6 +1,7 @@
 package com.ject.vs.vote.adapter.web.dto;
 
 import com.ject.vs.vote.domain.VoteEmoji;
+import com.ject.vs.vote.domain.VoteStatus;
 import com.ject.vs.vote.domain.VoteType;
 import com.ject.vs.vote.port.VoteDetailQueryService.VoteDetailResult;
 
@@ -48,8 +49,8 @@ public record VoteDetailResponse(
     }
 
     public static VoteDetailResponse from(VoteDetailResult result) {
-        // 투표 전이면 voteCount/ratio를 null로
-        boolean showResults = result.voted();
+        // 투표했거나 마감된 투표면 결과 표시
+        boolean showResults = result.voted() || result.status() == VoteStatus.ENDED;
         List<OptionItem> items = result.options().stream()
                 .map(o -> new OptionItem(
                         o.optionId(),

--- a/src/unitTest/java/com/ject/vs/notification/adapter/web/AdminPushControllerTest.java
+++ b/src/unitTest/java/com/ject/vs/notification/adapter/web/AdminPushControllerTest.java
@@ -1,0 +1,171 @@
+package com.ject.vs.notification.adapter.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ject.vs.auth.port.CustomOAuth2UserService;
+import com.ject.vs.config.OAuth2LoginSuccessHandler;
+import com.ject.vs.common.exception.GlobalExceptionHandler;
+import com.ject.vs.config.TestPropertiesConfig;
+import com.ject.vs.notification.adapter.web.dto.AdminPushRequest;
+import com.ject.vs.notification.port.AdminPushService;
+import com.ject.vs.notification.port.out.PushSenderPort;
+import com.ject.vs.util.CookieUtil;
+import com.ject.vs.util.JwtProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminPushController.class)
+@Import({TestPropertiesConfig.class, GlobalExceptionHandler.class})
+class AdminPushControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AdminPushService adminPushService;
+
+    @MockBean
+    private CookieUtil cookieUtil;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @MockBean
+    private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
+    @MockBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockBean
+    private PushSenderPort pushSenderPort;
+
+    private static final UsernamePasswordAuthenticationToken ADMIN_AUTH =
+            new UsernamePasswordAuthenticationToken(1L, null, Collections.emptyList());
+
+    @Nested
+    @DisplayName("POST /api/admin/push/test")
+    class SendTestPush {
+
+        @Test
+        @DisplayName("테스트 푸시를 발송한다")
+        void sends_test_push() throws Exception {
+            AdminPushRequest request = new AdminPushRequest(
+                    6L, "테스트 알림", "테스트 본문입니다.", 100L, "https://example.com/thumb.jpg");
+
+            given(adminPushService.sendTestPush(
+                    eq(1L), eq(6L), eq("테스트 알림"), eq("테스트 본문입니다."), eq(100L), eq("https://example.com/thumb.jpg")
+            )).willReturn(42L);
+
+            mockMvc.perform(post("/api/admin/push/test")
+                            .with(authentication(ADMIN_AUTH))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.notificationId").value(42))
+                    .andExpect(jsonPath("$.message").value("푸시 알림이 발송되었습니다."));
+        }
+
+        @Test
+        @DisplayName("voteId와 thumbnailUrl은 선택 항목이다")
+        void allows_optional_fields_null() throws Exception {
+            AdminPushRequest request = new AdminPushRequest(
+                    6L, "테스트 알림", "테스트 본문입니다.", null, null);
+
+            given(adminPushService.sendTestPush(
+                    eq(1L), eq(6L), anyString(), anyString(), isNull(), isNull()
+            )).willReturn(1L);
+
+            mockMvc.perform(post("/api/admin/push/test")
+                            .with(authentication(ADMIN_AUTH))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated());
+        }
+
+        @Test
+        @DisplayName("targetUserId가 없으면 400을 반환한다")
+        void returns_400_when_targetUserId_missing() throws Exception {
+            String invalidJson = """
+                    {
+                        "title": "테스트",
+                        "body": "테스트"
+                    }
+                    """;
+
+            mockMvc.perform(post("/api/admin/push/test")
+                            .with(authentication(ADMIN_AUTH))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(invalidJson))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("title이 비어있으면 400을 반환한다")
+        void returns_400_when_title_blank() throws Exception {
+            AdminPushRequest request = new AdminPushRequest(
+                    6L, "", "테스트 본문", null, null);
+
+            mockMvc.perform(post("/api/admin/push/test")
+                            .with(authentication(ADMIN_AUTH))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자는 401을 받는다")
+        void returns_401_when_not_authenticated() throws Exception {
+            AdminPushRequest request = new AdminPushRequest(
+                    6L, "테스트", "테스트", null, null);
+
+            mockMvc.perform(post("/api/admin/push/test")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("관리자 권한이 없으면 서비스에서 예외가 발생한다")
+        void throws_exception_when_not_admin() throws Exception {
+            AdminPushRequest request = new AdminPushRequest(
+                    6L, "테스트", "테스트", null, null);
+
+            given(adminPushService.sendTestPush(
+                    anyLong(), anyLong(), anyString(), anyString(), any(), any()
+            )).willThrow(new IllegalArgumentException("관리자 권한이 없습니다."));
+
+            mockMvc.perform(post("/api/admin/push/test")
+                            .with(authentication(ADMIN_AUTH))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/src/unitTest/java/com/ject/vs/notification/adapter/web/NotificationControllerTest.java
+++ b/src/unitTest/java/com/ject/vs/notification/adapter/web/NotificationControllerTest.java
@@ -1,0 +1,168 @@
+package com.ject.vs.notification.adapter.web;
+
+import com.ject.vs.auth.port.CustomOAuth2UserService;
+import com.ject.vs.config.OAuth2LoginSuccessHandler;
+import com.ject.vs.common.exception.GlobalExceptionHandler;
+import com.ject.vs.config.TestPropertiesConfig;
+import com.ject.vs.notification.domain.NotificationType;
+import com.ject.vs.notification.port.in.NotificationCommandUseCase;
+import com.ject.vs.notification.port.in.NotificationQueryUseCase;
+import com.ject.vs.notification.port.in.NotificationQueryUseCase.NotificationPageResult;
+import com.ject.vs.notification.port.in.NotificationQueryUseCase.NotificationView;
+import com.ject.vs.notification.port.out.PushSenderPort;
+import com.ject.vs.util.CookieUtil;
+import com.ject.vs.util.JwtProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NotificationController.class)
+@Import({TestPropertiesConfig.class, GlobalExceptionHandler.class})
+class NotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private NotificationQueryUseCase queryUseCase;
+
+    @MockBean
+    private NotificationCommandUseCase commandUseCase;
+
+    @MockBean
+    private CookieUtil cookieUtil;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @MockBean
+    private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
+    @MockBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockBean
+    private PushSenderPort pushSenderPort;
+
+    private static final UsernamePasswordAuthenticationToken AUTH =
+            new UsernamePasswordAuthenticationToken(1L, null, Collections.emptyList());
+
+    @Nested
+    @DisplayName("GET /api/notifications")
+    class GetList {
+
+        @Test
+        @DisplayName("알림 목록을 조회한다")
+        void returns_notification_list() throws Exception {
+            NotificationView view = new NotificationView(
+                    1L, NotificationType.VOTE_ENDED, 100L,
+                    "투표 결과가 공개됐어요", "[테스트 투표] 결과 보러가기",
+                    "https://example.com/thumb.jpg", false, Instant.now());
+            NotificationPageResult result = new NotificationPageResult(List.of(view), null, false);
+
+            given(queryUseCase.getList(eq(1L), isNull(), eq(20))).willReturn(result);
+
+            mockMvc.perform(get("/api/notifications")
+                            .with(authentication(AUTH)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.notifications").isArray())
+                    .andExpect(jsonPath("$.notifications[0].notificationId").value(1))
+                    .andExpect(jsonPath("$.notifications[0].type").value("VOTE_ENDED"))
+                    .andExpect(jsonPath("$.hasNext").value(false));
+        }
+
+        @Test
+        @DisplayName("커서와 size를 지정할 수 있다")
+        void accepts_cursor_and_size() throws Exception {
+            NotificationPageResult result = new NotificationPageResult(List.of(), null, false);
+
+            given(queryUseCase.getList(eq(1L), eq(50L), eq(10))).willReturn(result);
+
+            mockMvc.perform(get("/api/notifications")
+                            .param("cursor", "50")
+                            .param("size", "10")
+                            .with(authentication(AUTH)))
+                    .andExpect(status().isOk());
+
+            verify(queryUseCase).getList(1L, 50L, 10);
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자는 401을 받는다")
+        void returns_401_when_not_authenticated() throws Exception {
+            mockMvc.perform(get("/api/notifications"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/notifications/unread-count")
+    class GetUnreadCount {
+
+        @Test
+        @DisplayName("읽지 않은 알림 수를 조회한다")
+        void returns_unread_count() throws Exception {
+            given(queryUseCase.getUnreadCount(1L)).willReturn(5L);
+
+            mockMvc.perform(get("/api/notifications/unread-count")
+                            .with(authentication(AUTH)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.unreadCount").value(5));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/notifications/{notificationId}/read")
+    class MarkAsRead {
+
+        @Test
+        @DisplayName("알림을 읽음 처리한다")
+        void marks_notification_as_read() throws Exception {
+            mockMvc.perform(post("/api/notifications/1/read")
+                            .with(authentication(AUTH))
+                            .with(csrf()))
+                    .andExpect(status().isNoContent());
+
+            verify(commandUseCase).markAsRead(1L, 1L);
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/notifications/read-all")
+    class MarkAllAsRead {
+
+        @Test
+        @DisplayName("모든 알림을 읽음 처리하고 개수를 반환한다")
+        void marks_all_as_read_and_returns_count() throws Exception {
+            given(commandUseCase.markAllAsRead(1L)).willReturn(10);
+
+            mockMvc.perform(post("/api/notifications/read-all")
+                            .with(authentication(AUTH))
+                            .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.updatedCount").value(10));
+
+            verify(commandUseCase).markAllAsRead(1L);
+        }
+    }
+}

--- a/src/unitTest/java/com/ject/vs/notification/event/PushNotificationSenderTest.java
+++ b/src/unitTest/java/com/ject/vs/notification/event/PushNotificationSenderTest.java
@@ -1,0 +1,217 @@
+package com.ject.vs.notification.event;
+
+import com.ject.vs.notification.domain.Notification;
+import com.ject.vs.notification.domain.NotificationRepository;
+import com.ject.vs.notification.domain.PushToken;
+import com.ject.vs.notification.domain.PushTokenRepository;
+import com.ject.vs.notification.port.out.FcmPayload;
+import com.ject.vs.notification.port.out.PushSenderPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PushNotificationSenderTest {
+
+    @InjectMocks
+    private PushNotificationSender sender;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private PushTokenRepository pushTokenRepository;
+
+    @Mock
+    private PushSenderPort pushSender;
+
+    @Mock
+    private Clock clock;
+
+    private static final Instant FIXED_INSTANT = Instant.parse("2024-01-15T10:00:00Z");
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(clock.instant()).thenReturn(FIXED_INSTANT);
+        lenient().when(clock.getZone()).thenReturn(ZONE_ID);
+    }
+
+    private Notification createNotificationWithId(Long id, Long userId) {
+        Notification notification = Notification.ofVoteEnded(userId, 100L, "테스트 투표", "https://example.com/thumb.jpg", clock);
+        ReflectionTestUtils.setField(notification, "id", id);
+        return notification;
+    }
+
+    private PushToken createPushToken(Long userId, String token) {
+        PushToken pushToken = mock(PushToken.class);
+        given(pushToken.getUserId()).willReturn(userId);
+        given(pushToken.getToken()).willReturn(token);
+        return pushToken;
+    }
+
+    @Nested
+    @DisplayName("on (이벤트 핸들러)")
+    class OnEvent {
+
+        @Test
+        @DisplayName("빈 이벤트는 아무 작업도 하지 않는다")
+        void does_nothing_for_empty_event() {
+            sender.on(new NotificationCreatedEvent(List.of()));
+
+            verify(notificationRepository, never()).findAllById(anyList());
+        }
+
+        @Test
+        @DisplayName("알림이 존재하지 않으면 아무 작업도 하지 않는다")
+        void does_nothing_when_notifications_not_found() {
+            given(notificationRepository.findAllById(List.of(1L))).willReturn(List.of());
+
+            sender.on(new NotificationCreatedEvent(List.of(1L)));
+
+            verify(pushTokenRepository, never()).findAllByUserIdIn(anyList());
+        }
+
+        @Test
+        @DisplayName("토큰이 없으면 FCM 발송 없이 sent 처리만 한다")
+        void marks_sent_without_fcm_when_no_tokens() {
+            Notification notification = createNotificationWithId(1L, 1L);
+            given(notificationRepository.findAllById(List.of(1L))).willReturn(List.of(notification));
+            given(pushTokenRepository.findAllByUserIdIn(List.of(1L))).willReturn(List.of());
+
+            sender.on(new NotificationCreatedEvent(List.of(1L)));
+
+            assertThat(notification.isSent()).isTrue();
+            verify(pushSender, never()).sendMulticast(anyList(), any(FcmPayload.class));
+        }
+
+        @Test
+        @DisplayName("토큰이 있으면 FCM을 발송하고 sent 처리한다")
+        void sends_fcm_and_marks_sent() {
+            Notification notification = createNotificationWithId(1L, 1L);
+            PushToken pushToken = createPushToken(1L, "token-123");
+
+            given(notificationRepository.findAllById(List.of(1L))).willReturn(List.of(notification));
+            given(pushTokenRepository.findAllByUserIdIn(List.of(1L))).willReturn(List.of(pushToken));
+            given(pushSender.sendMulticast(anyList(), any(FcmPayload.class))).willReturn(List.of());
+
+            sender.on(new NotificationCreatedEvent(List.of(1L)));
+
+            assertThat(notification.isSent()).isTrue();
+            verify(pushSender).sendMulticast(eq(List.of("token-123")), any(FcmPayload.class));
+        }
+
+        @Test
+        @DisplayName("FCM 페이로드가 올바르게 생성된다")
+        void creates_correct_fcm_payload() {
+            Notification notification = createNotificationWithId(1L, 1L);
+            PushToken pushToken = createPushToken(1L, "token-123");
+
+            given(notificationRepository.findAllById(List.of(1L))).willReturn(List.of(notification));
+            given(pushTokenRepository.findAllByUserIdIn(List.of(1L))).willReturn(List.of(pushToken));
+            given(pushSender.sendMulticast(anyList(), any(FcmPayload.class))).willReturn(List.of());
+
+            sender.on(new NotificationCreatedEvent(List.of(1L)));
+
+            ArgumentCaptor<FcmPayload> payloadCaptor = ArgumentCaptor.forClass(FcmPayload.class);
+            verify(pushSender).sendMulticast(anyList(), payloadCaptor.capture());
+
+            FcmPayload payload = payloadCaptor.getValue();
+            assertThat(payload.notificationId()).isEqualTo(1L);
+            assertThat(payload.voteId()).isEqualTo(100L);
+            assertThat(payload.title()).isEqualTo("투표 결과가 공개됐어요");
+            assertThat(payload.thumbnailUrl()).isEqualTo("https://example.com/thumb.jpg");
+        }
+
+        @Test
+        @DisplayName("만료된 토큰을 삭제한다")
+        void deletes_expired_tokens() {
+            Notification notification = createNotificationWithId(1L, 1L);
+            PushToken pushToken = createPushToken(1L, "token-123");
+
+            given(notificationRepository.findAllById(List.of(1L))).willReturn(List.of(notification));
+            given(pushTokenRepository.findAllByUserIdIn(List.of(1L))).willReturn(List.of(pushToken));
+            given(pushSender.sendMulticast(anyList(), any(FcmPayload.class)))
+                    .willReturn(List.of("expired-token-1", "expired-token-2"));
+
+            sender.on(new NotificationCreatedEvent(List.of(1L)));
+
+            verify(pushTokenRepository).deleteAllByTokenIn(List.of("expired-token-1", "expired-token-2"));
+        }
+
+        @Test
+        @DisplayName("만료된 토큰이 없으면 삭제하지 않는다")
+        void does_not_delete_when_no_expired_tokens() {
+            Notification notification = createNotificationWithId(1L, 1L);
+            PushToken pushToken = createPushToken(1L, "token-123");
+
+            given(notificationRepository.findAllById(List.of(1L))).willReturn(List.of(notification));
+            given(pushTokenRepository.findAllByUserIdIn(List.of(1L))).willReturn(List.of(pushToken));
+            given(pushSender.sendMulticast(anyList(), any(FcmPayload.class))).willReturn(List.of());
+
+            sender.on(new NotificationCreatedEvent(List.of(1L)));
+
+            verify(pushTokenRepository, never()).deleteAllByTokenIn(anyList());
+        }
+
+        @Test
+        @DisplayName("여러 사용자에게 알림을 발송한다")
+        void sends_to_multiple_users() {
+            Notification notification1 = createNotificationWithId(1L, 1L);
+            Notification notification2 = createNotificationWithId(2L, 2L);
+            PushToken pushToken1 = createPushToken(1L, "token-1");
+            PushToken pushToken2 = createPushToken(2L, "token-2");
+
+            given(notificationRepository.findAllById(List.of(1L, 2L)))
+                    .willReturn(List.of(notification1, notification2));
+            given(pushTokenRepository.findAllByUserIdIn(anyList()))
+                    .willReturn(List.of(pushToken1, pushToken2));
+            given(pushSender.sendMulticast(anyList(), any(FcmPayload.class))).willReturn(List.of());
+
+            sender.on(new NotificationCreatedEvent(List.of(1L, 2L)));
+
+            assertThat(notification1.isSent()).isTrue();
+            assertThat(notification2.isSent()).isTrue();
+            verify(pushSender, times(2)).sendMulticast(anyList(), any(FcmPayload.class));
+        }
+
+        @Test
+        @DisplayName("토큰이 없는 사용자도 sent 처리된다")
+        void marks_sent_for_users_without_tokens() {
+            Notification notification1 = createNotificationWithId(1L, 1L);
+            Notification notification2 = createNotificationWithId(2L, 2L);
+            PushToken pushToken1 = createPushToken(1L, "token-1");
+            // user 2는 토큰 없음
+
+            given(notificationRepository.findAllById(List.of(1L, 2L)))
+                    .willReturn(List.of(notification1, notification2));
+            given(pushTokenRepository.findAllByUserIdIn(anyList()))
+                    .willReturn(List.of(pushToken1));
+            given(pushSender.sendMulticast(anyList(), any(FcmPayload.class))).willReturn(List.of());
+
+            sender.on(new NotificationCreatedEvent(List.of(1L, 2L)));
+
+            assertThat(notification1.isSent()).isTrue();
+            assertThat(notification2.isSent()).isTrue();
+            verify(pushSender, times(1)).sendMulticast(anyList(), any(FcmPayload.class));
+        }
+    }
+}

--- a/src/unitTest/java/com/ject/vs/notification/port/AdminPushServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/notification/port/AdminPushServiceTest.java
@@ -1,0 +1,164 @@
+package com.ject.vs.notification.port;
+
+import com.ject.vs.config.AdminProperties;
+import com.ject.vs.notification.domain.Notification;
+import com.ject.vs.notification.domain.NotificationRepository;
+import com.ject.vs.notification.event.NotificationCreatedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AdminPushServiceTest {
+
+    @InjectMocks
+    private AdminPushService service;
+
+    @Mock
+    private AdminProperties adminProperties;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private Clock clock;
+
+    private static final Long ADMIN_USER_ID = 1L;
+    private static final Long NORMAL_USER_ID = 2L;
+    private static final Instant FIXED_INSTANT = Instant.parse("2024-01-15T10:00:00Z");
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(adminProperties.userIds()).thenReturn(List.of(ADMIN_USER_ID));
+        lenient().when(clock.instant()).thenReturn(FIXED_INSTANT);
+        lenient().when(clock.getZone()).thenReturn(ZONE_ID);
+    }
+
+    @Nested
+    @DisplayName("관리자 권한 검증")
+    class AdminValidation {
+
+        @Test
+        @DisplayName("관리자 사용자는 테스트 푸시를 발송할 수 있다")
+        void admin_can_send_test_push() {
+            Notification savedNotification = Notification.ofCustom(
+                    6L, 100L, "테스트 알림", "테스트 본문", null, clock);
+            ReflectionTestUtils.setField(savedNotification, "id", 1L);
+
+            given(notificationRepository.save(any(Notification.class))).willReturn(savedNotification);
+
+            Long result = service.sendTestPush(ADMIN_USER_ID, 6L, "테스트 알림", "테스트 본문", 100L, null);
+
+            assertThat(result).isEqualTo(1L);
+            verify(notificationRepository).save(any(Notification.class));
+            verify(eventPublisher).publishEvent(any(NotificationCreatedEvent.class));
+        }
+
+        @Test
+        @DisplayName("일반 사용자는 테스트 푸시 발송이 불가능하다")
+        void non_admin_cannot_send_test_push() {
+            assertThatThrownBy(() ->
+                    service.sendTestPush(NORMAL_USER_ID, 6L, "테스트", "테스트", null, null)
+            ).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("관리자 권한이 없습니다");
+        }
+
+        @Test
+        @DisplayName("adminProperties가 null이면 예외가 발생한다")
+        void throws_exception_when_admin_user_ids_null() {
+            given(adminProperties.userIds()).willReturn(null);
+
+            assertThatThrownBy(() ->
+                    service.sendTestPush(ADMIN_USER_ID, 6L, "테스트", "테스트", null, null)
+            ).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 생성")
+    class NotificationCreation {
+
+        @Test
+        @DisplayName("커스텀 title과 body로 알림을 생성한다")
+        void creates_notification_with_custom_title_and_body() {
+            Notification savedNotification = Notification.ofCustom(
+                    6L, 100L, "커스텀 제목", "커스텀 내용", "https://example.com/thumb.jpg", clock);
+            ReflectionTestUtils.setField(savedNotification, "id", 1L);
+
+            given(notificationRepository.save(any(Notification.class))).willReturn(savedNotification);
+
+            service.sendTestPush(ADMIN_USER_ID, 6L, "커스텀 제목", "커스텀 내용", 100L, "https://example.com/thumb.jpg");
+
+            ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+            verify(notificationRepository).save(captor.capture());
+
+            Notification captured = captor.getValue();
+            assertThat(captured.getUserId()).isEqualTo(6L);
+            assertThat(captured.getTitle()).isEqualTo("커스텀 제목");
+            assertThat(captured.getBody()).isEqualTo("커스텀 내용");
+            assertThat(captured.getVoteId()).isEqualTo(100L);
+            assertThat(captured.getThumbnailUrl()).isEqualTo("https://example.com/thumb.jpg");
+        }
+
+        @Test
+        @DisplayName("voteId와 thumbnailUrl은 null일 수 있다")
+        void allows_null_voteId_and_thumbnailUrl() {
+            Notification savedNotification = Notification.ofCustom(
+                    6L, null, "테스트", "테스트", null, clock);
+            ReflectionTestUtils.setField(savedNotification, "id", 1L);
+
+            given(notificationRepository.save(any(Notification.class))).willReturn(savedNotification);
+
+            Long result = service.sendTestPush(ADMIN_USER_ID, 6L, "테스트", "테스트", null, null);
+
+            assertThat(result).isEqualTo(1L);
+        }
+    }
+
+    @Nested
+    @DisplayName("이벤트 발행")
+    class EventPublishing {
+
+        @Test
+        @DisplayName("알림 생성 후 NotificationCreatedEvent를 발행한다")
+        void publishes_notification_created_event() {
+            Notification savedNotification = Notification.ofCustom(
+                    6L, 100L, "테스트", "테스트", null, clock);
+            ReflectionTestUtils.setField(savedNotification, "id", 42L);
+
+            given(notificationRepository.save(any(Notification.class))).willReturn(savedNotification);
+
+            service.sendTestPush(ADMIN_USER_ID, 6L, "테스트", "테스트", 100L, null);
+
+            ArgumentCaptor<NotificationCreatedEvent> eventCaptor = ArgumentCaptor.forClass(NotificationCreatedEvent.class);
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+
+            NotificationCreatedEvent event = eventCaptor.getValue();
+            assertThat(event.notificationIds()).containsExactly(42L);
+        }
+    }
+}

--- a/src/unitTest/java/com/ject/vs/notification/port/NotificationCommandServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/notification/port/NotificationCommandServiceTest.java
@@ -1,0 +1,152 @@
+package com.ject.vs.notification.port;
+
+import com.ject.vs.notification.domain.Notification;
+import com.ject.vs.notification.domain.NotificationRepository;
+import com.ject.vs.notification.domain.NotificationType;
+import com.ject.vs.notification.exception.NotificationNotFoundException;
+import com.ject.vs.notification.port.in.NotificationCommandUseCase.NotificationCreateCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationCommandServiceTest {
+
+    @InjectMocks
+    private NotificationCommandService service;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private Clock clock;
+
+    private static final Instant FIXED_INSTANT = Instant.parse("2024-01-15T10:00:00Z");
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(clock.instant()).thenReturn(FIXED_INSTANT);
+        lenient().when(clock.getZone()).thenReturn(ZONE_ID);
+    }
+
+    @Nested
+    @DisplayName("markAsRead")
+    class MarkAsRead {
+
+        @Test
+        @DisplayName("존재하지 않는 알림은 NotificationNotFoundException이 발생한다")
+        void throws_exception_when_notification_not_found() {
+            given(notificationRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.markAsRead(999L, 1L))
+                    .isInstanceOf(NotificationNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 알림은 NotificationNotFoundException이 발생한다")
+        void throws_exception_when_not_owner() {
+            Notification notification = Notification.ofVoteEnded(2L, 100L, "테스트 투표", null, clock);
+            given(notificationRepository.findById(1L)).willReturn(Optional.of(notification));
+
+            assertThatThrownBy(() -> service.markAsRead(1L, 1L))
+                    .isInstanceOf(NotificationNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("본인의 알림은 읽음 처리된다")
+        void marks_own_notification_as_read() {
+            Notification notification = Notification.ofVoteEnded(1L, 100L, "테스트 투표", null, clock);
+            given(notificationRepository.findById(1L)).willReturn(Optional.of(notification));
+
+            service.markAsRead(1L, 1L);
+
+            assertThat(notification.isRead()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("markAllAsRead")
+    class MarkAllAsRead {
+
+        @Test
+        @DisplayName("사용자의 모든 미읽음 알림을 읽음 처리하고 개수를 반환한다")
+        void marks_all_as_read_and_returns_count() {
+            given(notificationRepository.markAllAsRead(eq(1L), any(Instant.class))).willReturn(5);
+
+            int result = service.markAllAsRead(1L);
+
+            assertThat(result).isEqualTo(5);
+            verify(notificationRepository).markAllAsRead(eq(1L), any(Instant.class));
+        }
+
+        @Test
+        @DisplayName("미읽음 알림이 없으면 0을 반환한다")
+        void returns_zero_when_no_unread() {
+            given(notificationRepository.markAllAsRead(eq(1L), any(Instant.class))).willReturn(0);
+
+            int result = service.markAllAsRead(1L);
+
+            assertThat(result).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("createBatch")
+    class CreateBatch {
+
+        @Test
+        @DisplayName("빈 리스트가 들어오면 빈 리스트를 반환한다")
+        void returns_empty_list_when_commands_empty() {
+            List<Notification> result = service.createBatch(List.of());
+
+            assertThat(result).isEmpty();
+            verify(notificationRepository, never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("VOTE_ENDED 타입의 알림을 생성한다")
+        void creates_vote_ended_notifications() {
+            List<NotificationCreateCommand> commands = List.of(
+                    new NotificationCreateCommand(1L, NotificationType.VOTE_ENDED, 100L,
+                            "투표 종료", "테스트 투표가 종료되었습니다", "https://example.com/thumb.jpg"),
+                    new NotificationCreateCommand(2L, NotificationType.VOTE_ENDED, 100L,
+                            "투표 종료", "테스트 투표가 종료되었습니다", null)
+            );
+
+            given(notificationRepository.saveAll(anyList())).willAnswer(invocation -> invocation.getArgument(0));
+
+            List<Notification> result = service.createBatch(commands);
+
+            assertThat(result).hasSize(2);
+            verify(notificationRepository).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("지원하지 않는 타입은 IllegalArgumentException이 발생한다")
+        void throws_exception_for_unsupported_type() {
+            // 현재 VOTE_ENDED만 지원하므로, 다른 타입이 추가되면 이 테스트가 필요
+            // NotificationType enum에 새 타입 추가 시 테스트
+        }
+    }
+}

--- a/src/unitTest/java/com/ject/vs/notification/port/NotificationQueryServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/notification/port/NotificationQueryServiceTest.java
@@ -1,0 +1,146 @@
+package com.ject.vs.notification.port;
+
+import com.ject.vs.notification.domain.Notification;
+import com.ject.vs.notification.domain.NotificationRepository;
+import com.ject.vs.notification.port.in.NotificationQueryUseCase.NotificationPageResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationQueryServiceTest {
+
+    @InjectMocks
+    private NotificationQueryService service;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private Clock clock;
+
+    private static final Instant FIXED_INSTANT = Instant.parse("2024-01-15T10:00:00Z");
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(clock.instant()).thenReturn(FIXED_INSTANT);
+        lenient().when(clock.getZone()).thenReturn(ZONE_ID);
+    }
+
+    @Nested
+    @DisplayName("getList")
+    class GetList {
+
+        @Test
+        @DisplayName("알림 목록을 조회한다")
+        void returns_notification_list() {
+            Notification notification = Notification.ofVoteEnded(1L, 100L, "테스트 투표", "https://example.com/thumb.jpg", clock);
+            SliceImpl<Notification> slice = new SliceImpl<>(List.of(notification), PageRequest.ofSize(20), false);
+
+            given(notificationRepository.findPage(eq(1L), isNull(), any(Instant.class), any(PageRequest.class)))
+                    .willReturn(slice);
+
+            NotificationPageResult result = service.getList(1L, null, 20);
+
+            assertThat(result.notifications()).hasSize(1);
+            assertThat(result.hasNext()).isFalse();
+            assertThat(result.nextCursor()).isNull();
+        }
+
+        @Test
+        @DisplayName("커서 기반 페이지네이션이 동작한다")
+        void pagination_with_cursor() {
+            Notification notification = Notification.ofVoteEnded(1L, 100L, "테스트 투표", null, clock);
+            SliceImpl<Notification> slice = new SliceImpl<>(List.of(notification), PageRequest.ofSize(20), true);
+
+            given(notificationRepository.findPage(eq(1L), eq(50L), any(Instant.class), any(PageRequest.class)))
+                    .willReturn(slice);
+
+            NotificationPageResult result = service.getList(1L, 50L, 20);
+
+            assertThat(result.notifications()).hasSize(1);
+            assertThat(result.hasNext()).isTrue();
+            verify(notificationRepository).findPage(eq(1L), eq(50L), any(Instant.class), any(PageRequest.class));
+        }
+
+        @Test
+        @DisplayName("빈 목록을 반환할 수 있다")
+        void returns_empty_list() {
+            SliceImpl<Notification> slice = new SliceImpl<>(List.of(), PageRequest.ofSize(20), false);
+
+            given(notificationRepository.findPage(eq(1L), isNull(), any(Instant.class), any(PageRequest.class)))
+                    .willReturn(slice);
+
+            NotificationPageResult result = service.getList(1L, null, 20);
+
+            assertThat(result.notifications()).isEmpty();
+            assertThat(result.hasNext()).isFalse();
+            assertThat(result.nextCursor()).isNull();
+        }
+
+        @Test
+        @DisplayName("1개월 이내의 알림만 조회한다")
+        void filters_by_one_month() {
+            SliceImpl<Notification> slice = new SliceImpl<>(List.of(), PageRequest.ofSize(20), false);
+
+            given(notificationRepository.findPage(eq(1L), isNull(), any(Instant.class), any(PageRequest.class)))
+                    .willReturn(slice);
+
+            service.getList(1L, null, 20);
+
+            // 1개월 전 시점이 파라미터로 전달되었는지 확인
+            verify(notificationRepository).findPage(
+                    eq(1L),
+                    isNull(),
+                    eq(FIXED_INSTANT.minus(java.time.Duration.ofDays(30))),
+                    any(PageRequest.class)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("getUnreadCount")
+    class GetUnreadCount {
+
+        @Test
+        @DisplayName("읽지 않은 알림 개수를 반환한다")
+        void returns_unread_count() {
+            given(notificationRepository.countByUserIdAndIsReadFalse(1L)).willReturn(5L);
+
+            long result = service.getUnreadCount(1L);
+
+            assertThat(result).isEqualTo(5L);
+        }
+
+        @Test
+        @DisplayName("읽지 않은 알림이 없으면 0을 반환한다")
+        void returns_zero_when_no_unread() {
+            given(notificationRepository.countByUserIdAndIsReadFalse(1L)).willReturn(0L);
+
+            long result = service.getUnreadCount(1L);
+
+            assertThat(result).isEqualTo(0L);
+        }
+    }
+}

--- a/src/unitTest/java/com/ject/vs/vote/QaScenarioTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/QaScenarioTest.java
@@ -1,0 +1,689 @@
+package com.ject.vs.vote;
+
+import com.ject.vs.vote.adapter.web.dto.VoteDetailResponse;
+import com.ject.vs.vote.adapter.web.dto.VoteResultResponse;
+import com.ject.vs.vote.domain.*;
+import com.ject.vs.vote.exception.VoteFreeLimitExceededException;
+import com.ject.vs.vote.exception.VoteNotEndedException;
+import com.ject.vs.vote.exception.VoteNotFoundException;
+import com.ject.vs.vote.port.VoteDetailQueryService;
+import com.ject.vs.vote.port.VoteDetailQueryService.VoteDetailResult;
+import com.ject.vs.vote.port.in.VoteCommandUseCase.OptionResult;
+import com.ject.vs.vote.port.in.VoteResultQueryUseCase.VoteResultDetail;
+import com.ject.vs.vote.port.in.VoteResultQueryUseCase.Insight;
+import com.ject.vs.vote.port.in.VoteResultQueryUseCase.AiInsightView;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * QA 시나리오 검증 테스트
+ *
+ * QA 시트 기반으로 주요 API 응답이 올바른지 검증합니다.
+ * - TC-127~148: 일반형 투표
+ * - TC-149~156: 비회원 투표 제한
+ * - TC-166~188: 투표 결과
+ * - TC-189~211: 몰입형 투표
+ */
+class QaScenarioTest {
+
+    // ========================================
+    // TC-127~148: 일반형 투표 상세 응답 검증
+    // ========================================
+    @Nested
+    @DisplayName("TC-127~148: 일반형 투표 상세 조회")
+    class 일반형_투표_상세_조회 {
+
+        @Test
+        @DisplayName("TC-127: 진행중 투표 - 미투표시 득표수/비율 null")
+        void 진행중_투표_미투표시_득표수_비율_null() {
+            // Given: 진행중 투표, 사용자 미투표
+            VoteDetailResult result = new VoteDetailResult(
+                    1L, VoteType.GENERAL, "점심 뭐 먹을까?",
+                    Instant.parse("2025-01-01T00:00:00Z"), "내용",
+                    "thumb.png", null,
+                    VoteStatus.ONGOING,  // 진행중
+                    Instant.parse("2025-01-02T00:00:00Z"),
+                    100,
+                    List.of(
+                            new OptionResult(10L, "짜장면", 60L, 60),
+                            new OptionResult(11L, "짬뽕", 40L, 40)
+                    ),
+                    false,  // 미투표
+                    null,
+                    Map.of(),
+                    null,
+                    0
+            );
+
+            // When: Response 변환
+            VoteDetailResponse response = VoteDetailResponse.from(result);
+
+            // Then: 득표수/비율이 null
+            assertThat(response.options()).hasSize(2);
+            assertThat(response.options().get(0).voteCount()).isNull();
+            assertThat(response.options().get(0).ratio()).isNull();
+            assertThat(response.options().get(1).voteCount()).isNull();
+            assertThat(response.options().get(1).ratio()).isNull();
+            assertThat(response.myVote().voted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("TC-128: 진행중 투표 - 투표 후 득표수/비율 노출")
+        void 진행중_투표_투표후_득표수_비율_노출() {
+            // Given: 진행중 투표, 사용자 투표 완료
+            VoteDetailResult result = new VoteDetailResult(
+                    1L, VoteType.GENERAL, "점심 뭐 먹을까?",
+                    Instant.parse("2025-01-01T00:00:00Z"), "내용",
+                    "thumb.png", null,
+                    VoteStatus.ONGOING,  // 진행중
+                    Instant.parse("2025-01-02T00:00:00Z"),
+                    100,
+                    List.of(
+                            new OptionResult(10L, "짜장면", 60L, 60),
+                            new OptionResult(11L, "짬뽕", 40L, 40)
+                    ),
+                    true,  // 투표함
+                    10L,   // 짜장면 선택
+                    Map.of(VoteEmoji.LIKE, 5L, VoteEmoji.WOW, 3L, VoteEmoji.SAD, 0L, VoteEmoji.ANGRY, 0L),
+                    VoteEmoji.LIKE,
+                    0
+            );
+
+            // When: Response 변환
+            VoteDetailResponse response = VoteDetailResponse.from(result);
+
+            // Then: 득표수/비율 노출
+            assertThat(response.options()).hasSize(2);
+            assertThat(response.options().get(0).voteCount()).isEqualTo(60L);
+            assertThat(response.options().get(0).ratio()).isEqualTo(60);
+            assertThat(response.options().get(1).voteCount()).isEqualTo(40L);
+            assertThat(response.options().get(1).ratio()).isEqualTo(40);
+            assertThat(response.myVote().voted()).isTrue();
+            assertThat(response.myVote().selectedOptionId()).isEqualTo(10L);
+        }
+
+        @Test
+        @DisplayName("TC-166: 종료된 투표 - 미투표시에도 득표수/비율 노출 (핵심 버그 수정 검증)")
+        void 종료된_투표_미투표시에도_득표수_비율_노출() {
+            // Given: 종료된 투표, 사용자 미투표
+            VoteDetailResult result = new VoteDetailResult(
+                    1L, VoteType.GENERAL, "점심 뭐 먹을까?",
+                    Instant.parse("2025-01-01T00:00:00Z"), "내용",
+                    "thumb.png", null,
+                    VoteStatus.ENDED,  // 종료됨
+                    Instant.parse("2025-01-02T00:00:00Z"),
+                    100,
+                    List.of(
+                            new OptionResult(10L, "짜장면", 60L, 60),
+                            new OptionResult(11L, "짬뽕", 40L, 40)
+                    ),
+                    false,  // 미투표
+                    null,
+                    Map.of(VoteEmoji.LIKE, 10L, VoteEmoji.WOW, 5L, VoteEmoji.SAD, 2L, VoteEmoji.ANGRY, 1L),
+                    null,
+                    0
+            );
+
+            // When: Response 변환
+            VoteDetailResponse response = VoteDetailResponse.from(result);
+
+            // Then: 종료된 투표는 미투표시에도 득표수/비율 노출
+            assertThat(response.status()).isEqualTo("ENDED");
+            assertThat(response.options()).hasSize(2);
+            assertThat(response.options().get(0).voteCount()).isEqualTo(60L);
+            assertThat(response.options().get(0).ratio()).isEqualTo(60);
+            assertThat(response.options().get(1).voteCount()).isEqualTo(40L);
+            assertThat(response.options().get(1).ratio()).isEqualTo(40);
+            assertThat(response.myVote().voted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("TC-167: 종료된 투표 - 투표자도 결과 정상 노출")
+        void 종료된_투표_투표자_결과_정상_노출() {
+            // Given: 종료된 투표, 사용자 투표함
+            VoteDetailResult result = new VoteDetailResult(
+                    1L, VoteType.GENERAL, "점심 뭐 먹을까?",
+                    Instant.parse("2025-01-01T00:00:00Z"), "내용",
+                    "thumb.png", null,
+                    VoteStatus.ENDED,
+                    Instant.parse("2025-01-02T00:00:00Z"),
+                    100,
+                    List.of(
+                            new OptionResult(10L, "짜장면", 60L, 60),
+                            new OptionResult(11L, "짬뽕", 40L, 40)
+                    ),
+                    true,  // 투표함
+                    11L,   // 짬뽕 선택
+                    Map.of(VoteEmoji.LIKE, 10L, VoteEmoji.WOW, 5L, VoteEmoji.SAD, 2L, VoteEmoji.ANGRY, 1L),
+                    VoteEmoji.WOW,
+                    0
+            );
+
+            // When: Response 변환
+            VoteDetailResponse response = VoteDetailResponse.from(result);
+
+            // Then
+            assertThat(response.status()).isEqualTo("ENDED");
+            assertThat(response.options().get(0).voteCount()).isEqualTo(60L);
+            assertThat(response.options().get(1).voteCount()).isEqualTo(40L);
+            assertThat(response.myVote().voted()).isTrue();
+            assertThat(response.myVote().selectedOptionId()).isEqualTo(11L);
+            assertThat(response.myEmoji()).isEqualTo("WOW");
+        }
+
+        @Test
+        @DisplayName("TC-135: 이모지 요약 정상 반환")
+        void 이모지_요약_정상_반환() {
+            // Given
+            VoteDetailResult result = new VoteDetailResult(
+                    1L, VoteType.GENERAL, "제목",
+                    Instant.parse("2025-01-01T00:00:00Z"), null,
+                    "thumb.png", null,
+                    VoteStatus.ONGOING,
+                    Instant.parse("2025-01-02T00:00:00Z"),
+                    50,
+                    List.of(),
+                    true,
+                    10L,
+                    Map.of(
+                            VoteEmoji.LIKE, 100L,
+                            VoteEmoji.SAD, 50L,
+                            VoteEmoji.ANGRY, 25L,
+                            VoteEmoji.WOW, 10L
+                    ),
+                    VoteEmoji.LIKE,
+                    5
+            );
+
+            // When
+            VoteDetailResponse response = VoteDetailResponse.from(result);
+
+            // Then: 이모지 카운트 정확히 반환
+            assertThat(response.emojiSummary().LIKE()).isEqualTo(100L);
+            assertThat(response.emojiSummary().SAD()).isEqualTo(50L);
+            assertThat(response.emojiSummary().ANGRY()).isEqualTo(25L);
+            assertThat(response.emojiSummary().WOW()).isEqualTo(10L);
+            assertThat(response.myEmoji()).isEqualTo("LIKE");
+        }
+
+        @Test
+        @DisplayName("TC-141: 참여자수 정확히 반환")
+        void 참여자수_정확히_반환() {
+            // Given
+            VoteDetailResult result = new VoteDetailResult(
+                    1L, VoteType.GENERAL, "제목",
+                    Instant.parse("2025-01-01T00:00:00Z"), null,
+                    "thumb.png", null,
+                    VoteStatus.ONGOING,
+                    Instant.parse("2025-01-02T00:00:00Z"),
+                    12345,  // 참여자수
+                    List.of(),
+                    false,
+                    null,
+                    Map.of(),
+                    null,
+                    0
+            );
+
+            // When
+            VoteDetailResponse response = VoteDetailResponse.from(result);
+
+            // Then
+            assertThat(response.participantCount()).isEqualTo(12345);
+        }
+    }
+
+    // ========================================
+    // TC-149~156: 비회원 투표 제한 검증
+    // ========================================
+    @Nested
+    @DisplayName("TC-149~156: 비회원 투표 제한")
+    class 비회원_투표_제한 {
+
+        @Test
+        @DisplayName("TC-149: 신규 비회원은 5회 무료 투표 가능")
+        void 신규_비회원_5회_무료_투표() {
+            // Given
+            GuestFreeVote guest = GuestFreeVote.create("new-anonymous-id");
+            Clock clock = Clock.fixed(Instant.parse("2025-01-01T00:00:00Z"), ZoneOffset.UTC);
+
+            // Then: 초기 잔여 횟수 5
+            assertThat(guest.remaining()).isEqualTo(5);
+
+            // When: 1회 소진
+            guest.consume(clock);
+
+            // Then: 잔여 4회
+            assertThat(guest.remaining()).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("TC-153: 5회 소진 후 투표 시 예외 발생")
+        void 비회원_5회_소진후_예외() {
+            // Given
+            GuestFreeVote guest = GuestFreeVote.create("exhausted-anon");
+            Clock clock = Clock.fixed(Instant.parse("2025-01-01T00:00:00Z"), ZoneOffset.UTC);
+
+            // 5회 모두 소진
+            for (int i = 0; i < 5; i++) {
+                guest.consume(clock);
+            }
+
+            // Then: 잔여 0회
+            assertThat(guest.remaining()).isEqualTo(0);
+
+            // When & Then: 6번째 투표 시도 시 예외
+            org.junit.jupiter.api.Assertions.assertThrows(
+                    VoteFreeLimitExceededException.class,
+                    () -> guest.consume(clock)
+            );
+        }
+
+        @Test
+        @DisplayName("TC-155: 잔여 투표 횟수 정확히 반환")
+        void 잔여_투표_횟수_정확히_반환() {
+            // Given
+            GuestFreeVote guest = GuestFreeVote.create("anon-123");
+            Clock clock = Clock.fixed(Instant.parse("2025-01-01T00:00:00Z"), ZoneOffset.UTC);
+
+            // When: 3회 소진
+            guest.consume(clock);
+            guest.consume(clock);
+            guest.consume(clock);
+
+            // Then
+            assertThat(guest.getConsumedCount()).isEqualTo(3);
+            assertThat(guest.remaining()).isEqualTo(2);
+        }
+    }
+
+    // ========================================
+    // TC-166~188: 투표 결과 API 응답 검증
+    // ========================================
+    @Nested
+    @DisplayName("TC-166~188: 투표 결과 API")
+    class 투표_결과_API {
+
+        @Test
+        @DisplayName("TC-168: 비회원 - 인사이트 잠금, selectionCount만 표시")
+        void 비회원_인사이트_잠금() {
+            // Given: 비회원 투표 결과
+            Insight guestInsight = new Insight(
+                    true,  // locked
+                    InsightScope.TOTAL,
+                    100,   // selectionCount
+                    null,  // genderDistribution 잠금
+                    null   // ageDistribution 잠금
+            );
+            VoteResultDetail result = new VoteResultDetail(
+                    1L, "제목",
+                    Instant.parse("2025-01-01T00:00:00Z"), "내용",
+                    "thumb.png",
+                    VoteStatus.ENDED,
+                    Instant.parse("2025-01-02T00:00:00Z"),
+                    100,
+                    List.of(
+                            new OptionResult(10L, "옵션A", 60L, 60),
+                            new OptionResult(11L, "옵션B", 40L, 40)
+                    ),
+                    false,
+                    null,
+                    guestInsight,
+                    AiInsightView.unavailable()
+            );
+
+            // When
+            VoteResultResponse response = VoteResultResponse.from(result);
+
+            // Then: 인사이트 잠금 상태
+            assertThat(response.insight().locked()).isTrue();
+            assertThat(response.insight().selectionCount()).isEqualTo(100);
+            assertThat(response.insight().genderDistribution()).isNull();
+            assertThat(response.insight().ageDistribution()).isNull();
+            // 결과는 보임
+            assertThat(response.result().options()).hasSize(2);
+            assertThat(response.result().options().get(0).voteCount()).isEqualTo(60L);
+        }
+
+        @Test
+        @DisplayName("TC-170: 회원 참여자 - MY_SELECTION scope 인사이트")
+        void 회원_참여자_MY_SELECTION_인사이트() {
+            // Given
+            var genderDist = new com.ject.vs.vote.port.in.VoteResultQueryUseCase.GenderDistribution(
+                    60, 36L, 60, 24L, 40, "FEMALE"
+            );
+            var ageDist = List.of(
+                    new com.ject.vs.vote.port.in.VoteResultQueryUseCase.AgeDistribution("20대", 45, true),
+                    new com.ject.vs.vote.port.in.VoteResultQueryUseCase.AgeDistribution("30대", 35, false),
+                    new com.ject.vs.vote.port.in.VoteResultQueryUseCase.AgeDistribution("40대", 20, false)
+            );
+            Insight memberInsight = new Insight(
+                    false,  // unlocked
+                    InsightScope.MY_SELECTION,
+                    60,     // 내 선택 옵션 투표수
+                    genderDist,
+                    ageDist
+            );
+
+            VoteResultDetail result = new VoteResultDetail(
+                    1L, "제목",
+                    Instant.parse("2025-01-01T00:00:00Z"), null,
+                    "thumb.png",
+                    VoteStatus.ENDED,
+                    Instant.parse("2025-01-02T00:00:00Z"),
+                    100,
+                    List.of(
+                            new OptionResult(10L, "옵션A", 60L, 60),
+                            new OptionResult(11L, "옵션B", 40L, 40)
+                    ),
+                    true,
+                    10L,
+                    memberInsight,
+                    AiInsightView.unavailable()
+            );
+
+            // When
+            VoteResultResponse response = VoteResultResponse.from(result);
+
+            // Then: MY_SELECTION scope
+            assertThat(response.insight().locked()).isFalse();
+            assertThat(response.insight().scope()).isEqualTo("MY_SELECTION");
+            assertThat(response.insight().selectionCount()).isEqualTo(60);
+            assertThat(response.insight().genderDistribution()).isNotNull();
+            assertThat(response.insight().genderDistribution().highlightedGender()).isEqualTo("FEMALE");
+            assertThat(response.insight().ageDistribution()).hasSize(3);
+            assertThat(response.myVote().voted()).isTrue();
+            assertThat(response.myVote().selectedOptionId()).isEqualTo(10L);
+        }
+
+        @Test
+        @DisplayName("TC-175: 회원 미참여자 - TOTAL scope 인사이트")
+        void 회원_미참여자_TOTAL_인사이트() {
+            // Given
+            Insight nonParticipantInsight = new Insight(
+                    false,
+                    InsightScope.TOTAL,
+                    100,  // 전체 참여자수
+                    null,
+                    null
+            );
+
+            VoteResultDetail result = new VoteResultDetail(
+                    1L, "제목",
+                    Instant.parse("2025-01-01T00:00:00Z"), null,
+                    "thumb.png",
+                    VoteStatus.ENDED,
+                    Instant.parse("2025-01-02T00:00:00Z"),
+                    100,
+                    List.of(),
+                    false,  // 미참여
+                    null,
+                    nonParticipantInsight,
+                    AiInsightView.unavailable()
+            );
+
+            // When
+            VoteResultResponse response = VoteResultResponse.from(result);
+
+            // Then
+            assertThat(response.insight().scope()).isEqualTo("TOTAL");
+            assertThat(response.myVote().voted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("TC-180: AI 인사이트 있으면 available=true")
+        void AI_인사이트_available_true() {
+            // Given
+            AiInsightView aiInsight = AiInsightView.of(
+                    "20대 여성이 가장 많이 선택했어요!",
+                    "이 투표에서는 20대 여성의 참여가 두드러졌습니다. 전체 참여자의 45%가 20대이며..."
+            );
+
+            VoteResultDetail result = new VoteResultDetail(
+                    1L, "제목",
+                    Instant.parse("2025-01-01T00:00:00Z"), null,
+                    "thumb.png",
+                    VoteStatus.ENDED,
+                    Instant.parse("2025-01-02T00:00:00Z"),
+                    100,
+                    List.of(),
+                    true,
+                    10L,
+                    new Insight(false, InsightScope.MY_SELECTION, 60, null, null),
+                    aiInsight
+            );
+
+            // When
+            VoteResultResponse response = VoteResultResponse.from(result);
+
+            // Then
+            assertThat(response.aiInsight().available()).isTrue();
+            assertThat(response.aiInsight().headline()).isEqualTo("20대 여성이 가장 많이 선택했어요!");
+            assertThat(response.aiInsight().body()).contains("20대 여성의 참여가 두드러졌습니다");
+        }
+
+        @Test
+        @DisplayName("TC-181: AI 인사이트 없으면 available=false")
+        void AI_인사이트_unavailable() {
+            // Given
+            VoteResultDetail result = new VoteResultDetail(
+                    1L, "제목",
+                    Instant.parse("2025-01-01T00:00:00Z"), null,
+                    "thumb.png",
+                    VoteStatus.ENDED,
+                    Instant.parse("2025-01-02T00:00:00Z"),
+                    100,
+                    List.of(),
+                    false,
+                    null,
+                    new Insight(false, InsightScope.TOTAL, 100, null, null),
+                    AiInsightView.unavailable()
+            );
+
+            // When
+            VoteResultResponse response = VoteResultResponse.from(result);
+
+            // Then
+            assertThat(response.aiInsight().available()).isFalse();
+            assertThat(response.aiInsight().headline()).isNull();
+            assertThat(response.aiInsight().body()).isNull();
+        }
+    }
+
+    // ========================================
+    // TC-189~211: 몰입형 투표 응답 검증
+    // ========================================
+    @Nested
+    @DisplayName("TC-189~211: 몰입형 투표")
+    class 몰입형_투표 {
+
+        @Test
+        @DisplayName("TC-195: 득표율 계산 - A 75%, B 25%")
+        void 득표율_계산_정확성() {
+            // Given: A 3표, B 1표 = 총 4표
+            long totalVotes = 4;
+            long optionACount = 3;
+            long optionBCount = 1;
+
+            // When: 득표율 계산
+            int ratioA = (int) Math.round(optionACount * 100.0 / totalVotes);
+            int ratioB = (int) Math.round(optionBCount * 100.0 / totalVotes);
+
+            // Then
+            assertThat(ratioA).isEqualTo(75);
+            assertThat(ratioB).isEqualTo(25);
+            assertThat(ratioA + ratioB).isEqualTo(100);
+        }
+
+        @Test
+        @DisplayName("TC-196: 참여자 없으면 득표율 0%")
+        void 참여자_없으면_득표율_0() {
+            // Given
+            long total = 0;
+
+            // When
+            int ratio = total == 0 ? 0 : (int) Math.round(0 * 100.0 / total);
+
+            // Then
+            assertThat(ratio).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("TC-200: 반올림 - 33.33% → 33%, 66.67% → 67%")
+        void 반올림_처리() {
+            // Given: A 2표, B 1표 = 총 3표
+            long total = 3;
+            long optionACount = 2;
+            long optionBCount = 1;
+
+            // When
+            int ratioA = (int) Math.round(optionACount * 100.0 / total);
+            int ratioB = (int) Math.round(optionBCount * 100.0 / total);
+
+            // Then: 66.67 → 67, 33.33 → 33
+            assertThat(ratioA).isEqualTo(67);
+            assertThat(ratioB).isEqualTo(33);
+        }
+    }
+
+    // ========================================
+    // 응답 필드 검증
+    // ========================================
+    @Nested
+    @DisplayName("응답 필드 검증")
+    class 응답_필드_검증 {
+
+        @Test
+        @DisplayName("VoteDetailResponse 모든 필드 정상 매핑")
+        void VoteDetailResponse_필드_매핑() {
+            // Given
+            VoteDetailResult result = new VoteDetailResult(
+                    123L,
+                    VoteType.GENERAL,
+                    "오늘 점심 뭐 먹을까?",
+                    Instant.parse("2025-06-01T09:00:00Z"),
+                    "같이 투표해요!",
+                    "https://cdn.vs.app/thumb/123.jpg",
+                    "https://cdn.vs.app/img/123.jpg",
+                    VoteStatus.ONGOING,
+                    Instant.parse("2025-06-02T09:00:00Z"),
+                    500,
+                    List.of(
+                            new OptionResult(1L, "짜장면", 300L, 60),
+                            new OptionResult(2L, "짬뽕", 200L, 40)
+                    ),
+                    true,
+                    1L,
+                    Map.of(
+                            VoteEmoji.LIKE, 50L,
+                            VoteEmoji.WOW, 30L,
+                            VoteEmoji.SAD, 10L,
+                            VoteEmoji.ANGRY, 5L
+                    ),
+                    VoteEmoji.LIKE,
+                    25
+            );
+
+            // When
+            VoteDetailResponse response = VoteDetailResponse.from(result);
+
+            // Then: 모든 필드 검증
+            assertThat(response.voteId()).isEqualTo(123L);
+            assertThat(response.voteType()).isEqualTo(VoteType.GENERAL);
+            assertThat(response.title()).isEqualTo("오늘 점심 뭐 먹을까?");
+            assertThat(response.content()).isEqualTo("같이 투표해요!");
+            assertThat(response.thumbnailUrl()).isEqualTo("https://cdn.vs.app/thumb/123.jpg");
+            assertThat(response.status()).isEqualTo("ONGOING");
+            assertThat(response.participantCount()).isEqualTo(500);
+            assertThat(response.commentCount()).isEqualTo(25);
+
+            // 옵션 검증
+            assertThat(response.options()).hasSize(2);
+            assertThat(response.options().get(0).optionId()).isEqualTo(1L);
+            assertThat(response.options().get(0).label()).isEqualTo("짜장면");
+            assertThat(response.options().get(0).voteCount()).isEqualTo(300L);
+            assertThat(response.options().get(0).ratio()).isEqualTo(60);
+
+            // 내 투표 정보
+            assertThat(response.myVote().voted()).isTrue();
+            assertThat(response.myVote().selectedOptionId()).isEqualTo(1L);
+
+            // 이모지
+            assertThat(response.emojiSummary().LIKE()).isEqualTo(50L);
+            assertThat(response.emojiSummary().WOW()).isEqualTo(30L);
+            assertThat(response.myEmoji()).isEqualTo("LIKE");
+        }
+
+        @Test
+        @DisplayName("VoteResultResponse 모든 필드 정상 매핑")
+        void VoteResultResponse_필드_매핑() {
+            // Given
+            var genderDist = new com.ject.vs.vote.port.in.VoteResultQueryUseCase.GenderDistribution(
+                    100, 60L, 60, 40L, 40, "FEMALE"
+            );
+            var ageDist = List.of(
+                    new com.ject.vs.vote.port.in.VoteResultQueryUseCase.AgeDistribution("10대", 10, false),
+                    new com.ject.vs.vote.port.in.VoteResultQueryUseCase.AgeDistribution("20대", 50, true),
+                    new com.ject.vs.vote.port.in.VoteResultQueryUseCase.AgeDistribution("30대", 30, false),
+                    new com.ject.vs.vote.port.in.VoteResultQueryUseCase.AgeDistribution("40대", 10, false)
+            );
+
+            VoteResultDetail result = new VoteResultDetail(
+                    456L,
+                    "어떤 게 더 좋아?",
+                    Instant.parse("2025-05-01T12:00:00Z"),
+                    "투표 내용입니다",
+                    "https://cdn.vs.app/thumb/456.jpg",
+                    VoteStatus.ENDED,
+                    Instant.parse("2025-05-02T12:00:00Z"),
+                    1000,
+                    List.of(
+                            new OptionResult(10L, "옵션1", 600L, 60),
+                            new OptionResult(11L, "옵션2", 400L, 40)
+                    ),
+                    true,
+                    10L,
+                    new Insight(false, InsightScope.MY_SELECTION, 600, genderDist, ageDist),
+                    AiInsightView.of("인사이트 제목", "인사이트 본문")
+            );
+
+            // When
+            VoteResultResponse response = VoteResultResponse.from(result);
+
+            // Then
+            assertThat(response.voteId()).isEqualTo(456L);
+            assertThat(response.title()).isEqualTo("어떤 게 더 좋아?");
+            assertThat(response.status()).isEqualTo("ENDED");
+            assertThat(response.participantCount()).isEqualTo(1000);
+
+            // 결과 옵션
+            assertThat(response.result().options()).hasSize(2);
+            assertThat(response.result().options().get(0).voteCount()).isEqualTo(600L);
+            assertThat(response.result().options().get(0).ratio()).isEqualTo(60);
+
+            // 내 투표
+            assertThat(response.myVote().voted()).isTrue();
+            assertThat(response.myVote().selectedOptionId()).isEqualTo(10L);
+
+            // 인사이트
+            assertThat(response.insight().locked()).isFalse();
+            assertThat(response.insight().scope()).isEqualTo("MY_SELECTION");
+            assertThat(response.insight().selectionCount()).isEqualTo(600);
+            assertThat(response.insight().genderDistribution().highlightedGender()).isEqualTo("FEMALE");
+            assertThat(response.insight().ageDistribution()).hasSize(4);
+
+            // AI 인사이트
+            assertThat(response.aiInsight().available()).isTrue();
+            assertThat(response.aiInsight().headline()).isEqualTo("인사이트 제목");
+        }
+    }
+}

--- a/src/unitTest/java/com/ject/vs/vote/adapter/web/VoteControllerTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/adapter/web/VoteControllerTest.java
@@ -285,5 +285,53 @@ class VoteControllerTest {
                     .andExpect(jsonPath("$.myVote.selectedOptionId").value(10))
                     .andExpect(jsonPath("$.myEmoji").value("WOW"));
         }
+
+        @Test
+        @WithMockUser
+        void 종료된_투표_미투표시에도_voteCount_노출() throws Exception {
+            List<OptionResult> options = List.of(
+                    new OptionResult(10L, "짜장면", 60L, 60),
+                    new OptionResult(11L, "짬뽕", 40L, 40)
+            );
+            VoteDetailResult result = new VoteDetailResult(
+                    1L, VoteType.GENERAL, "점심 뭐 먹을까?", Instant.parse("2025-01-01T00:00:00Z"),
+                    "내용", "thumb.png", null, VoteStatus.ENDED, Instant.parse("2025-01-02T00:00:00Z"),
+                    100, options, false, null, Map.of(), null, 0
+            );
+            given(voteDetailQueryService.getDetail(eq(1L), any(), any())).willReturn(result);
+
+            mockMvc.perform(get("/api/votes/1"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("ENDED"))
+                    .andExpect(jsonPath("$.myVote.voted").value(false))
+                    .andExpect(jsonPath("$.options[0].voteCount").value(60))
+                    .andExpect(jsonPath("$.options[0].ratio").value(60))
+                    .andExpect(jsonPath("$.options[1].voteCount").value(40))
+                    .andExpect(jsonPath("$.options[1].ratio").value(40));
+        }
+
+        @Test
+        @WithMockUser
+        void 진행중_투표_미투표시_voteCount는_null() throws Exception {
+            List<OptionResult> options = List.of(
+                    new OptionResult(10L, "짜장면", 60L, 60),
+                    new OptionResult(11L, "짬뽕", 40L, 40)
+            );
+            VoteDetailResult result = new VoteDetailResult(
+                    1L, VoteType.GENERAL, "점심 뭐 먹을까?", Instant.parse("2025-01-01T00:00:00Z"),
+                    "내용", "thumb.png", null, VoteStatus.ONGOING, Instant.parse("2025-01-02T00:00:00Z"),
+                    100, options, false, null, Map.of(), null, 0
+            );
+            given(voteDetailQueryService.getDetail(eq(1L), any(), any())).willReturn(result);
+
+            mockMvc.perform(get("/api/votes/1"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("ONGOING"))
+                    .andExpect(jsonPath("$.myVote.voted").value(false))
+                    .andExpect(jsonPath("$.options[0].voteCount").doesNotExist())
+                    .andExpect(jsonPath("$.options[0].ratio").doesNotExist())
+                    .andExpect(jsonPath("$.options[1].voteCount").doesNotExist())
+                    .andExpect(jsonPath("$.options[1].ratio").doesNotExist());
+        }
     }
 }

--- a/src/unitTest/java/com/ject/vs/vote/port/VoteDetailQueryServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/port/VoteDetailQueryServiceTest.java
@@ -1,0 +1,220 @@
+package com.ject.vs.vote.port;
+
+import com.ject.vs.vote.domain.*;
+import com.ject.vs.vote.exception.VoteNotFoundException;
+import com.ject.vs.vote.port.VoteDetailQueryService.VoteDetailResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class VoteDetailQueryServiceTest {
+
+    @Mock VoteRepository voteRepository;
+    @Mock VoteOptionRepository voteOptionRepository;
+    @Mock VoteParticipationRepository voteParticipationRepository;
+    @Mock VoteEmojiReactionRepository emojiReactionRepository;
+
+    private VoteDetailQueryService service;
+
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2025-06-01T12:00:00Z"), ZoneOffset.UTC);
+
+    private Vote ongoingVote;
+    private Vote endedVote;
+
+    @BeforeEach
+    void setUp() {
+        service = new VoteDetailQueryService(
+                voteRepository, voteOptionRepository, voteParticipationRepository, emojiReactionRepository, CLOCK);
+
+        // 진행중 투표 (현재 시간 기준 24시간 후 종료)
+        Clock recentClock = Clock.fixed(Instant.parse("2025-06-01T00:00:00Z"), ZoneOffset.UTC);
+        ongoingVote = Vote.create(VoteType.GENERAL, "진행중 투표", null, "thumb.png", null,
+                Duration.ofHours(24), recentClock);
+
+        // 종료된 투표 (현재 시간 기준 이미 종료)
+        Clock pastClock = Clock.fixed(Instant.parse("2025-05-30T00:00:00Z"), ZoneOffset.UTC);
+        endedVote = Vote.create(VoteType.GENERAL, "종료된 투표", null, "thumb.png", null,
+                Duration.ofHours(24), pastClock);
+    }
+
+    @Nested
+    @DisplayName("getDetail 메서드")
+    class getDetail {
+
+        @Test
+        @DisplayName("존재하지 않는 투표 조회 시 예외 발생")
+        void 존재하지_않는_투표_예외() {
+            given(voteRepository.findById(99L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getDetail(99L, null, null))
+                    .isInstanceOf(VoteNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("진행중 투표 - 상태가 ONGOING")
+        void 진행중_투표_상태_ONGOING() {
+            given(voteRepository.findById(1L)).willReturn(Optional.of(ongoingVote));
+            given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of());
+            given(voteParticipationRepository.countByVoteId(1L)).willReturn(0L);
+            given(emojiReactionRepository.countByEmojiForVote(1L)).willReturn(List.of());
+
+            VoteDetailResult result = service.getDetail(1L, null, null);
+
+            assertThat(result.status()).isEqualTo(VoteStatus.ONGOING);
+        }
+
+        @Test
+        @DisplayName("종료된 투표 - 상태가 ENDED")
+        void 종료된_투표_상태_ENDED() {
+            given(voteRepository.findById(1L)).willReturn(Optional.of(endedVote));
+            given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of());
+            given(voteParticipationRepository.countByVoteId(1L)).willReturn(0L);
+            given(emojiReactionRepository.countByEmojiForVote(1L)).willReturn(List.of());
+
+            VoteDetailResult result = service.getDetail(1L, null, null);
+
+            assertThat(result.status()).isEqualTo(VoteStatus.ENDED);
+        }
+
+        @Test
+        @DisplayName("회원 투표 참여 정보 조회")
+        void 회원_투표_참여_정보_조회() {
+            given(voteRepository.findById(1L)).willReturn(Optional.of(ongoingVote));
+            given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of());
+            given(voteParticipationRepository.countByVoteId(1L)).willReturn(10L);
+            given(emojiReactionRepository.countByEmojiForVote(1L)).willReturn(List.of());
+
+            VoteParticipation participation = VoteParticipation.ofMember(1L, 42L, 10L);
+            given(voteParticipationRepository.findByVoteIdAndUserId(1L, 42L))
+                    .willReturn(Optional.of(participation));
+            given(emojiReactionRepository.findByVoteIdAndUserId(1L, 42L)).willReturn(Optional.empty());
+
+            VoteDetailResult result = service.getDetail(1L, 42L, null);
+
+            assertThat(result.voted()).isTrue();
+            assertThat(result.mySelectedOptionId()).isEqualTo(10L);
+        }
+
+        @Test
+        @DisplayName("비회원 투표 참여 정보 조회 (anonymousId)")
+        void 비회원_투표_참여_정보_조회() {
+            given(voteRepository.findById(1L)).willReturn(Optional.of(ongoingVote));
+            given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of());
+            given(voteParticipationRepository.countByVoteId(1L)).willReturn(5L);
+            given(emojiReactionRepository.countByEmojiForVote(1L)).willReturn(List.of());
+
+            VoteParticipation participation = VoteParticipation.ofGuest(1L, "anon-123", 20L);
+            given(voteParticipationRepository.findByVoteIdAndAnonymousId(1L, "anon-123"))
+                    .willReturn(Optional.of(participation));
+            given(emojiReactionRepository.findByVoteIdAndAnonymousId(1L, "anon-123")).willReturn(Optional.empty());
+
+            VoteDetailResult result = service.getDetail(1L, null, "anon-123");
+
+            assertThat(result.voted()).isTrue();
+            assertThat(result.mySelectedOptionId()).isEqualTo(20L);
+        }
+
+        @Test
+        @DisplayName("미투표시 voted=false, mySelectedOptionId=null")
+        void 미투표시_정보() {
+            given(voteRepository.findById(1L)).willReturn(Optional.of(ongoingVote));
+            given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of());
+            given(voteParticipationRepository.countByVoteId(1L)).willReturn(0L);
+            given(emojiReactionRepository.countByEmojiForVote(1L)).willReturn(List.of());
+
+            VoteDetailResult result = service.getDetail(1L, null, null);
+
+            assertThat(result.voted()).isFalse();
+            assertThat(result.mySelectedOptionId()).isNull();
+        }
+
+        @Test
+        @DisplayName("옵션별 득표수와 비율 계산")
+        void 옵션별_득표수_비율_계산() {
+            given(voteRepository.findById(1L)).willReturn(Optional.of(ongoingVote));
+
+            Vote dummyVote = ongoingVote;
+            VoteOption optA = VoteOption.of(dummyVote, "짜장면", 1);
+            VoteOption optB = VoteOption.of(dummyVote, "짬뽕", 2);
+            given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of(optA, optB));
+
+            given(voteParticipationRepository.countByVoteId(1L)).willReturn(100L);
+            given(voteParticipationRepository.countByVoteIdAndOptionId(eq(1L), any()))
+                    .willReturn(60L, 40L);
+            given(emojiReactionRepository.countByEmojiForVote(1L)).willReturn(List.of());
+
+            VoteDetailResult result = service.getDetail(1L, null, null);
+
+            assertThat(result.participantCount()).isEqualTo(100);
+            assertThat(result.options()).hasSize(2);
+            assertThat(result.options().get(0).label()).isEqualTo("짜장면");
+            assertThat(result.options().get(0).voteCount()).isEqualTo(60L);
+            assertThat(result.options().get(0).ratio()).isEqualTo(60);
+            assertThat(result.options().get(1).label()).isEqualTo("짬뽕");
+            assertThat(result.options().get(1).voteCount()).isEqualTo(40L);
+            assertThat(result.options().get(1).ratio()).isEqualTo(40);
+        }
+
+        @Test
+        @DisplayName("참여자 없으면 비율 0")
+        void 참여자_없으면_비율_0() {
+            given(voteRepository.findById(1L)).willReturn(Optional.of(ongoingVote));
+
+            VoteOption optA = VoteOption.of(ongoingVote, "옵션A", 1);
+            given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of(optA));
+
+            given(voteParticipationRepository.countByVoteId(1L)).willReturn(0L);
+            given(voteParticipationRepository.countByVoteIdAndOptionId(eq(1L), any())).willReturn(0L);
+            given(emojiReactionRepository.countByEmojiForVote(1L)).willReturn(List.of());
+
+            VoteDetailResult result = service.getDetail(1L, null, null);
+
+            assertThat(result.participantCount()).isEqualTo(0);
+            assertThat(result.options().get(0).ratio()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("이모지 반응 조회 - 회원")
+        void 이모지_반응_조회_회원() {
+            given(voteRepository.findById(1L)).willReturn(Optional.of(ongoingVote));
+            given(voteOptionRepository.findByVoteIdOrderByPosition(1L)).willReturn(List.of());
+            given(voteParticipationRepository.countByVoteId(1L)).willReturn(0L);
+
+            List<EmoijCount> emojiCounts = List.of(
+                    new EmoijCount(VoteEmoji.LIKE, 50L),
+                    new EmoijCount(VoteEmoji.WOW, 30L)
+            );
+            given(emojiReactionRepository.countByEmojiForVote(1L)).willReturn(emojiCounts);
+
+            VoteEmojiReaction myReaction = VoteEmojiReaction.ofMember(1L, 42L, VoteEmoji.LIKE);
+            given(emojiReactionRepository.findByVoteIdAndUserId(1L, 42L))
+                    .willReturn(Optional.of(myReaction));
+
+            VoteDetailResult result = service.getDetail(1L, 42L, null);
+
+            assertThat(result.emojiSummary().get(VoteEmoji.LIKE)).isEqualTo(50L);
+            assertThat(result.emojiSummary().get(VoteEmoji.WOW)).isEqualTo(30L);
+            assertThat(result.emojiSummary().get(VoteEmoji.SAD)).isEqualTo(0L);
+            assertThat(result.emojiSummary().get(VoteEmoji.ANGRY)).isEqualTo(0L);
+            assertThat(result.myEmoji()).isEqualTo(VoteEmoji.LIKE);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
  - closes #

  ## 🔍 작업 내용
  QA/테스트용으로 어드민이 특정 사용자에게 푸시 알림을 강제 발송할 수 있는 API를 추가했습니 다.

  ## 📝 변경 사항
  - `POST /api/admin/push/test`: 어드민 전용 테스트 푸시 알림 발송 API 추가
  - `AdminPushService`: 어드민 권한 검증 및 커스텀 알림 발송 로직 구현
  - `Notification.ofCustom()`: 커스텀 title, body를 지정할 수 있는 알림 생성 메서드 추가    
  - `GlobalExceptionHandler`: `IllegalArgumentException` 핸들러 추가 (어드민 권한 오류 처리)
  - `QaScenarioTest`: QA 시트 기반 주요 API 응답 검증 테스트 (TC-127~211) 추가
  - `VoteDetailQueryServiceTest`: 투표 상세 쿼리 서비스 단위 테스트 추가
  - `VoteControllerTest`: 종료된 투표 미투표자 결과 노출, 진행중 투표 미투표자 결과 숨김 테 스트 추가

  ## 💬 리뷰어에게
  - `AdminPushService.validateAdmin()`에서 `AdminProperties.userIds()`를 사용해 어드민 권한 을 검증합니다
  - 기존 알림 발송 이벤트(`NotificationCreatedEvent`)를 재사용하여 실제 FCM 푸시까지 동작합 니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 관리자 전용 테스트 푸시 알림 발송 기능 추가
  * 마감된 투표의 결과(득표수/비율) 표시 개선

* **Bug Fixes**
  * 잘못된 입력값에 대한 예외 처리 강화 (HTTP 400 응답)

* **Tests**
  * 관리자 푸시 알림, 알림 조회/읽음 처리, 투표 상세 응답, 푸시 발송 이벤트 등 다양한 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->