### PR TITLE
fix: 채팅 목록을 최근 메시지 시간 기준 내림차순 정렬

### DIFF
--- a/src/main/java/com/ject/vs/chat/port/ChatService.java
+++ b/src/main/java/com/ject/vs/chat/port/ChatService.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -98,6 +99,9 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
                             unreadCount
                     );
                 })
+                .sorted(Comparator.comparing(
+                        ChatListItemResult::lastMessageAt,
+                        Comparator.nullsLast(Comparator.reverseOrder())))
                 .toList();
     }
 

--- a/src/unitTest/java/com/ject/vs/chat/port/ChatServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/chat/port/ChatServiceTest.java
@@ -6,10 +6,12 @@ import com.ject.vs.chat.domain.ChatRoomUnread;
 import com.ject.vs.chat.domain.ChatRoomUnreadRepository;
 import com.ject.vs.chat.exception.ChatForbiddenException;
 import com.ject.vs.chat.exception.InvalidMessageException;
+import com.ject.vs.chat.port.in.dto.ChatListItemResult;
 import com.ject.vs.chat.port.in.dto.MarkAsReadCommand;
 import com.ject.vs.chat.port.in.dto.MessagePageResult;
 import com.ject.vs.chat.port.in.dto.MessageResult;
 import com.ject.vs.chat.port.in.dto.SendMessageCommand;
+import com.ject.vs.vote.domain.VoteStatus;
 import com.ject.vs.user.domain.ImageColor;
 import com.ject.vs.user.domain.User;
 import com.ject.vs.user.port.in.UserQueryUseCase;
@@ -27,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -136,6 +139,57 @@ class ChatServiceTest {
 
             // then
             assertThat(existing.getLastReadMessageId()).isEqualTo(20L);
+        }
+    }
+
+    @Nested
+    class getChatList {
+
+        @Test
+        void 최근_메시지_시간_기준_내림차순으로_정렬한다() {
+            // given
+            Long userId = 1L;
+            given(voteParticipationQueryUseCase.findAllVoteIdsByUserId(userId)).willReturn(List.of(10L, 20L, 30L));
+            given(voteQueryUseCase.findAllVoteIdsByStatus(List.of(10L, 20L, 30L), VoteStatus.ONGOING))
+                    .willReturn(List.of(10L, 20L, 30L));
+
+            Instant endAt = Instant.parse("2026-12-31T00:00:00Z");
+            given(voteQueryUseCase.getVoteChatSummary(10L))
+                    .willReturn(new VoteQueryUseCase.VoteChatSummary(10L, "t10", null, VoteStatus.ONGOING, endAt, "A", "B"));
+            given(voteQueryUseCase.getVoteChatSummary(20L))
+                    .willReturn(new VoteQueryUseCase.VoteChatSummary(20L, "t20", null, VoteStatus.ONGOING, endAt, "A", "B"));
+            given(voteQueryUseCase.getVoteChatSummary(30L))
+                    .willReturn(new VoteQueryUseCase.VoteChatSummary(30L, "t30", null, VoteStatus.ONGOING, endAt, "A", "B"));
+
+            given(voteParticipationQueryUseCase.countParticipantsByVoteId(any())).willReturn(1L);
+            given(chatRoomUnreadRepository.findByIdUserIdAndIdVoteId(eq(userId), any())).willReturn(Optional.empty());
+            given(chatMessageRepository.countByVoteId(any())).willReturn(0L);
+
+            ChatMessage oldMsg = mock(ChatMessage.class);
+            ChatMessage midMsg = mock(ChatMessage.class);
+            ChatMessage newMsg = mock(ChatMessage.class);
+
+            given(oldMsg.getContent()).willReturn("old");
+            given(midMsg.getContent()).willReturn("mid");
+            given(newMsg.getContent()).willReturn("new");
+            given(oldMsg.getCreatedAt()).willReturn(Instant.parse("2026-01-01T00:00:00Z"));
+            given(midMsg.getCreatedAt()).willReturn(Instant.parse("2026-01-02T00:00:00Z"));
+            given(newMsg.getCreatedAt()).willReturn(Instant.parse("2026-01-03T00:00:00Z"));
+
+            given(chatMessageRepository.findFirstByVoteIdOrderByIdDesc(10L)).willReturn(Optional.of(oldMsg));
+            given(chatMessageRepository.findFirstByVoteIdOrderByIdDesc(20L)).willReturn(Optional.of(midMsg));
+            given(chatMessageRepository.findFirstByVoteIdOrderByIdDesc(30L)).willReturn(Optional.of(newMsg));
+
+            // when
+            List<ChatListItemResult> result = chatService.getChatList(userId, VoteStatus.ONGOING);
+
+            // then
+            assertThat(result).extracting(ChatListItemResult::voteId).containsExactly(30L, 20L, 10L);
+            assertThat(result).extracting(ChatListItemResult::lastMessageAt)
+                    .containsExactly(
+                            Instant.parse("2026-01-03T00:00:00Z"),
+                            Instant.parse("2026-01-02T00:00:00Z"),
+                            Instant.parse("2026-01-01T00:00:00Z"));
         }
     }
 


### PR DESCRIPTION
## Summary

`GET /api/chats` 응답을 **최근 메시지 시간(`lastMessageAt`) 기준 내림차순**으로 정렬합니다.

## Changes

- `ChatService.getChatList()` 결과에 `lastMessageAt` desc 정렬 적용
- 메시지가 없는 채팅방(`lastMessageAt == null`)은 목록 맨 아래로 배치

## Test plan

- [x] `./gradlew unitTest --tests "com.ject.vs.chat.port.ChatServiceTest"`
- [ ] 진행 중/종료 탭 채팅 목록에서 최근 대화한 방이 상단에 노출되는지 확인