### PR TITLE
fix: Gemini 모델을 gemini-2.5-flash로 변경 (2.0-flash 접근권 없음/404)

### DIFF
--- a/src/main/java/com/ject/vs/ai/config/GeminiProperties.java
+++ b/src/main/java/com/ject/vs/ai/config/GeminiProperties.java
@@ -16,8 +16,8 @@ public record GeminiProperties(
             location = "us-central1";
         }
         if (model == null || model.isBlank()) {
-            // gemini-1.5 계열은 retired. 현행 모델을 기본값으로 사용한다. (필요 시 GEMINI_MODEL로 override)
-            model = "gemini-2.0-flash";
+            // gemini-1.5 retired, 2.0-flash는 프로젝트 접근권 없음(404). 접근 확인된 모델 사용. (필요 시 GEMINI_MODEL로 override)
+            model = "gemini-2.5-flash";
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,8 +19,8 @@ gemini:
   project-id: ${GEMINI_PROJECT_ID:}
   # 서울(asia-northeast3)은 Gemini 모델 미지원 → us-central1 사용. GEMINI_LOCATION으로 override 가능
   location: ${GEMINI_LOCATION:us-central1}
-  # gemini-1.5 계열 retired → 현행 모델 사용. GEMINI_MODEL로 override 가능
-  model: ${GEMINI_MODEL:gemini-2.0-flash}
+  # gemini-1.5 retired, 2.0-flash는 이 프로젝트 접근권 없음(404). 접근 확인된 2.5-flash 사용. GEMINI_MODEL로 override 가능
+  model: ${GEMINI_MODEL:gemini-2.5-flash}
   enabled: ${GEMINI_ENABLED:false}
 
 # 오늘의 추천 투표 설정 권한 (운영진 user id 목록)


### PR DESCRIPTION
## 📌 관련 이슈
- closes #

## 🔍 작업 내용
AI 인사이트가 여전히 생성되지 않던 문제 후속 수정. GCP에서 직접 호출 테스트 결과 프로젝트(jectvsserver)가 `gemini-2.0-flash`에는 접근권이 없고(404), `gemini-2.5-flash`는 정상 동작(200) 확인.

## 📝 변경 사항
- Gemini 기본 모델 `gemini-2.0-flash` → `gemini-2.5-flash` (us-central1)

## 💬 리뷰어에게
- us-central1 직접 호출 검증: 2.0-flash/2.0-flash-001/flash-latest = 404, **2.5-flash = 200**