### PR TITLE
fix: 투표 종료 알림 중복 발송 방지

### DIFF
--- a/src/main/java/com/ject/vs/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/ject/vs/notification/domain/NotificationRepository.java
@@ -8,8 +8,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
+import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query("SELECT n.userId FROM Notification n WHERE n.voteId = :voteId AND n.type = :type")
+    List<Long> findUserIdsByVoteIdAndType(@Param("voteId") Long voteId, @Param("type") NotificationType type);
 
     @Query("""
         SELECT n FROM Notification n

--- a/src/main/java/com/ject/vs/notification/event/VoteEndedNotificationHandler.java
+++ b/src/main/java/com/ject/vs/notification/event/VoteEndedNotificationHandler.java
@@ -1,6 +1,7 @@
 package com.ject.vs.notification.event;
 
 import com.ject.vs.notification.domain.Notification;
+import com.ject.vs.notification.domain.NotificationRepository;
 import com.ject.vs.notification.domain.NotificationType;
 import com.ject.vs.notification.port.in.NotificationCommandUseCase;
 import com.ject.vs.notification.port.in.NotificationCommandUseCase.NotificationCreateCommand;
@@ -16,7 +17,9 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -26,6 +29,7 @@ public class VoteEndedNotificationHandler {
     private final VoteQueryPort voteQueryPort;
     private final VoteParticipationRepository voteParticipationRepository;
     private final NotificationCommandUseCase notificationCommandUseCase;
+    private final NotificationRepository notificationRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     @EventListener
@@ -40,8 +44,20 @@ public class VoteEndedNotificationHandler {
                 .findAllUserIdsByVoteId(event.voteId());
         if (participantUserIds.isEmpty()) return;
 
-        // 3. Notification batch insert
-        List<NotificationCreateCommand> commands = participantUserIds.stream()
+        // 3. 이미 알림을 받은 사용자 제외 (중복 알림 방지)
+        Set<Long> alreadyNotifiedUserIds = new HashSet<>(
+                notificationRepository.findUserIdsByVoteIdAndType(event.voteId(), NotificationType.VOTE_ENDED)
+        );
+        List<Long> targetUserIds = participantUserIds.stream()
+                .filter(uid -> !alreadyNotifiedUserIds.contains(uid))
+                .toList();
+        if (targetUserIds.isEmpty()) {
+            log.debug("All participants already notified for voteId={}", event.voteId());
+            return;
+        }
+
+        // 4. Notification batch insert
+        List<NotificationCreateCommand> commands = targetUserIds.stream()
                 .map(uid -> new NotificationCreateCommand(
                         uid, NotificationType.VOTE_ENDED,
                         vote.getId(), vote.getTitle(),
@@ -49,7 +65,7 @@ public class VoteEndedNotificationHandler {
                 .toList();
         List<Notification> created = notificationCommandUseCase.createBatch(commands);
 
-        // 4. 푸시 발송을 위한 이벤트 발행
+        // 5. 푸시 발송을 위한 이벤트 발행
         List<Long> notificationIds = created.stream()
                 .map(Notification::getId)
                 .toList();


### PR DESCRIPTION
 ## 📌 관련 이슈
  - closes #

  ## 🔍 작업 내용
  투표 종료 알림이 1분마다 중복으로 발송되는 버그 수정

  ## 📝 변경 사항
  - `NotificationRepository`에 `findUserIdsByVoteIdAndType()` 메서드 추가
    - 특정 투표에 대해 이미 알림을 받은 사용자 ID 목록 조회
  - `VoteEndedNotificationHandler`에서 알림 생성 전 중복 체크 로직 추가
    - 이미 알림을 받은 사용자는 알림 생성 대상에서 제외
    - 스케줄러가 매 1분마다 실행되어도 중복 알림이 발송되지 않음

  ## 💬 리뷰어에게
  - 기존에는 스케줄러가 `endAt < now` 조건으로 만료된 투표를 매번 조회하여 중복 알림이 발생했습니다       
  - DB 스키마 변경 없이 코드 레벨에서 중복 체크하는 방식으로 해결했습니다
  - 알림 생성 전 `findUserIdsByVoteIdAndType()`으로 이미 알림받은 사용자를 조회하여 제외합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 투표 종료 알림 발송 시 이미 해당 알림을 받은 사용자에 대한 중복 발송을 방지하는 기능을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->