### PR TITLE
fix: Gemini 모델·리전 NOT_FOUND 해결 (gemini-2.0-flash / us-central1)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -151,6 +151,8 @@ if [ -n "${GEMINI_PROJECT_ID:-}" ]; then
   DOCKER_OPTS+=(
     -e GEMINI_PROJECT_ID
     -e GEMINI_ENABLED
+    -e GEMINI_MODEL
+    -e GEMINI_LOCATION
   )
   log "Gemini 설정 추가됨"
 fi

--- a/src/main/java/com/ject/vs/ai/config/GeminiProperties.java
+++ b/src/main/java/com/ject/vs/ai/config/GeminiProperties.java
@@ -11,10 +11,13 @@ public record GeminiProperties(
 ) {
     public GeminiProperties {
         if (location == null || location.isBlank()) {
-            location = "asia-northeast3";
+            // asia-northeast3(서울)은 Gemini 모델 가용성이 없어 NOT_FOUND가 발생한다.
+            // Gemini 모델이 보장되는 리전을 기본값으로 사용한다. (필요 시 GEMINI_LOCATION으로 override)
+            location = "us-central1";
         }
         if (model == null || model.isBlank()) {
-            model = "gemini-1.5-flash";
+            // gemini-1.5 계열은 retired. 현행 모델을 기본값으로 사용한다. (필요 시 GEMINI_MODEL로 override)
+            model = "gemini-2.0-flash";
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,8 +17,10 @@ aws:
 
 gemini:
   project-id: ${GEMINI_PROJECT_ID:}
-  location: ${GEMINI_LOCATION:asia-northeast3}
-  model: ${GEMINI_MODEL:gemini-1.5-flash}
+  # 서울(asia-northeast3)은 Gemini 모델 미지원 → us-central1 사용. GEMINI_LOCATION으로 override 가능
+  location: ${GEMINI_LOCATION:us-central1}
+  # gemini-1.5 계열 retired → 현행 모델 사용. GEMINI_MODEL로 override 가능
+  model: ${GEMINI_MODEL:gemini-2.0-flash}
   enabled: ${GEMINI_ENABLED:false}
 
 # 오늘의 추천 투표 설정 권한 (운영진 user id 목록)


### PR DESCRIPTION
## 🔍 작업 내용
운영에서 투표 종료 후 AI 개인화 인사이트가 생성되지 않던 문제를 수정합니다.
원인은 Vertex AI 호출 시 모델·리전 조합이 유효하지 않아 `NOT_FOUND` 예외가 발생한 것입니다.
(파이프라인·인증·project-id는 정상, 모델만 미존재)

## 📝 변경 사항
- Gemini 기본 모델 `gemini-1.5-flash`(retired) → `gemini-2.0-flash`
- Gemini 기본 리전 `asia-northeast3`(Gemini 미지원) → `us-central1`
- `deploy.sh`가 컨테이너에 `GEMINI_MODEL`/`GEMINI_LOCATION` 환경변수를 전달하도록 추가
  (기존엔 `GEMINI_PROJECT_ID`/`GEMINI_ENABLED`만 넘겨 env 튜닝이 적용되지 않던 문제)

## 💬 리뷰어에게
- 운영 로그 실제 에러:
  `NOT_FOUND: Publisher Model .../asia-northeast3/.../gemini-1.5-flash was not found`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타 변경사항 (Chores)**
  * Gemini 모델 기본값을 최신 버전으로 업데이트
  * Gemini 위치 기본값을 변경
  * 배포 설정에서 Gemini 환경 변수 전달 방식 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->