### PR TITLE
fix: 통합 테스트 ImageService 빈 누락 오류 수정

### DIFF
--- a/src/main/java/com/ject/vs/vote/port/VoteCommandService.java
+++ b/src/main/java/com/ject/vs/vote/port/VoteCommandService.java
@@ -23,7 +23,7 @@ public class VoteCommandService implements VoteCommandUseCase {
     private final VoteOptionRepository voteOptionRepository;
     private final VoteParticipationRepository voteParticipationRepository;
     private final GuestFreeVoteService guestFreeVoteService;
-    private final ImageService imageService;
+    private final Optional<ImageService> imageService;
     private final Clock clock;
 
     @Override
@@ -42,9 +42,11 @@ public class VoteCommandService implements VoteCommandUseCase {
 
     @Override
     public VoteCreateResult createWithImages(VoteCreateWithImagesCommand cmd) {
-        String thumbnailUrl = imageService.upload(cmd.thumbnailFile());
+        ImageService service = imageService.orElseThrow(() ->
+                new IllegalStateException("ImageService is not available. S3 configuration may be missing."));
+        String thumbnailUrl = service.upload(cmd.thumbnailFile());
         String imageUrl = cmd.imageFile() != null && !cmd.imageFile().isEmpty()
-                ? imageService.upload(cmd.imageFile())
+                ? service.upload(cmd.imageFile())
                 : null;
 
         Vote vote = Vote.create(


### PR DESCRIPTION
 ## 📌 관련 이슈
  - closes #

  ## 🔍 작업 내용
  통합 테스트 실행 시 `ImageService` 빈을 찾지 못해 발생하는 `NoSuchBeanDefinitionException` 오류 수정   

  ## 📝 변경 사항
  - `VoteCommandService`에서 `ImageService` 의존성을 `Optional<ImageService>`로 변경
  - S3가 비활성화된 테스트 환경에서도 애플리케이션 컨텍스트가 정상 로드되도록 수정
  - `createWithImages()` 호출 시 `ImageService`가 없으면 명확한 예외 메시지 제공

  ## 💬 리뷰어에게
  - `ImageService`는 `@ConditionalOnBean(S3Client.class)`로 S3 설정이 있을 때만 빈으로 등록됩니다        
  - 테스트 환경에서는 S3가 비활성화되어 있어 해당 빈이 없었고, 이를 `Optional`로 감싸 해결했습니다       
  - 실제 운영 환경에서는 S3 설정이 있으므로 기존과 동일하게 동작합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 이미지 업로드 기능이 설정되지 않았을 때 더 명확한 오류 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->