### PR TITLE
Refactor/remove vote type

### DIFF
--- a/src/integrationTest/java/com/ject/vs/support/VoteIntegrationTestSupport.java
+++ b/src/integrationTest/java/com/ject/vs/support/VoteIntegrationTestSupport.java
@@ -20,7 +20,6 @@ public abstract class VoteIntegrationTestSupport extends BaseIntegrationTest {
 
     protected Vote createOngoingVote(String title) {
         Vote vote = Vote.create(
-                VoteType.GENERAL,
                 title,
                 "content for " + title,
                 "https://example.com/thumb.jpg",

--- a/src/main/java/com/ject/vs/chat/adapter/web/dto/GaugeResponse.java
+++ b/src/main/java/com/ject/vs/chat/adapter/web/dto/GaugeResponse.java
@@ -5,6 +5,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "투표 게이지 응답")
 public record GaugeResponse(
+        @Schema(description = "투표 ID", example = "1")
+        Long voteId,
+
         @Schema(description = "A 선택지 투표 비율. 0부터 100까지의 정수입니다.", example = "55", minimum = "0", maximum = "100")
         int optionARatio,
 
@@ -16,6 +19,6 @@ public record GaugeResponse(
 ) {
 
     public static GaugeResponse from(GaugeResult result) {
-        return new GaugeResponse(result.optionARatio(), result.optionBRatio(), result.participantCount());
+        return new GaugeResponse(result.voteId(), result.optionARatio(), result.optionBRatio(), result.participantCount());
     }
 }

--- a/src/main/java/com/ject/vs/chat/port/ChatService.java
+++ b/src/main/java/com/ject/vs/chat/port/ChatService.java
@@ -116,7 +116,7 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
     @Transactional(readOnly = true)
     public GaugeResult getGauge(Long voteId) {
         VoteQueryUseCase.VoteRatio ratio = voteQueryUseCase.getRatio(voteId);
-        return new GaugeResult(ratio.optionARatio(), ratio.optionBRatio(), ratio.participantCount());
+        return new GaugeResult(voteId, ratio.optionARatio(), ratio.optionBRatio(), ratio.participantCount());
     }
 
     @Override

--- a/src/main/java/com/ject/vs/chat/port/in/dto/GaugeResult.java
+++ b/src/main/java/com/ject/vs/chat/port/in/dto/GaugeResult.java
@@ -1,3 +1,3 @@
 package com.ject.vs.chat.port.in.dto;
 
-public record GaugeResult(int optionARatio, int optionBRatio, int participantCount) {}
+public record GaugeResult(Long voteId, int optionARatio, int optionBRatio, int participantCount) {}

--- a/src/main/java/com/ject/vs/home/adapter/web/dto/HomeHotTopicResponse.java
+++ b/src/main/java/com/ject/vs/home/adapter/web/dto/HomeHotTopicResponse.java
@@ -1,7 +1,6 @@
 package com.ject.vs.home.adapter.web.dto;
 
 import com.ject.vs.home.port.in.HomeVoteQueryUseCase.HotTopicResult;
-import com.ject.vs.vote.domain.VoteType;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -14,7 +13,6 @@ public record HomeHotTopicResponse(List<HotTopicItem> hotTopics) {
             int rank,
             Long voteId,
             String thumbnailUrl,
-            VoteType voteType,
             String title,
             String content,
             long participantCount,
@@ -32,7 +30,6 @@ public record HomeHotTopicResponse(List<HotTopicItem> hotTopics) {
                         i.rank(),
                         i.voteId(),
                         i.thumbnailUrl(),
-                        i.voteType(),
                         i.title(),
                         i.content(),
                         i.participantCount(),

--- a/src/main/java/com/ject/vs/home/adapter/web/dto/HomeRecommendationResponse.java
+++ b/src/main/java/com/ject/vs/home/adapter/web/dto/HomeRecommendationResponse.java
@@ -1,7 +1,6 @@
 package com.ject.vs.home.adapter.web.dto;
 
 import com.ject.vs.home.port.in.HomeVoteQueryUseCase.RecommendationResult;
-import com.ject.vs.vote.domain.VoteType;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -13,7 +12,6 @@ public record HomeRecommendationResponse(List<RecommendationItem> recommendation
     public record RecommendationItem(
             Long voteId,
             String thumbnailUrl,
-            VoteType voteType,
             String title,
             String content,
             OffsetDateTime endAt
@@ -29,7 +27,6 @@ public record HomeRecommendationResponse(List<RecommendationItem> recommendation
                 .map(i -> new RecommendationItem(
                         i.voteId(),
                         i.thumbnailUrl(),
-                        i.voteType(),
                         i.title(),
                         i.content(),
                         toKst(i.endAt())

--- a/src/main/java/com/ject/vs/home/adapter/web/dto/HomeVoteListResponse.java
+++ b/src/main/java/com/ject/vs/home/adapter/web/dto/HomeVoteListResponse.java
@@ -2,7 +2,6 @@ package com.ject.vs.home.adapter.web.dto;
 
 import com.ject.vs.home.port.in.HomeVoteQueryUseCase.VoteListResult;
 import com.ject.vs.vote.domain.VoteStatus;
-import com.ject.vs.vote.domain.VoteType;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -19,7 +18,6 @@ public record HomeVoteListResponse(
             Long voteId,
             String thumbnailUrl,
             VoteStatus status,
-            VoteType voteType,
             String title,
             String content,
             OffsetDateTime endAt
@@ -36,7 +34,6 @@ public record HomeVoteListResponse(
                         i.voteId(),
                         i.thumbnailUrl(),
                         i.status(),
-                        i.voteType(),
                         i.title(),
                         i.content(),
                         toKst(i.endAt())

--- a/src/main/java/com/ject/vs/home/port/HomeVoteQueryService.java
+++ b/src/main/java/com/ject/vs/home/port/HomeVoteQueryService.java
@@ -44,7 +44,6 @@ public class HomeVoteQueryService implements HomeVoteQueryUseCase {
                     return new RecommendationItem(
                             vote.getId(),
                             vote.getThumbnailUrl(),
-                            vote.getType(),
                             vote.getTitle(),
                             vote.getContent(),
                             vote.getEndAt()
@@ -113,7 +112,6 @@ public class HomeVoteQueryService implements HomeVoteQueryUseCase {
                     i + 1,
                     vote.getId(),
                     vote.getThumbnailUrl(),
-                    vote.getType(),
                     vote.getTitle(),
                     vote.getContent(),
                     participantCounts.getOrDefault(vote.getId(), 0L),
@@ -172,7 +170,6 @@ public class HomeVoteQueryService implements HomeVoteQueryUseCase {
                         vote.getId(),
                         vote.getThumbnailUrl(),
                         vote.getStatus(clock),
-                        vote.getType(),
                         vote.getTitle(),
                         vote.getContent(),
                         vote.getEndAt()

--- a/src/main/java/com/ject/vs/home/port/in/HomeVoteQueryUseCase.java
+++ b/src/main/java/com/ject/vs/home/port/in/HomeVoteQueryUseCase.java
@@ -1,7 +1,6 @@
 package com.ject.vs.home.port.in;
 
 import com.ject.vs.vote.domain.VoteStatus;
-import com.ject.vs.vote.domain.VoteType;
 
 import java.time.Instant;
 import java.util.List;
@@ -27,7 +26,6 @@ public interface HomeVoteQueryUseCase {
     record RecommendationItem(
             Long voteId,
             String thumbnailUrl,
-            VoteType voteType,
             String title,
             String content,
             Instant endAt
@@ -42,7 +40,6 @@ public interface HomeVoteQueryUseCase {
             int rank,
             Long voteId,
             String thumbnailUrl,
-            VoteType voteType,
             String title,
             String content,
             long participantCount,
@@ -62,7 +59,6 @@ public interface HomeVoteQueryUseCase {
             Long voteId,
             String thumbnailUrl,
             VoteStatus status,
-            VoteType voteType,
             String title,
             String content,
             Instant endAt

--- a/src/main/java/com/ject/vs/vote/adapter/web/dto/MyParticipatedVoteResponse.java
+++ b/src/main/java/com/ject/vs/vote/adapter/web/dto/MyParticipatedVoteResponse.java
@@ -1,7 +1,5 @@
 package com.ject.vs.vote.adapter.web.dto;
 
-import com.ject.vs.vote.domain.VoteType;
-
 import java.time.Instant;
 import java.util.List;
 
@@ -11,7 +9,6 @@ public record MyParticipatedVoteResponse(
 ) {
     public record VoteElement(
             Long id,
-            VoteType voteType,
             String title,
             String content,
             String thumbnailUrl,

--- a/src/main/java/com/ject/vs/vote/adapter/web/dto/VoteCreateRequest.java
+++ b/src/main/java/com/ject/vs/vote/adapter/web/dto/VoteCreateRequest.java
@@ -1,14 +1,12 @@
 package com.ject.vs.vote.adapter.web.dto;
 
 import com.ject.vs.vote.domain.VoteDuration;
-import com.ject.vs.vote.domain.VoteType;
 import com.ject.vs.vote.port.in.VoteCommandUseCase.VoteCreateCommand;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record VoteCreateRequest(
-        @NotNull VoteType type,
         @NotBlank @Size(max = 100) String title,
         @Size(max = 1000) String content,
         @NotBlank String thumbnailUrl,
@@ -18,6 +16,6 @@ public record VoteCreateRequest(
         @NotBlank @Size(max = 50) String optionB
 ) {
     public VoteCreateCommand toCommand() {
-        return new VoteCreateCommand(type, title, content, thumbnailUrl, imageUrl, duration, optionA, optionB);
+        return new VoteCreateCommand(title, content, thumbnailUrl, imageUrl, duration, optionA, optionB);
     }
 }

--- a/src/main/java/com/ject/vs/vote/adapter/web/dto/VoteDetailResponse.java
+++ b/src/main/java/com/ject/vs/vote/adapter/web/dto/VoteDetailResponse.java
@@ -2,7 +2,6 @@ package com.ject.vs.vote.adapter.web.dto;
 
 import com.ject.vs.vote.domain.VoteEmoji;
 import com.ject.vs.vote.domain.VoteStatus;
-import com.ject.vs.vote.domain.VoteType;
 import com.ject.vs.vote.port.VoteDetailQueryService.VoteDetailResult;
 
 import java.time.Instant;
@@ -13,7 +12,6 @@ import java.util.Map;
 
 public record VoteDetailResponse(
         Long voteId,
-        VoteType voteType,
         String title,
         OffsetDateTime createdAt,
         String content,
@@ -65,7 +63,6 @@ public record VoteDetailResponse(
 
         return new VoteDetailResponse(
                 result.voteId(),
-                result.type(),
                 result.title(),
                 toKst(result.createdAt()),
                 result.content(),

--- a/src/main/java/com/ject/vs/vote/domain/Vote.java
+++ b/src/main/java/com/ject/vs/vote/domain/Vote.java
@@ -1,7 +1,6 @@
 package com.ject.vs.vote.domain;
 
 import com.ject.vs.common.domain.BaseTimeEntity;
-import com.ject.vs.vote.exception.ImageRequiredException;
 import com.ject.vs.vote.exception.VoteOptionNotFoundException;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -23,10 +22,6 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class Vote extends BaseTimeEntity {
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private VoteType type;
-
     @Column(nullable = false)
     private String title;
 
@@ -47,14 +42,10 @@ public class Vote extends BaseTimeEntity {
     private String aiInsightHeadline;
     private String aiInsightBody;
 
-    public static Vote create(VoteType type, String title, String content,
+    public static Vote create(String title, String content,
                               String thumbnailUrl, String imageUrl,
                               Duration validityPeriod, Clock clock) {
-        if (type == VoteType.IMMERSIVE && (imageUrl == null || imageUrl.isBlank())) {
-            throw new ImageRequiredException();
-        }
         Vote vote = new Vote();
-        vote.type = type;
         vote.title = title;
         vote.content = content;
         vote.thumbnailUrl = thumbnailUrl;

--- a/src/main/java/com/ject/vs/vote/domain/VoteRepository.java
+++ b/src/main/java/com/ject/vs/vote/domain/VoteRepository.java
@@ -18,15 +18,11 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
 
     List<Vote> findAllByIdIn(List<Long> ids);
 
-    Slice<Vote> findByTypeOrderByEndAtDesc(VoteType type, Pageable pageable);
+    @Query("SELECT v FROM Vote v WHERE v.endAt > :now ORDER BY v.id DESC")
+    Slice<Vote> findByEndAtAfterOrderByIdDesc(@Param("now") Instant now, Pageable pageable);
 
-    Slice<Vote> findByTypeAndIdLessThanOrderByEndAtDesc(VoteType type, Long cursor, Pageable pageable);
-
-    @Query("SELECT v FROM Vote v WHERE v.type = :type AND v.endAt > :now ORDER BY v.id DESC")
-    Slice<Vote> findByTypeAndEndAtAfterOrderByIdDesc(@Param("type") VoteType type, @Param("now") Instant now, Pageable pageable);
-
-    @Query("SELECT v FROM Vote v WHERE v.type = :type AND v.id < :cursor AND v.endAt > :now ORDER BY v.id DESC")
-    Slice<Vote> findByTypeAndIdLessThanAndEndAtAfterOrderByIdDesc(@Param("type") VoteType type, @Param("cursor") Long cursor, @Param("now") Instant now, Pageable pageable);
+    @Query("SELECT v FROM Vote v WHERE v.id < :cursor AND v.endAt > :now ORDER BY v.id DESC")
+    Slice<Vote> findByIdLessThanAndEndAtAfterOrderByIdDesc(@Param("cursor") Long cursor, @Param("now") Instant now, Pageable pageable);
 
     @Query("select v from Vote v join VoteParticipation vp on vp.voteId = v.id " +
             "where vp.userId = :userId and v.endAt > current_timestamp " +

--- a/src/main/java/com/ject/vs/vote/domain/VoteType.java
+++ b/src/main/java/com/ject/vs/vote/domain/VoteType.java
@@ -1,5 +1,0 @@
-package com.ject.vs.vote.domain;
-
-public enum VoteType {
-    GENERAL, IMMERSIVE
-}

--- a/src/main/java/com/ject/vs/vote/port/ImmersiveVoteQueryService.java
+++ b/src/main/java/com/ject/vs/vote/port/ImmersiveVoteQueryService.java
@@ -37,29 +37,29 @@ public class ImmersiveVoteQueryService implements ImmersiveVoteQueryUseCase {
 
         if (cursor != null) {
             PageRequest pageable = PageRequest.of(0, size);
-            Slice<Vote> slice = voteRepository.findByTypeAndIdLessThanAndEndAtAfterOrderByIdDesc(
-                    VoteType.IMMERSIVE, cursor, now, pageable);
+            Slice<Vote> slice = voteRepository.findByIdLessThanAndEndAtAfterOrderByIdDesc(
+                    cursor, now, pageable);
             items = slice.getContent().stream().map(v -> toFeedItem(v, userId, anonymousId)).toList();
             hasNext = slice.hasNext();
         } else if (startVoteId != null) {
             Vote startVote = voteRepository.findById(startVoteId).orElse(null);
-            if (startVote != null && !startVote.isEnded(clock) && startVote.getType() == VoteType.IMMERSIVE) {
-                Slice<Vote> rest = voteRepository.findByTypeAndIdLessThanAndEndAtAfterOrderByIdDesc(
-                        VoteType.IMMERSIVE, startVoteId, now, PageRequest.of(0, size - 1));
+            if (startVote != null && !startVote.isEnded(clock)) {
+                Slice<Vote> rest = voteRepository.findByIdLessThanAndEndAtAfterOrderByIdDesc(
+                        startVoteId, now, PageRequest.of(0, size - 1));
                 List<ImmersiveFeedItem> combined = new ArrayList<>();
                 combined.add(toFeedItem(startVote, userId, anonymousId));
                 rest.getContent().stream().map(v -> toFeedItem(v, userId, anonymousId)).forEach(combined::add);
                 items = combined;
                 hasNext = rest.hasNext();
             } else {
-                Slice<Vote> slice = voteRepository.findByTypeAndEndAtAfterOrderByIdDesc(
-                        VoteType.IMMERSIVE, now, PageRequest.of(0, size));
+                Slice<Vote> slice = voteRepository.findByEndAtAfterOrderByIdDesc(
+                        now, PageRequest.of(0, size));
                 items = slice.getContent().stream().map(v -> toFeedItem(v, userId, anonymousId)).toList();
                 hasNext = slice.hasNext();
             }
         } else {
-            Slice<Vote> slice = voteRepository.findByTypeAndEndAtAfterOrderByIdDesc(
-                    VoteType.IMMERSIVE, now, PageRequest.of(0, size));
+            Slice<Vote> slice = voteRepository.findByEndAtAfterOrderByIdDesc(
+                    now, PageRequest.of(0, size));
             items = slice.getContent().stream().map(v -> toFeedItem(v, userId, anonymousId)).toList();
             hasNext = slice.hasNext();
         }

--- a/src/main/java/com/ject/vs/vote/port/VoteCommandService.java
+++ b/src/main/java/com/ject/vs/vote/port/VoteCommandService.java
@@ -27,7 +27,7 @@ public class VoteCommandService implements VoteCommandUseCase {
     @Override
     public VoteCreateResult create(VoteCreateCommand cmd) {
         Vote vote = Vote.create(
-                cmd.type(), cmd.title(), cmd.content(),
+                cmd.title(), cmd.content(),
                 cmd.thumbnailUrl(), cmd.imageUrl(),
                 cmd.duration().getValue(),
                 clock

--- a/src/main/java/com/ject/vs/vote/port/VoteDetailQueryService.java
+++ b/src/main/java/com/ject/vs/vote/port/VoteDetailQueryService.java
@@ -70,7 +70,7 @@ public class VoteDetailQueryService {
         boolean voted = mySelectedOptionId != null;
 
         return new VoteDetailResult(
-                vote.getId(), vote.getType(), vote.getTitle(), vote.getCreatedAt(), vote.getContent(),
+                vote.getId(), vote.getTitle(), vote.getCreatedAt(), vote.getContent(),
                 vote.getThumbnailUrl(), vote.getImageUrl(), status, vote.getEndAt(),
                 (int) total, optionResults, voted, mySelectedOptionId, emojiSummary, myEmoji, 0
         );
@@ -78,7 +78,6 @@ public class VoteDetailQueryService {
 
     public record VoteDetailResult(
             Long voteId,
-            VoteType type,
             String title,
             Instant createdAt,
             String content,

--- a/src/main/java/com/ject/vs/vote/port/VoteQueryService.java
+++ b/src/main/java/com/ject/vs/vote/port/VoteQueryService.java
@@ -134,7 +134,6 @@ public class VoteQueryService implements VoteQueryUseCase, VoteParticipationQuer
         List<MyParticipatedVoteResponse.VoteElement> elementList = list.stream()
                 .map(v -> new MyParticipatedVoteResponse.VoteElement(
                         v.getId(),
-                        v.getType(),
                         v.getTitle(),
                         v.getContent(),
                         v.getThumbnailUrl(),
@@ -159,7 +158,6 @@ public class VoteQueryService implements VoteQueryUseCase, VoteParticipationQuer
         List<MyParticipatedVoteResponse.VoteElement> elementList = list.stream()
                 .map(v -> new MyParticipatedVoteResponse.VoteElement(
                         v.getId(),
-                        v.getType(),
                         v.getTitle(),
                         v.getContent(),
                         v.getThumbnailUrl(),

--- a/src/main/java/com/ject/vs/vote/port/in/VoteCommandUseCase.java
+++ b/src/main/java/com/ject/vs/vote/port/in/VoteCommandUseCase.java
@@ -3,7 +3,6 @@ package com.ject.vs.vote.port.in;
 import com.ject.vs.vote.domain.Vote;
 import com.ject.vs.vote.domain.VoteDuration;
 import com.ject.vs.vote.domain.VoteStatus;
-import com.ject.vs.vote.domain.VoteType;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -20,7 +19,6 @@ public interface VoteCommandUseCase {
     void cancel(Long voteId, Long userId);
 
     record VoteCreateCommand(
-            VoteType type,
             String title,
             String content,
             String thumbnailUrl,

--- a/src/main/resources/db/migration/V11__remove_vote_type_column.sql
+++ b/src/main/resources/db/migration/V11__remove_vote_type_column.sql
@@ -1,0 +1,9 @@
+-- vote 테이블에서 "type" 컬럼 제거
+-- GENERAL / IMMERSIVE 투표 유형 구분을 제거하고 단일 Vote 모델로 통합
+-- 모든 투표 API(/api/votes, /api/immersive-votes, /api/home/*)는 vote 테이블의 데이터를 직접 사용
+
+-- "type" 컬럼에 의존하는 인덱스 먼저 삭제 (컬럼 삭제 전 필수)
+DROP INDEX IF EXISTS idx_vote_type_end_at;
+
+-- "type" 컬럼 삭제 (PostgreSQL 9.2+ 에서 IF EXISTS 지원)
+ALTER TABLE vote DROP COLUMN IF EXISTS "type";

--- a/src/unitTest/java/com/ject/vs/chat/adapter/event/ChatWebSocketE2ETest.java
+++ b/src/unitTest/java/com/ject/vs/chat/adapter/event/ChatWebSocketE2ETest.java
@@ -123,7 +123,7 @@ class ChatWebSocketE2ETest {
     private TestFixture createFixture() {
         User sender = userRepository.saveAndFlush(User.createWithEmail("e2e-sender-" + System.nanoTime() + "@test.com"));
         User receiver = userRepository.saveAndFlush(User.createWithEmail("e2e-receiver-" + System.nanoTime() + "@test.com"));
-        Vote vote = voteRepository.saveAndFlush(Vote.create(VoteType.GENERAL, "e2e chat vote", null, "thumb", null, Duration.ofHours(1), Clock.systemUTC()));
+        Vote vote = voteRepository.saveAndFlush(Vote.create("e2e chat vote", null, "thumb", null, Duration.ofHours(1), Clock.systemUTC()));
         VoteOption option = voteOptionRepository.saveAndFlush(VoteOption.of(vote, "A", 1));
         voteParticipationRepository.saveAndFlush(VoteParticipation.ofMember(vote.getId(), sender.getId(), option.getId()));
         voteParticipationRepository.saveAndFlush(VoteParticipation.ofMember(vote.getId(), receiver.getId(), option.getId()));

--- a/src/unitTest/java/com/ject/vs/chat/adapter/event/ChatWebSocketIntegrationTest.java
+++ b/src/unitTest/java/com/ject/vs/chat/adapter/event/ChatWebSocketIntegrationTest.java
@@ -142,7 +142,7 @@ class ChatWebSocketIntegrationTest {
     void voteId가_다른_topic_구독자는_메시지를_수신하지_않는다() throws Exception {
         // given
         TestFixture fixture = createFixture();
-        Vote otherVote = voteRepository.saveAndFlush(Vote.create(VoteType.GENERAL, "other", null, "thumb", null, Duration.ofHours(1), Clock.systemUTC()));
+        Vote otherVote = voteRepository.saveAndFlush(Vote.create("other", null, "thumb", null, Duration.ofHours(1), Clock.systemUTC()));
         StompSession session = connectAnonymously();
         BlockingQueue<MessageResult> targetMessages = new LinkedBlockingQueue<>();
         BlockingQueue<MessageResult> otherMessages = new LinkedBlockingQueue<>();
@@ -161,7 +161,7 @@ class ChatWebSocketIntegrationTest {
     private TestFixture createFixture() {
         User sender = userRepository.saveAndFlush(User.createWithEmail("sender-" + System.nanoTime() + "@test.com"));
         User receiver = userRepository.saveAndFlush(User.createWithEmail("receiver-" + System.nanoTime() + "@test.com"));
-        Vote vote = voteRepository.saveAndFlush(Vote.create(VoteType.GENERAL, "chat vote", null, "thumb", null, Duration.ofHours(1), Clock.systemUTC()));
+        Vote vote = voteRepository.saveAndFlush(Vote.create("chat vote", null, "thumb", null, Duration.ofHours(1), Clock.systemUTC()));
         VoteOption option = voteOptionRepository.saveAndFlush(VoteOption.of(vote, "A", 1));
         voteParticipationRepository.saveAndFlush(VoteParticipation.ofMember(vote.getId(), sender.getId(), option.getId()));
         voteParticipationRepository.saveAndFlush(VoteParticipation.ofMember(vote.getId(), receiver.getId(), option.getId()));

--- a/src/unitTest/java/com/ject/vs/chat/adapter/web/ChatControllerTest.java
+++ b/src/unitTest/java/com/ject/vs/chat/adapter/web/ChatControllerTest.java
@@ -113,7 +113,7 @@ class ChatControllerTest {
         @WithMockUser
         void 정상_요청이면_200을_반환한다() throws Exception {
             // given
-            given(chatQueryUseCase.getGauge(1L)).willReturn(new GaugeResult(50, 50, 10));
+            given(chatQueryUseCase.getGauge(1L)).willReturn(new GaugeResult(1L, 50, 50, 10));
 
             // when & then
             mockMvc.perform(get("/api/chats/1/gauge"))

--- a/src/unitTest/java/com/ject/vs/chat/domain/ChatMessageRepositoryTest.java
+++ b/src/unitTest/java/com/ject/vs/chat/domain/ChatMessageRepositoryTest.java
@@ -3,7 +3,7 @@ package com.ject.vs.chat.domain;
 import com.ject.vs.config.JpaAuditingConfig;
 import com.ject.vs.user.domain.User;
 import com.ject.vs.vote.domain.Vote;
-import com.ject.vs.vote.domain.VoteType;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -44,7 +44,7 @@ class ChatMessageRepositoryTest {
     void setUp() {
         User user = entityManager.persistAndFlush(User.createWithSub("test-sub"));
         Vote vote = entityManager.persistAndFlush(
-                Vote.create(VoteType.GENERAL, "테스트", null, "thumb", null, Duration.ofHours(24), FIXED_CLOCK)
+                Vote.create("테스트", null, "thumb", null, Duration.ofHours(24), FIXED_CLOCK)
         );
         voteId = vote.getId();
         userId = user.getId();

--- a/src/unitTest/java/com/ject/vs/chat/domain/ChatRoomUnreadRepositoryTest.java
+++ b/src/unitTest/java/com/ject/vs/chat/domain/ChatRoomUnreadRepositoryTest.java
@@ -3,7 +3,7 @@ package com.ject.vs.chat.domain;
 import com.ject.vs.config.JpaAuditingConfig;
 import com.ject.vs.user.domain.User;
 import com.ject.vs.vote.domain.Vote;
-import com.ject.vs.vote.domain.VoteType;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -43,7 +43,7 @@ class ChatRoomUnreadRepositoryTest {
     void setUp() {
         User user = entityManager.persistAndFlush(User.createWithSub("test-sub"));
         Vote vote = entityManager.persistAndFlush(
-                Vote.create(VoteType.GENERAL, "테스트", null, "thumb", null, Duration.ofHours(24), FIXED_CLOCK)
+                Vote.create("테스트", null, "thumb", null, Duration.ofHours(24), FIXED_CLOCK)
         );
         userId = user.getId();
         voteId = vote.getId();

--- a/src/unitTest/java/com/ject/vs/vote/QaScenarioTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/QaScenarioTest.java
@@ -47,7 +47,7 @@ class QaScenarioTest {
         void 진행중_투표_미투표시_득표수_비율_null() {
             // Given: 진행중 투표, 사용자 미투표
             VoteDetailResult result = new VoteDetailResult(
-                    1L, VoteType.GENERAL, "점심 뭐 먹을까?",
+                    1L, "점심 뭐 먹을까?",
                     Instant.parse("2025-01-01T00:00:00Z"), "내용",
                     "thumb.png", null,
                     VoteStatus.ONGOING,  // 진행중
@@ -81,7 +81,7 @@ class QaScenarioTest {
         void 진행중_투표_투표후_득표수_비율_노출() {
             // Given: 진행중 투표, 사용자 투표 완료
             VoteDetailResult result = new VoteDetailResult(
-                    1L, VoteType.GENERAL, "점심 뭐 먹을까?",
+                    1L, "점심 뭐 먹을까?",
                     Instant.parse("2025-01-01T00:00:00Z"), "내용",
                     "thumb.png", null,
                     VoteStatus.ONGOING,  // 진행중
@@ -116,7 +116,7 @@ class QaScenarioTest {
         void 종료된_투표_미투표시에도_득표수_비율_노출() {
             // Given: 종료된 투표, 사용자 미투표
             VoteDetailResult result = new VoteDetailResult(
-                    1L, VoteType.GENERAL, "점심 뭐 먹을까?",
+                    1L, "점심 뭐 먹을까?",
                     Instant.parse("2025-01-01T00:00:00Z"), "내용",
                     "thumb.png", null,
                     VoteStatus.ENDED,  // 종료됨
@@ -151,7 +151,7 @@ class QaScenarioTest {
         void 종료된_투표_투표자_결과_정상_노출() {
             // Given: 종료된 투표, 사용자 투표함
             VoteDetailResult result = new VoteDetailResult(
-                    1L, VoteType.GENERAL, "점심 뭐 먹을까?",
+                    1L, "점심 뭐 먹을까?",
                     Instant.parse("2025-01-01T00:00:00Z"), "내용",
                     "thumb.png", null,
                     VoteStatus.ENDED,
@@ -185,7 +185,7 @@ class QaScenarioTest {
         void 이모지_요약_정상_반환() {
             // Given
             VoteDetailResult result = new VoteDetailResult(
-                    1L, VoteType.GENERAL, "제목",
+                    1L, "제목",
                     Instant.parse("2025-01-01T00:00:00Z"), null,
                     "thumb.png", null,
                     VoteStatus.ONGOING,
@@ -220,7 +220,7 @@ class QaScenarioTest {
         void 참여자수_정확히_반환() {
             // Given
             VoteDetailResult result = new VoteDetailResult(
-                    1L, VoteType.GENERAL, "제목",
+                    1L, "제목",
                     Instant.parse("2025-01-01T00:00:00Z"), null,
                     "thumb.png", null,
                     VoteStatus.ONGOING,
@@ -568,7 +568,6 @@ class QaScenarioTest {
             // Given
             VoteDetailResult result = new VoteDetailResult(
                     123L,
-                    VoteType.GENERAL,
                     "오늘 점심 뭐 먹을까?",
                     Instant.parse("2025-06-01T09:00:00Z"),
                     "같이 투표해요!",
@@ -598,7 +597,6 @@ class QaScenarioTest {
 
             // Then: 모든 필드 검증
             assertThat(response.voteId()).isEqualTo(123L);
-            assertThat(response.voteType()).isEqualTo(VoteType.GENERAL);
             assertThat(response.title()).isEqualTo("오늘 점심 뭐 먹을까?");
             assertThat(response.content()).isEqualTo("같이 투표해요!");
             assertThat(response.thumbnailUrl()).isEqualTo("https://cdn.vs.app/thumb/123.jpg");

--- a/src/unitTest/java/com/ject/vs/vote/adapter/web/VoteControllerTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/adapter/web/VoteControllerTest.java
@@ -68,14 +68,14 @@ class VoteControllerTest {
 
     private VoteCreateRequest validCreateRequest() {
         return new VoteCreateRequest(
-                VoteType.GENERAL, "제목", null, "thumb.png", null,
+                "제목", null, "thumb.png", null,
                 VoteDuration.HOURS_24, "옵션A", "옵션B"
         );
     }
 
     private VoteDetailResult sampleDetail() {
         return new VoteDetailResult(
-                1L, VoteType.GENERAL, "제목", Instant.parse("2025-01-01T00:00:00Z"),
+                1L, "제목", Instant.parse("2025-01-01T00:00:00Z"),
                 null, "thumb.png", null, VoteStatus.ONGOING, Instant.parse("2025-01-02T00:00:00Z"),
                 5, List.of(), false, null, Map.of(), null, 0
         );
@@ -255,7 +255,7 @@ class VoteControllerTest {
         @WithMockUser
         void 비회원_조회_voteCount는_null() throws Exception {
             VoteDetailResult result = new VoteDetailResult(
-                    1L, VoteType.GENERAL, "제목", Instant.parse("2025-01-01T00:00:00Z"),
+                    1L, "제목", Instant.parse("2025-01-01T00:00:00Z"),
                     "내용", "thumb.png", null, VoteStatus.ONGOING, Instant.parse("2025-01-02T00:00:00Z"),
                     31, List.of(), false, null, Map.of(), null, 0
             );
@@ -272,7 +272,7 @@ class VoteControllerTest {
         @Test
         void 회원_투표후_조회_voteCount_노출() throws Exception {
             VoteDetailResult result = new VoteDetailResult(
-                    1L, VoteType.GENERAL, "제목", Instant.parse("2025-01-01T00:00:00Z"),
+                    1L, "제목", Instant.parse("2025-01-01T00:00:00Z"),
                     "내용", "thumb.png", null, VoteStatus.ONGOING, Instant.parse("2025-01-02T00:00:00Z"),
                     31, List.of(), true, 10L, Map.of(VoteEmoji.WOW, 36L), VoteEmoji.WOW, 0
             );

--- a/src/unitTest/java/com/ject/vs/vote/adapter/web/VoteControllerTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/adapter/web/VoteControllerTest.java
@@ -294,7 +294,7 @@ class VoteControllerTest {
                     new OptionResult(11L, "짬뽕", 40L, 40)
             );
             VoteDetailResult result = new VoteDetailResult(
-                    1L, VoteType.GENERAL, "점심 뭐 먹을까?", Instant.parse("2025-01-01T00:00:00Z"),
+                    1L, "점심 뭐 먹을까?", Instant.parse("2025-01-01T00:00:00Z"),
                     "내용", "thumb.png", null, VoteStatus.ENDED, Instant.parse("2025-01-02T00:00:00Z"),
                     100, options, false, null, Map.of(), null, 0
             );
@@ -318,7 +318,7 @@ class VoteControllerTest {
                     new OptionResult(11L, "짬뽕", 40L, 40)
             );
             VoteDetailResult result = new VoteDetailResult(
-                    1L, VoteType.GENERAL, "점심 뭐 먹을까?", Instant.parse("2025-01-01T00:00:00Z"),
+                    1L, "점심 뭐 먹을까?", Instant.parse("2025-01-01T00:00:00Z"),
                     "내용", "thumb.png", null, VoteStatus.ONGOING, Instant.parse("2025-01-02T00:00:00Z"),
                     100, options, false, null, Map.of(), null, 0
             );

--- a/src/unitTest/java/com/ject/vs/vote/domain/VoteParticipationRepositoryTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/domain/VoteParticipationRepositoryTest.java
@@ -45,7 +45,7 @@ class VoteParticipationRepositoryTest {
     @BeforeEach
     void setUp() {
         vote = voteRepository.save(
-                Vote.create(VoteType.GENERAL, "테스트 투표", null, "thumb", null,
+                Vote.create("테스트 투표", null, "thumb", null,
                         Duration.ofHours(24), FIXED_CLOCK)
         );
         optionA = voteOptionRepository.save(VoteOption.of(vote, "A", 0));

--- a/src/unitTest/java/com/ject/vs/vote/domain/VoteTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/domain/VoteTest.java
@@ -1,6 +1,5 @@
 package com.ject.vs.vote.domain;
 
-import com.ject.vs.vote.exception.ImageRequiredException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +9,6 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class VoteTest {
 
@@ -20,46 +18,26 @@ class VoteTest {
     class create {
 
         @Test
-        void 일반형_투표_정상_생성() {
+        void 투표_정상_생성() {
             Vote vote = Vote.create(
-                    VoteType.GENERAL, "제목", "내용",
+                    "제목", "내용",
                     "https://thumb.url", null,
                     Duration.ofHours(24), FIXED_CLOCK
             );
 
-            assertThat(vote.getType()).isEqualTo(VoteType.GENERAL);
             assertThat(vote.getTitle()).isEqualTo("제목");
             assertThat(vote.getStatus(FIXED_CLOCK)).isEqualTo(VoteStatus.ONGOING);
             assertThat(vote.getEndAt()).isEqualTo(Instant.parse("2025-01-02T00:00:00Z"));
         }
 
         @Test
-        void 몰입형_투표_imageUrl_없으면_ImageRequiredException() {
-            assertThatThrownBy(() -> Vote.create(
-                    VoteType.IMMERSIVE, "제목", "내용",
-                    "https://thumb.url", null,
-                    Duration.ofHours(24), FIXED_CLOCK
-            )).isInstanceOf(ImageRequiredException.class);
-        }
-
-        @Test
-        void 몰입형_투표_imageUrl_빈문자열이면_ImageRequiredException() {
-            assertThatThrownBy(() -> Vote.create(
-                    VoteType.IMMERSIVE, "제목", "내용",
-                    "https://thumb.url", "   ",
-                    Duration.ofHours(24), FIXED_CLOCK
-            )).isInstanceOf(ImageRequiredException.class);
-        }
-
-        @Test
-        void 몰입형_투표_imageUrl_있으면_정상_생성() {
+        void imageUrl_있으면_정상_생성() {
             Vote vote = Vote.create(
-                    VoteType.IMMERSIVE, "제목", "내용",
+                    "제목", "내용",
                     "https://thumb.url", "https://image.url",
                     Duration.ofHours(24), FIXED_CLOCK
             );
 
-            assertThat(vote.getType()).isEqualTo(VoteType.IMMERSIVE);
             assertThat(vote.getImageUrl()).isEqualTo("https://image.url");
         }
     }
@@ -69,7 +47,7 @@ class VoteTest {
 
         @Test
         void endAt_이전이면_true() {
-            Vote vote = Vote.create(VoteType.GENERAL, "제목", null, "thumb", null,
+            Vote vote = Vote.create("제목", null, "thumb", null,
                     Duration.ofHours(24), FIXED_CLOCK);
 
             Clock beforeEnd = Clock.fixed(Instant.parse("2025-01-01T12:00:00Z"), ZoneOffset.UTC);
@@ -78,7 +56,7 @@ class VoteTest {
 
         @Test
         void endAt_이후이면_false() {
-            Vote vote = Vote.create(VoteType.GENERAL, "제목", null, "thumb", null,
+            Vote vote = Vote.create("제목", null, "thumb", null,
                     Duration.ofHours(24), FIXED_CLOCK);
 
             Clock afterEnd = Clock.fixed(Instant.parse("2025-01-03T00:00:00Z"), ZoneOffset.UTC);
@@ -91,7 +69,7 @@ class VoteTest {
 
         @Test
         void endAt_이후이면_true() {
-            Vote vote = Vote.create(VoteType.GENERAL, "제목", null, "thumb", null,
+            Vote vote = Vote.create("제목", null, "thumb", null,
                     Duration.ofHours(24), FIXED_CLOCK);
 
             Clock afterEnd = Clock.fixed(Instant.parse("2025-01-03T00:00:00Z"), ZoneOffset.UTC);
@@ -104,7 +82,7 @@ class VoteTest {
 
         @Test
         void endAt_이후에는_status가_ENDED() {
-            Vote vote = Vote.create(VoteType.GENERAL, "제목", null, "thumb", null,
+            Vote vote = Vote.create("제목", null, "thumb", null,
                     Duration.ofHours(24), FIXED_CLOCK);
 
             Clock afterEnd = Clock.fixed(Instant.parse("2025-01-03T00:00:00Z"), ZoneOffset.UTC);
@@ -117,7 +95,7 @@ class VoteTest {
 
         @Test
         void headline과_body가_저장되고_hasAiInsight가_true() {
-            Vote vote = Vote.create(VoteType.GENERAL, "제목", null, "thumb", null,
+            Vote vote = Vote.create("제목", null, "thumb", null,
                     Duration.ofHours(24), FIXED_CLOCK);
 
             vote.cacheAiInsight("헤드라인", "바디");
@@ -129,7 +107,7 @@ class VoteTest {
 
         @Test
         void 캐시_없으면_hasAiInsight가_false() {
-            Vote vote = Vote.create(VoteType.GENERAL, "제목", null, "thumb", null,
+            Vote vote = Vote.create("제목", null, "thumb", null,
                     Duration.ofHours(24), FIXED_CLOCK);
 
             assertThat(vote.hasAiInsight()).isFalse();

--- a/src/unitTest/java/com/ject/vs/vote/port/ImmersiveVoteCommandServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/port/ImmersiveVoteCommandServiceTest.java
@@ -41,12 +41,12 @@ class ImmersiveVoteCommandServiceTest {
     @Mock private Clock clock;
 
     private Vote ongoingVote() {
-        return Vote.create(VoteType.IMMERSIVE, "몰입", null, "t", "img.png",
+        return Vote.create("몰입", null, "t", "img.png",
                 Duration.ofHours(24), FIXED_CLOCK);
     }
 
     private Vote endedVote() {
-        return Vote.create(VoteType.IMMERSIVE, "몰입", null, "t", "img.png",
+        return Vote.create("몰입", null, "t", "img.png",
                 Duration.ofHours(1), FIXED_CLOCK);
     }
 

--- a/src/unitTest/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
@@ -44,7 +44,7 @@ class ImmersiveVoteQueryServiceTest {
     @Mock private Clock clock;
 
     private Vote makeVote(Duration duration) {
-        return Vote.create(VoteType.IMMERSIVE, "몰입", null, "t", "img.png", duration, FIXED_CLOCK);
+        return Vote.create("몰입", null, "t", "img.png", duration, FIXED_CLOCK);
     }
 
     @Nested
@@ -58,7 +58,7 @@ class ImmersiveVoteQueryServiceTest {
         @Test
         void cursor_없을때_타입_정렬_쿼리_사용() {
             Vote vote = makeVote(Duration.ofHours(24));
-            given(voteRepository.findByTypeAndEndAtAfterOrderByIdDesc(eq(VoteType.IMMERSIVE), any(), any()))
+            given(voteRepository.findByEndAtAfterOrderByIdDesc(any(), any()))
                     .willReturn(new SliceImpl<>(List.of(vote), PageRequest.of(0, 10), false));
             given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
             given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());
@@ -74,8 +74,8 @@ class ImmersiveVoteQueryServiceTest {
         @Test
         void cursor_있을때_cursor_기반_쿼리_사용() {
             Vote vote = makeVote(Duration.ofHours(24));
-            given(voteRepository.findByTypeAndIdLessThanAndEndAtAfterOrderByIdDesc(
-                    eq(VoteType.IMMERSIVE), eq(100L), any(), any()))
+            given(voteRepository.findByIdLessThanAndEndAtAfterOrderByIdDesc(
+                    eq(100L), any(), any()))
                     .willReturn(new SliceImpl<>(List.of(vote), PageRequest.of(0, 10), false));
             given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
             given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());
@@ -91,7 +91,7 @@ class ImmersiveVoteQueryServiceTest {
         void hasNext_true이면_nextCursor_반환() {
             Vote v1 = makeVote(Duration.ofHours(24));
             Vote v2 = makeVote(Duration.ofHours(23));
-            given(voteRepository.findByTypeAndEndAtAfterOrderByIdDesc(eq(VoteType.IMMERSIVE), any(), any()))
+            given(voteRepository.findByEndAtAfterOrderByIdDesc(any(), any()))
                     .willReturn(new SliceImpl<>(List.of(v1, v2), PageRequest.of(0, 2), true));
             given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
             given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());
@@ -106,7 +106,7 @@ class ImmersiveVoteQueryServiceTest {
         @Test
         void 회원_userId로_mySelectedOptionId_조회() {
             Vote vote = makeVote(Duration.ofHours(24));
-            given(voteRepository.findByTypeAndEndAtAfterOrderByIdDesc(eq(VoteType.IMMERSIVE), any(), any()))
+            given(voteRepository.findByEndAtAfterOrderByIdDesc(any(), any()))
                     .willReturn(new SliceImpl<>(List.of(vote), PageRequest.of(0, 10), false));
             given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
             given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());
@@ -124,7 +124,7 @@ class ImmersiveVoteQueryServiceTest {
         @Test
         void 비회원_anonymousId로_mySelectedOptionId_조회() {
             Vote vote = makeVote(Duration.ofHours(24));
-            given(voteRepository.findByTypeAndEndAtAfterOrderByIdDesc(eq(VoteType.IMMERSIVE), any(), any()))
+            given(voteRepository.findByEndAtAfterOrderByIdDesc(any(), any()))
                     .willReturn(new SliceImpl<>(List.of(vote), PageRequest.of(0, 10), false));
             given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
             given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());
@@ -142,7 +142,7 @@ class ImmersiveVoteQueryServiceTest {
         @Test
         void 미참여시_mySelectedOptionId_null() {
             Vote vote = makeVote(Duration.ofHours(24));
-            given(voteRepository.findByTypeAndEndAtAfterOrderByIdDesc(eq(VoteType.IMMERSIVE), any(), any()))
+            given(voteRepository.findByEndAtAfterOrderByIdDesc(any(), any()))
                     .willReturn(new SliceImpl<>(List.of(vote), PageRequest.of(0, 10), false));
             given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
             given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());

--- a/src/unitTest/java/com/ject/vs/vote/port/VoteCommandServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/port/VoteCommandServiceTest.java
@@ -58,10 +58,10 @@ class VoteCommandServiceTest {
         void 정상적으로_투표를_생성한다() {
             given(clock.instant()).willReturn(Instant.parse("2025-01-01T00:00:00Z"));
             VoteCreateCommand cmd = new VoteCreateCommand(
-                    VoteType.GENERAL, "제목", null, "thumb", null,
+                    "제목", null, "thumb", null,
                     VoteDuration.HOURS_24, "A", "B");
 
-            Vote fakeVote = Vote.create(VoteType.GENERAL, "제목", null, "thumb", null,
+            Vote fakeVote = Vote.create("제목", null, "thumb", null,
                     Duration.ofHours(24), FIXED_CLOCK);
             given(voteRepository.save(any())).willReturn(fakeVote);
             VoteOption optA = VoteOption.of(fakeVote, "A", 0);
@@ -73,15 +73,6 @@ class VoteCommandServiceTest {
             assertThat(result.status()).isEqualTo(VoteStatus.ONGOING);
         }
 
-        @Test
-        void IMMERSIVE_타입에_imageUrl_없으면_ImageRequiredException() {
-            VoteCreateCommand cmd = new VoteCreateCommand(
-                    VoteType.IMMERSIVE, "제목", null, "thumb", null,
-                    VoteDuration.HOURS_24, "A", "B");
-
-            assertThatThrownBy(() -> service.create(cmd))
-                    .isInstanceOf(com.ject.vs.vote.exception.ImageRequiredException.class);
-        }
     }
 
     @Nested
@@ -89,7 +80,7 @@ class VoteCommandServiceTest {
 
         @Test
         void 신규_회원_참여_정상_저장() {
-            Vote ongoingVote = Vote.create(VoteType.GENERAL, "투표", null, "t", null,
+            Vote ongoingVote = Vote.create("투표", null, "t", null,
                     Duration.ofHours(24), FIXED_CLOCK);
             given(clock.instant()).willReturn(Instant.parse("2025-01-01T00:00:00Z"));
             given(voteRepository.findById(1L)).willReturn(Optional.of(ongoingVote));
@@ -108,7 +99,7 @@ class VoteCommandServiceTest {
 
         @Test
         void 기존_참여자는_옵션을_변경한다() {
-            Vote ongoingVote = Vote.create(VoteType.GENERAL, "투표", null, "t", null,
+            Vote ongoingVote = Vote.create("투표", null, "t", null,
                     Duration.ofHours(24), FIXED_CLOCK);
             given(clock.instant()).willReturn(Instant.parse("2025-01-01T00:00:00Z"));
             given(voteRepository.findById(1L)).willReturn(Optional.of(ongoingVote));
@@ -125,7 +116,7 @@ class VoteCommandServiceTest {
 
         @Test
         void 종료된_투표에_참여하면_VoteEndedException() {
-            Vote endedVote = Vote.create(VoteType.GENERAL, "투표", null, "t", null,
+            Vote endedVote = Vote.create("투표", null, "t", null,
                     Duration.ofHours(1), FIXED_CLOCK);
             given(clock.instant()).willReturn(Instant.parse("2025-01-01T02:00:00Z"));
             given(voteRepository.findById(1L)).willReturn(Optional.of(endedVote));
@@ -144,7 +135,7 @@ class VoteCommandServiceTest {
 
         @Test
         void 유효하지_않은_optionId는_InvalidOptionException() {
-            Vote ongoingVote = Vote.create(VoteType.GENERAL, "투표", null, "t", null,
+            Vote ongoingVote = Vote.create("투표", null, "t", null,
                     Duration.ofHours(24), FIXED_CLOCK);
             given(clock.instant()).willReturn(Instant.parse("2025-01-01T00:00:00Z"));
             given(voteRepository.findById(1L)).willReturn(Optional.of(ongoingVote));
@@ -160,7 +151,7 @@ class VoteCommandServiceTest {
 
         @Test
         void 신규_비회원은_차감_후_참여_저장() {
-            Vote ongoingVote = Vote.create(VoteType.GENERAL, "투표", null, "t", null,
+            Vote ongoingVote = Vote.create("투표", null, "t", null,
                     Duration.ofHours(24), FIXED_CLOCK);
             given(clock.instant()).willReturn(Instant.parse("2025-01-01T00:00:00Z"));
             given(voteRepository.findById(1L)).willReturn(Optional.of(ongoingVote));
@@ -179,7 +170,7 @@ class VoteCommandServiceTest {
 
         @Test
         void 기존_비회원은_옵션만_변경하고_차감_없음() {
-            Vote ongoingVote = Vote.create(VoteType.GENERAL, "투표", null, "t", null,
+            Vote ongoingVote = Vote.create("투표", null, "t", null,
                     Duration.ofHours(24), FIXED_CLOCK);
             given(clock.instant()).willReturn(Instant.parse("2025-01-01T00:00:00Z"));
             given(voteRepository.findById(1L)).willReturn(Optional.of(ongoingVote));
@@ -202,7 +193,7 @@ class VoteCommandServiceTest {
 
         @Test
         void 정상적으로_참여를_취소한다() {
-            Vote ongoingVote = Vote.create(VoteType.GENERAL, "투표", null, "t", null,
+            Vote ongoingVote = Vote.create("투표", null, "t", null,
                     Duration.ofHours(24), FIXED_CLOCK);
             given(clock.instant()).willReturn(Instant.parse("2025-01-01T00:00:00Z"));
             given(voteRepository.findById(1L)).willReturn(Optional.of(ongoingVote));
@@ -214,7 +205,7 @@ class VoteCommandServiceTest {
 
         @Test
         void 종료된_투표_취소는_VoteEndedException() {
-            Vote endedVote = Vote.create(VoteType.GENERAL, "투표", null, "t", null,
+            Vote endedVote = Vote.create("투표", null, "t", null,
                     Duration.ofHours(1), FIXED_CLOCK);
             given(clock.instant()).willReturn(Instant.parse("2025-01-01T02:00:00Z"));
             given(voteRepository.findById(1L)).willReturn(Optional.of(endedVote));

--- a/src/unitTest/java/com/ject/vs/vote/port/VoteDetailQueryServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/port/VoteDetailQueryServiceTest.java
@@ -46,12 +46,12 @@ class VoteDetailQueryServiceTest {
 
         // 진행중 투표 (현재 시간 기준 24시간 후 종료)
         Clock recentClock = Clock.fixed(Instant.parse("2025-06-01T00:00:00Z"), ZoneOffset.UTC);
-        ongoingVote = Vote.create(VoteType.GENERAL, "진행중 투표", null, "thumb.png", null,
+        ongoingVote = Vote.create("진행중 투표", null, "thumb.png", null,
                 Duration.ofHours(24), recentClock);
 
         // 종료된 투표 (현재 시간 기준 이미 종료)
         Clock pastClock = Clock.fixed(Instant.parse("2025-05-30T00:00:00Z"), ZoneOffset.UTC);
-        endedVote = Vote.create(VoteType.GENERAL, "종료된 투표", null, "thumb.png", null,
+        endedVote = Vote.create("종료된 투표", null, "thumb.png", null,
                 Duration.ofHours(24), pastClock);
     }
 

--- a/src/unitTest/java/com/ject/vs/vote/port/VoteQueryServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/port/VoteQueryServiceTest.java
@@ -90,7 +90,7 @@ class VoteQueryServiceTest {
         @Test
         void 진행중인_투표의_summary를_반환한다() {
             Clock nowClock = Clock.fixed(Instant.parse("2025-01-01T00:00:00Z"), ZoneOffset.UTC);
-            Vote vote = Vote.create(VoteType.GENERAL, "제목", null, "thumb", null,
+            Vote vote = Vote.create("제목", null, "thumb", null,
                     Duration.ofHours(24), nowClock);
             given(voteRepository.findById(1L)).willReturn(Optional.of(vote));
             given(clock.instant()).willReturn(Instant.parse("2025-01-01T12:00:00Z"));
@@ -161,9 +161,9 @@ class VoteQueryServiceTest {
         @Test
         void ONGOING_필터_적용() {
             Clock nowClock = Clock.fixed(Instant.parse("2025-01-01T00:00:00Z"), ZoneOffset.UTC);
-            Vote ongoing = Vote.create(VoteType.GENERAL, "진행중", null, "t", null,
+            Vote ongoing = Vote.create("진행중", null, "t", null,
                     Duration.ofHours(24), nowClock);
-            Vote ended = Vote.create(VoteType.GENERAL, "종료됨", null, "t", null,
+            Vote ended = Vote.create("종료됨", null, "t", null,
                     Duration.ofHours(1), nowClock);
 
             given(voteRepository.findAllByIdIn(List.of(1L, 2L))).willReturn(List.of(ongoing, ended));

--- a/src/unitTest/java/com/ject/vs/vote/port/VoteResultQueryServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/port/VoteResultQueryServiceTest.java
@@ -44,11 +44,11 @@ class VoteResultQueryServiceTest {
                 voteRepository, voteOptionRepository, voteParticipationRepository, userRepository, CLOCK);
 
         Clock pastClock = Clock.fixed(Instant.parse("2025-05-30T00:00:00Z"), ZoneOffset.UTC);
-        endedVote = Vote.create(VoteType.GENERAL, "제목", null, "thumb.png", null,
+        endedVote = Vote.create("제목", null, "thumb.png", null,
                 Duration.ofHours(24), pastClock);
 
         Clock recentClock = Clock.fixed(Instant.parse("2025-06-01T00:00:00Z"), ZoneOffset.UTC);
-        ongoingVote = Vote.create(VoteType.GENERAL, "진행중", null, "thumb.png", null,
+        ongoingVote = Vote.create("진행중", null, "thumb.png", null,
                 Duration.ofHours(24), recentClock);
     }
 

--- a/src/unitTest/java/com/ject/vs/vote/scheduler/VoteCloseSchedulerTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/scheduler/VoteCloseSchedulerTest.java
@@ -3,7 +3,7 @@ package com.ject.vs.vote.scheduler;
 import com.ject.vs.vote.domain.Vote;
 import com.ject.vs.vote.domain.VoteRepository;
 import com.ject.vs.vote.domain.VoteStatus;
-import com.ject.vs.vote.domain.VoteType;
+
 import com.ject.vs.vote.event.VoteEndedEvent;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -43,7 +43,7 @@ class VoteCloseSchedulerTest {
     private Vote makeExpiredVote() {
         // duration 1h, clock은 생성 시점이 FIXED_CLOCK → endAt = T+1h
         // 스케줄러가 T+2h에 실행되면 이미 만료
-        return Vote.create(VoteType.GENERAL, "test", null, "thumb.png", null,
+        return Vote.create("test", null, "thumb.png", null,
                 Duration.ofHours(1), FIXED_CLOCK);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- 별도 이슈 없음

## 🔍 작업 내용
- `VoteType` 기반 GENERAL / IMMERSIVE 투표 타입 구분을 제거하고, `vote` 테이블 단일 모델 기준으로 투표 생성/조회 흐름을 정리했습니다.
- 홈/투표/몰입형 투표 관련 API 응답 및 UseCase/Service/Repository에서 `voteType` 의존성을 제거했습니다.
- 채팅 투표 게이지 응답에 클라이언트가 투표를 식별할 수 있도록 `voteId`를 추가했습니다.

## 📝 변경 사항
- `VoteType` enum 삭제 및 `Vote.create()` / `VoteCreateRequest` / `VoteCreateCommand` 시그니처 단순화
- `/api/votes`, `/api/immersive-votes`, `/api/home/*`, 내 참여 투표/투표 상세 응답의 `voteType` 필드 제거
- `VoteRepository` 및 몰입형/홈 투표 조회 로직을 타입 필터 없이 `vote` 데이터 기준으로 조회하도록 수정
- Flyway `V11__remove_vote_type_column.sql` 추가
  - `idx_vote_type_end_at` 인덱스 제거
  - `vote.type` 컬럼 제거
- `GaugeResult`, `GaugeResponse`, `ChatService.getGauge()`에 `voteId` 전달 추가
- 타입 제거 및 게이지 응답 변경에 맞춰 관련 단위/통합 테스트 수정

## 💬 리뷰어에게
- `vote.type` 컬럼 제거 마이그레이션이 배포 환경에서 기존 쿼리/인덱스 의존성과 충돌하지 않는지 확인 부탁드립니다.
- `voteType` 응답 필드 제거가 클라이언트 계약 변경에 해당하므로, 프론트/앱 쪽 사용 여부도 함께 확인 부탁드립니다.
