### PR TITLE
fix: /api/home/votes ENDING_SOON 첫 페이지 500 오류 수정 및 통합테스트 Testcontainers 전환

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,14 @@ dependencies {
 	testImplementation(Dependencies.SpringBoot.TEST)
 	testImplementation(Dependencies.SpringSecurity.TEST)
 	testRuntimeOnly(Dependencies.Test.JUNIT_LAUNCHER)
+
+	// Testcontainers (for Postgres-specific integration tests)
+	"integrationTestImplementation"("org.testcontainers:testcontainers:1.21.3")
+	"integrationTestImplementation"("org.testcontainers:junit-jupiter:1.21.3")
+	"integrationTestImplementation"("org.testcontainers:postgresql:1.21.3")
+
+	// Spring Boot official Testcontainers support
+	"integrationTestImplementation"("org.springframework.boot:spring-boot-testcontainers:3.5.11")
 }
 
 tasks.withType<Test> {
@@ -113,10 +121,15 @@ val unitTest by tasks.registering(Test::class) {
 
 val integrationTest by tasks.registering(Test::class) {
 	group = LifecycleBasePlugin.VERIFICATION_GROUP
-	description = "Runs integration tests."
+	description = "Runs integration tests. (Testcontainers 기반 실제 PostgreSQL 사용)"
 	testClassesDirs = sourceSets["integrationTest"].output.classesDirs
 	classpath = sourceSets["integrationTest"].runtimeClasspath
 	shouldRunAfter(unitTest)
+
+	// Docker가 없는 환경에서 통합 테스트를 건너뛰기 위한 옵션
+	onlyIf {
+		!project.hasProperty("skipIntegrationTests")
+	}
 }
 
 tasks.check {

--- a/src/integrationTest/java/com/ject/vs/support/BaseIntegrationTest.java
+++ b/src/integrationTest/java/com/ject/vs/support/BaseIntegrationTest.java
@@ -1,12 +1,18 @@
 package com.ject.vs.support;
 
 import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Assumptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -16,17 +22,24 @@ import static org.mockito.Mockito.when;
 
 /**
  * Integration Test의 공통 설정을 담당하는 추상 클래스.
- * - Spring Context 로드
- * - Test 프로필 활성화
- * - 트랜잭션 롤백
- * - Clock 고정 (테스트에서 시간에 의존하는 로직을 제어하기 위함)
+ *
+ * 통합 테스트는 Testcontainers 기반 실제 PostgreSQL 위에서 실행됩니다.
  */
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
+@Testcontainers
 public abstract class BaseIntegrationTest {
 
     protected static final Instant FIXED_NOW = Instant.parse("2025-06-01T12:00:00Z");
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("vs_integration_test")
+                    .withUsername("test")
+                    .withPassword("test");
 
     @Autowired
     protected EntityManager entityManager;
@@ -38,5 +51,16 @@ public abstract class BaseIntegrationTest {
     void setUpBaseClock() {
         when(clock.instant()).thenReturn(FIXED_NOW);
         when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+    }
+
+    @BeforeAll
+    static void ensureContainerOrSkip() {
+        try {
+            if (!POSTGRES.isRunning()) {
+                POSTGRES.start();
+            }
+        } catch (Exception ex) {
+            Assumptions.abort("Docker를 사용할 수 없어 Testcontainers 기반 통합 테스트를 건너뜁니다: " + ex.getMessage());
+        }
     }
 }

--- a/src/integrationTest/java/com/ject/vs/support/VoteIntegrationTestSupport.java
+++ b/src/integrationTest/java/com/ject/vs/support/VoteIntegrationTestSupport.java
@@ -8,7 +8,7 @@ import java.time.Instant;
 
 /**
  * Vote 도메인 관련 Integration Test에서 공통으로 사용하는 테스트 데이터 생성 지원 클래스.
- * BaseIntegrationTest를 상속받아 시간 제어 기능도 함께 제공한다.
+ * BaseIntegrationTest를 상속받아 실제 PostgreSQL(Testcontainers) + 시간 제어 기능을 제공한다.
  */
 public abstract class VoteIntegrationTestSupport extends BaseIntegrationTest {
 

--- a/src/main/java/com/ject/vs/home/port/HomeVoteQueryService.java
+++ b/src/main/java/com/ject/vs/home/port/HomeVoteQueryService.java
@@ -147,13 +147,21 @@ public class HomeVoteQueryService implements HomeVoteQueryUseCase {
                 );
             }
             case ENDING_SOON -> {
-                EndingSoonCursor endingCursor = parseEndingSoonCursor(cursor);
-                yield voteRepository.findForHomeByEndingSoonWithKeyset(
-                        endingCursor.lastEndAt(),
-                        endingCursor.lastId(),
-                        now,
-                        pageable
-                );
+                if (cursor == null || cursor.isBlank()) {
+                    yield voteRepository.findFirstPageForHomeByEndingSoon(now, pageable);
+                } else {
+                    EndingSoonCursor endingCursor = parseEndingSoonCursor(cursor);
+                    if (endingCursor.lastEndAt() == null || endingCursor.lastId() == null) {
+                        yield voteRepository.findFirstPageForHomeByEndingSoon(now, pageable);
+                    } else {
+                        yield voteRepository.findForHomeByEndingSoonWithKeyset(
+                                endingCursor.lastEndAt(),
+                                endingCursor.lastId(),
+                                now,
+                                pageable
+                        );
+                    }
+                }
             }
         };
 

--- a/src/main/java/com/ject/vs/vote/domain/VoteRepository.java
+++ b/src/main/java/com/ject/vs/vote/domain/VoteRepository.java
@@ -134,13 +134,26 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
     );
 
     /**
-     * 종료임박순 Keyset Pagination 전용 (복합 커서)
+     * 종료임박순 - 첫 페이지 전용 (cursor 없음)
+     * null 커서 파라미터 + IS NULL 표현식을 제거하여 Postgres/Neon 환경에서 안정적으로 동작하게 함.
      */
     @Query("""
         SELECT v FROM Vote v
         WHERE v.endAt > :now
-          AND (:lastEndAt IS NULL 
-               OR v.endAt > :lastEndAt 
+        ORDER BY v.endAt ASC, v.id ASC
+        """)
+    Slice<Vote> findFirstPageForHomeByEndingSoon(
+            @Param("now") Instant now,
+            Pageable pageable
+    );
+
+    /**
+     * 종료임박순 Keyset Pagination 전용 (복합 커서, 두 번째 페이지 이후)
+     */
+    @Query("""
+        SELECT v FROM Vote v
+        WHERE v.endAt > :now
+          AND (v.endAt > :lastEndAt 
                OR (v.endAt = :lastEndAt AND v.id > :lastId))
         ORDER BY v.endAt ASC, v.id ASC
         """)


### PR DESCRIPTION
## 문제
- `GET /api/home/votes?sort=ENDING_SOON&excludeEnded=true&size=10` 요청 시 첫 페이지에서 500 Internal Server Error 발생
- cursor 없이 호출하는 경우에만 재현됨

## 원인
- `findForHomeByEndingSoonWithKeyset(null, null, ...)` 호출 시
- JPQL 내 `(:lastEndAt IS NULL OR ...)` 패턴이 Postgres 환경에서 nullable `Instant` 파라미터와 함께 사용될 때 호환성 이슈 발생 (H2에서는 정상 동작)

## 해결
- ENDING_SOON 첫 페이지 전용 쿼리 추가 (`findFirstPageForHomeByEndingSoon`)
- `HomeVoteQueryService`에서 cursor 유무에 따라 명확히 분기 처리
- malformed cursor 입력 시에도 기존 정책대로 안전하게 첫 페이지로 fallback

## 테스트 개선
- `BaseIntegrationTest`를 H2 → **Testcontainers + PostgreSQL**로 전환
- `@Container` + `@ServiceConnection` 사용
- 실제 운영 환경(Neon Postgres)과 유사한 조건에서 테스트 가능해짐

## 기타
- Docker가 없는 환경에서 통합 테스트를 건너뛰기 위한 `-PskipIntegrationTests` 옵션 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 통합 테스트 환경에 실제 PostgreSQL 데이터베이스 기반 테스트 구성 추가

* **Bug Fixes**
  * 홈 화면의 "종료임박순" 정렬 기능에서 커서 처리 로직 개선 및 페이지네이션 성능 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->