### PR TITLE
fix: 투표 상세 API commentCount 조회 구현

### DIFF
--- a/src/main/java/com/ject/vs/vote/port/ImmersiveVoteQueryService.java
+++ b/src/main/java/com/ject/vs/vote/port/ImmersiveVoteQueryService.java
@@ -1,5 +1,6 @@
 package com.ject.vs.vote.port;
 
+import com.ject.vs.chat.domain.ChatMessageRepository;
 import com.ject.vs.vote.domain.*;
 import com.ject.vs.vote.exception.VoteNotFoundException;
 import com.ject.vs.vote.port.in.ImmersiveVoteQueryUseCase;
@@ -26,6 +27,7 @@ public class ImmersiveVoteQueryService implements ImmersiveVoteQueryUseCase {
     private final VoteOptionRepository voteOptionRepository;
     private final VoteParticipationRepository voteParticipationRepository;
     private final VoteEmojiReactionRepository emojiReactionRepository;
+    private final ChatMessageRepository chatMessageRepository;
     private final Clock clock;
 
     @Override
@@ -136,6 +138,8 @@ public class ImmersiveVoteQueryService implements ImmersiveVoteQueryUseCase {
                     .orElse(null);
         }
 
+        int commentCount = (int) chatMessageRepository.countByVoteId(voteId);
+
         return new ImmersiveFeedItem(
                 voteId,
                 vote.getTitle(),
@@ -148,7 +152,7 @@ public class ImmersiveVoteQueryService implements ImmersiveVoteQueryUseCase {
                 emojiSummary,
                 emojiTotal,
                 myEmoji,
-                0, // TODO: commentCount
+                commentCount,
                 0  // TODO: Redis viewer count
         );
     }

--- a/src/main/java/com/ject/vs/vote/port/VoteDetailQueryService.java
+++ b/src/main/java/com/ject/vs/vote/port/VoteDetailQueryService.java
@@ -1,5 +1,6 @@
 package com.ject.vs.vote.port;
 
+import com.ject.vs.chat.domain.ChatMessageRepository;
 import com.ject.vs.vote.domain.*;
 import com.ject.vs.vote.exception.VoteNotFoundException;
 import com.ject.vs.vote.port.in.VoteCommandUseCase.OptionResult;
@@ -23,6 +24,7 @@ public class VoteDetailQueryService {
     private final VoteOptionRepository voteOptionRepository;
     private final VoteParticipationRepository voteParticipationRepository;
     private final VoteEmojiReactionRepository emojiReactionRepository;
+    private final ChatMessageRepository chatMessageRepository;
     private final Clock clock;
 
     public VoteDetailResult getDetail(Long voteId, Long userId, String anonymousId) {
@@ -69,10 +71,12 @@ public class VoteDetailQueryService {
 
         boolean voted = mySelectedOptionId != null;
 
+        int commentCount = (int) chatMessageRepository.countByVoteId(voteId);
+
         return new VoteDetailResult(
                 vote.getId(), vote.getTitle(), vote.getCreatedAt(), vote.getContent(),
                 vote.getThumbnailUrl(), vote.getImageUrl(), status, vote.getEndAt(),
-                (int) total, optionResults, voted, mySelectedOptionId, emojiSummary, myEmoji, 0
+                (int) total, optionResults, voted, mySelectedOptionId, emojiSummary, myEmoji, commentCount
         );
     }
 

--- a/src/unitTest/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
@@ -1,5 +1,6 @@
 package com.ject.vs.vote.port;
 
+import com.ject.vs.chat.domain.ChatMessageRepository;
 import com.ject.vs.vote.domain.*;
 import com.ject.vs.vote.port.in.ImmersiveVoteQueryUseCase.ImmersiveFeedResult;
 import com.ject.vs.vote.port.in.ImmersiveVoteQueryUseCase.ImmersiveLiveResult;
@@ -41,6 +42,7 @@ class ImmersiveVoteQueryServiceTest {
     @Mock private VoteOptionRepository voteOptionRepository;
     @Mock private VoteParticipationRepository voteParticipationRepository;
     @Mock private VoteEmojiReactionRepository emojiReactionRepository;
+    @Mock private ChatMessageRepository chatMessageRepository;
     @Mock private Clock clock;
 
     private Vote makeVote(Duration duration) {

--- a/src/unitTest/java/com/ject/vs/vote/port/VoteDetailQueryServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/port/VoteDetailQueryServiceTest.java
@@ -1,5 +1,6 @@
 package com.ject.vs.vote.port;
 
+import com.ject.vs.chat.domain.ChatMessageRepository;
 import com.ject.vs.vote.domain.*;
 import com.ject.vs.vote.exception.VoteNotFoundException;
 import com.ject.vs.vote.port.VoteDetailQueryService.VoteDetailResult;
@@ -31,6 +32,7 @@ class VoteDetailQueryServiceTest {
     @Mock VoteOptionRepository voteOptionRepository;
     @Mock VoteParticipationRepository voteParticipationRepository;
     @Mock VoteEmojiReactionRepository emojiReactionRepository;
+    @Mock ChatMessageRepository chatMessageRepository;
 
     private VoteDetailQueryService service;
 
@@ -42,7 +44,7 @@ class VoteDetailQueryServiceTest {
     @BeforeEach
     void setUp() {
         service = new VoteDetailQueryService(
-                voteRepository, voteOptionRepository, voteParticipationRepository, emojiReactionRepository, CLOCK);
+                voteRepository, voteOptionRepository, voteParticipationRepository, emojiReactionRepository, chatMessageRepository, CLOCK);
 
         // 진행중 투표 (현재 시간 기준 24시간 후 종료)
         Clock recentClock = Clock.fixed(Instant.parse("2025-06-01T00:00:00Z"), ZoneOffset.UTC);


### PR DESCRIPTION
## 📌 관련 이슈
  - closes #

  ## 🔍 작업 내용
  투표 상세 API에서 `commentCount`가 항상 0으로 반환되던 문제 수정

  ## 📝 변경 사항
  - `VoteDetailQueryService`에 `ChatMessageRepository` 주입 및 댓글 수 조회 로직 추가     
  - `ImmersiveVoteQueryService`에 `ChatMessageRepository` 주입 및 댓글 수 조회 로직 추가  
  - 관련 테스트 코드 수정 (`ChatMessageRepository` mock 추가)

  ## 💬 리뷰어에게
  - 기존에는 `commentCount`가 하드코딩된 `0`으로 반환되고 있었습니다
  - `ChatMessageRepository.countByVoteId()`를 사용하여 실제 채팅 메시지 수를 반환하도록 수했습니다