### PR TITLE
feat: 이미지 포함 투표 생성 API

### DIFF
--- a/src/integrationTest/java/com/ject/vs/user/port/UserServiceIntegrationTest.java
+++ b/src/integrationTest/java/com/ject/vs/user/port/UserServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.ject.vs.user.port;
 
+import com.ject.vs.image.port.ImageService;
 import com.ject.vs.user.domain.User;
 import com.ject.vs.user.domain.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
@@ -17,6 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("test")
 @Transactional
 class UserServiceIntegrationTest {
+
+    @MockitoBean
+    private ImageService imageService;
 
     @Autowired
     private UserService userService;

--- a/src/main/java/com/ject/vs/vote/adapter/web/VoteController.java
+++ b/src/main/java/com/ject/vs/vote/adapter/web/VoteController.java
@@ -15,9 +15,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "일반형 투표", description = "일반형 투표 관련 API")
 @RestController
@@ -37,6 +39,28 @@ public class VoteController {
             @RequestBody @Valid VoteCreateRequest request) {
         if (userId == null) throw new UnauthorizedException();
         return VoteCreateResponse.from(voteCommandUseCase.create(request.toCommand()));
+    }
+
+    @Operation(summary = "투표 생성 (이미지 포함)", description = "이미지 파일과 함께 투표를 생성합니다. 서버에서 S3 업로드를 처리합니다.")
+    @PostMapping(value = "/with-images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @ResponseStatus(HttpStatus.CREATED)
+    public VoteCreateResponse createWithImages(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam("title") String title,
+            @RequestParam(value = "content", required = false) String content,
+            @RequestParam("thumbnailFile") MultipartFile thumbnailFile,
+            @RequestParam(value = "imageFile", required = false) MultipartFile imageFile,
+            @RequestParam("duration") String duration,
+            @RequestParam("optionA") String optionA,
+            @RequestParam("optionB") String optionB) {
+        if (userId == null) throw new UnauthorizedException();
+
+        var command = new VoteCommandUseCase.VoteCreateWithImagesCommand(
+                title, content, thumbnailFile, imageFile,
+                com.ject.vs.vote.domain.VoteDuration.valueOf(duration),
+                optionA, optionB
+        );
+        return VoteCreateResponse.from(voteCommandUseCase.createWithImages(command));
     }
 
     @Operation(summary = "투표 상세 조회", description = "투표 상세 정보를 조회합니다. 투표 전에는 결과(voteCount/ratio)가 null로 응답됩니다.")

--- a/src/main/java/com/ject/vs/vote/port/VoteCommandService.java
+++ b/src/main/java/com/ject/vs/vote/port/VoteCommandService.java
@@ -1,5 +1,6 @@
 package com.ject.vs.vote.port;
 
+import com.ject.vs.image.port.ImageService;
 import com.ject.vs.vote.domain.*;
 import com.ject.vs.vote.exception.InvalidOptionException;
 import com.ject.vs.vote.exception.VoteEndedException;
@@ -22,6 +23,7 @@ public class VoteCommandService implements VoteCommandUseCase {
     private final VoteOptionRepository voteOptionRepository;
     private final VoteParticipationRepository voteParticipationRepository;
     private final GuestFreeVoteService guestFreeVoteService;
+    private final ImageService imageService;
     private final Clock clock;
 
     @Override
@@ -29,6 +31,25 @@ public class VoteCommandService implements VoteCommandUseCase {
         Vote vote = Vote.create(
                 cmd.title(), cmd.content(),
                 cmd.thumbnailUrl(), cmd.imageUrl(),
+                cmd.duration().getValue(),
+                clock
+        );
+        Vote saved = voteRepository.save(vote);
+        voteOptionRepository.save(VoteOption.of(saved, cmd.optionA(), 0));
+        voteOptionRepository.save(VoteOption.of(saved, cmd.optionB(), 1));
+        return VoteCreateResult.from(saved, clock);
+    }
+
+    @Override
+    public VoteCreateResult createWithImages(VoteCreateWithImagesCommand cmd) {
+        String thumbnailUrl = imageService.upload(cmd.thumbnailFile());
+        String imageUrl = cmd.imageFile() != null && !cmd.imageFile().isEmpty()
+                ? imageService.upload(cmd.imageFile())
+                : null;
+
+        Vote vote = Vote.create(
+                cmd.title(), cmd.content(),
+                thumbnailUrl, imageUrl,
                 cmd.duration().getValue(),
                 clock
         );

--- a/src/main/java/com/ject/vs/vote/port/in/VoteCommandUseCase.java
+++ b/src/main/java/com/ject/vs/vote/port/in/VoteCommandUseCase.java
@@ -3,6 +3,7 @@ package com.ject.vs.vote.port.in;
 import com.ject.vs.vote.domain.Vote;
 import com.ject.vs.vote.domain.VoteDuration;
 import com.ject.vs.vote.domain.VoteStatus;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -11,6 +12,8 @@ import java.util.List;
 public interface VoteCommandUseCase {
 
     VoteCreateResult create(VoteCreateCommand command);
+
+    VoteCreateResult createWithImages(VoteCreateWithImagesCommand command);
 
     ParticipateResult participateAsMember(Long voteId, Long userId, Long optionId);
 
@@ -23,6 +26,17 @@ public interface VoteCommandUseCase {
             String content,
             String thumbnailUrl,
             String imageUrl,
+            VoteDuration duration,
+            String optionA,
+            String optionB
+    ) {
+    }
+
+    record VoteCreateWithImagesCommand(
+            String title,
+            String content,
+            MultipartFile thumbnailFile,
+            MultipartFile imageFile,
             VoteDuration duration,
             String optionA,
             String optionB

--- a/src/unitTest/java/com/ject/vs/VsServerApplicationTests.java
+++ b/src/unitTest/java/com/ject/vs/VsServerApplicationTests.java
@@ -1,13 +1,17 @@
 package com.ject.vs;
 
-import com.ject.vs.notification.port.out.PushSenderPort;
+import com.ject.vs.image.port.ImageService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ActiveProfiles("test")
 @SpringBootTest
 class VsServerApplicationTests {
+
+	@MockitoBean
+	private ImageService imageService;
 
 	@Test
 	void contextLoads() {

--- a/src/unitTest/java/com/ject/vs/chat/adapter/event/ChatWebSocketE2ETest.java
+++ b/src/unitTest/java/com/ject/vs/chat/adapter/event/ChatWebSocketE2ETest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ject.vs.chat.adapter.web.dto.SendMessageRequest;
 import com.ject.vs.chat.port.in.dto.MessageResult;
 import com.ject.vs.chat.port.in.dto.UnreadPayload;
-import com.ject.vs.notification.port.out.PushSenderPort;
+import com.ject.vs.image.port.ImageService;
 import com.ject.vs.user.domain.User;
 import com.ject.vs.user.domain.UserRepository;
 import com.ject.vs.util.CookieUtil;
@@ -47,6 +47,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ChatWebSocketE2ETest {
 
+    @MockitoBean
+    private ImageService imageService;
 
     @LocalServerPort
     private int port;

--- a/src/unitTest/java/com/ject/vs/chat/adapter/event/ChatWebSocketIntegrationTest.java
+++ b/src/unitTest/java/com/ject/vs/chat/adapter/event/ChatWebSocketIntegrationTest.java
@@ -7,7 +7,7 @@ import com.ject.vs.chat.domain.ChatRoomUnread;
 import com.ject.vs.chat.domain.ChatRoomUnreadRepository;
 import com.ject.vs.chat.port.in.dto.MessageResult;
 import com.ject.vs.chat.port.in.dto.UnreadPayload;
-import com.ject.vs.notification.port.out.PushSenderPort;
+import com.ject.vs.image.port.ImageService;
 import com.ject.vs.user.domain.User;
 import com.ject.vs.user.domain.UserRepository;
 import com.ject.vs.util.CookieUtil;
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.simp.stomp.StompFrameHandler;
@@ -47,8 +46,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ChatWebSocketIntegrationTest {
 
-    @MockBean
-    PushSenderPort pushSenderPort;
+    @MockitoBean
+    private ImageService imageService;
 
     @LocalServerPort
     private int port;

--- a/src/unitTest/java/com/ject/vs/config/TestPropertiesConfig.java
+++ b/src/unitTest/java/com/ject/vs/config/TestPropertiesConfig.java
@@ -1,9 +1,11 @@
 package com.ject.vs.config;
 
-import org.springframework.boot.test.context.TestConfiguration;
+import com.ject.vs.image.port.ImageService;
+import org.mockito.Mockito;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
-@TestConfiguration
+@Configuration
 public class TestPropertiesConfig {
 
     @Bean
@@ -24,5 +26,10 @@ public class TestPropertiesConfig {
                 "http://localhost:3000/oauth2/redirect",
                 "http://localhost:3000/extra-info"
         );
+    }
+
+    @Bean
+    public ImageService imageService() {
+        return Mockito.mock(ImageService.class);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
  -

  ## 🔍 작업 내용
  서버에서 직접 S3 업로드를 처리하는 이미지 포함 투표 생성 API 구현

  ## 📝 변경 사항
  - VoteCreateWithImagesCommand DTO 추가 (MultipartFile 포함)
  - VoteCommandService에 createWithImages() 메서드 구현
  - POST /votes/with-images 엔드포인트 추가 (multipart/form-data)
  - ImageService를 통한 S3 업로드 연동
  - 테스트 환경에서 ImageService mock 처리 추가

  ## 💬 리뷰어에게
  - ImageService가 @ConditionalOnBean(S3Client.class)로 조건부 생성되어 테스트에서 mock 처리했습니다
  - 기존 /votes API와 역할 분리가 적절한지 검토 부탁드립니다