### PR TITLE
fix: 투표 취소 후 채팅 메시지 senderVoteOption null 반환

### DIFF
--- a/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
+++ b/src/main/java/com/ject/vs/chat/adapter/event/ChatMessageEventListener.java
@@ -36,7 +36,7 @@ public class ChatMessageEventListener {
 
         User sender = userQueryUseCase.getUser(message.getSenderId());
         VoteOptionCode voteOptionCode =
-                voteQueryUseCase.getSelectedOption(message.getVoteId(), message.getSenderId()).getCode();
+                voteQueryUseCase.findSelectedOptionCode(message.getVoteId(), message.getSenderId()).orElse(null);
 
         MessageResult messageResult = new MessageResult(
                 message.getId(),

--- a/src/main/java/com/ject/vs/chat/port/ChatService.java
+++ b/src/main/java/com/ject/vs/chat/port/ChatService.java
@@ -50,7 +50,7 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
         ChatMessage saved = chatMessageRepository.save(message);
         User sender = userQueryUseCase.getUser(command.senderId());
         VoteOptionCode voteOptionCode =
-                voteQueryUseCase.getSelectedOption(command.voteId(), command.senderId()).getCode();
+                voteQueryUseCase.findSelectedOptionCode(command.voteId(), command.senderId()).orElse(null);
 
         return new MessageResult(
                 saved.getId(),
@@ -141,7 +141,7 @@ public class ChatService implements ChatCommandUseCase, ChatQueryUseCase {
                 .map(msg -> {
                     User sender = userQueryUseCase.getUser(msg.getSenderId());
                     VoteOptionCode voteOptionCode =
-                            voteQueryUseCase.getSelectedOption(voteId, msg.getSenderId()).getCode();
+                            voteQueryUseCase.findSelectedOptionCode(voteId, msg.getSenderId()).orElse(null);
 
                     return new MessageResult(
                             msg.getId(),

--- a/src/main/java/com/ject/vs/vote/port/VoteQueryService.java
+++ b/src/main/java/com/ject/vs/vote/port/VoteQueryService.java
@@ -75,6 +75,11 @@ public class VoteQueryService implements VoteQueryUseCase, VoteParticipationQuer
     }
 
     @Override
+    public Optional<VoteOptionCode> findSelectedOptionCode(Long voteId, Long userId) {
+        return getSelectedOptionId(voteId, userId).map(optionId -> getSelectedOption(voteId, userId).getCode());
+    }
+
+    @Override
     public int getParticipantCount(Long voteId) {
         return (int) voteParticipationRepository.countByVoteId(voteId);
     }

--- a/src/main/java/com/ject/vs/vote/port/in/VoteQueryUseCase.java
+++ b/src/main/java/com/ject/vs/vote/port/in/VoteQueryUseCase.java
@@ -22,6 +22,9 @@ public interface VoteQueryUseCase {
 
     VoteOption getSelectedOption(Long voteId, Long userId);
 
+    /** 투표 취소 등 참여 이력이 없으면 empty — 채팅 senderVoteOption null 처리용 */
+    Optional<VoteOptionCode> findSelectedOptionCode(Long voteId, Long userId);
+
     int getParticipantCount(Long voteId);
 
     /** 채팅 도메인 getChatList() 호환용 — 실제 Vote.endAt 기준으로 필터링 */

--- a/src/unitTest/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
+++ b/src/unitTest/java/com/ject/vs/chat/adapter/event/ChatMessageEventListenerTest.java
@@ -10,7 +10,6 @@ import com.ject.vs.chat.port.in.dto.UnreadPayload;
 import com.ject.vs.user.domain.ImageColor;
 import com.ject.vs.user.domain.User;
 import com.ject.vs.user.port.in.UserQueryUseCase;
-import com.ject.vs.vote.domain.VoteOption;
 import com.ject.vs.vote.domain.VoteOptionCode;
 import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
 import com.ject.vs.vote.port.in.VoteQueryUseCase;
@@ -64,9 +63,8 @@ class ChatMessageEventListenerTest {
     void setUpDefaults() {
         lenient().when(userQueryUseCase.getUser(any())).thenReturn(mock(User.class));
 
-        VoteOption dummyOption = mock(VoteOption.class);
-        lenient().when(dummyOption.getCode()).thenReturn(VoteOptionCode.A);
-        lenient().when(voteQueryUseCase.getSelectedOption(anyLong(), anyLong())).thenReturn(dummyOption);
+        lenient().when(voteQueryUseCase.findSelectedOptionCode(anyLong(), anyLong()))
+                .thenReturn(Optional.of(VoteOptionCode.A));
     }
 
     @Nested

--- a/src/unitTest/java/com/ject/vs/chat/port/ChatServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/chat/port/ChatServiceTest.java
@@ -15,7 +15,6 @@ import com.ject.vs.vote.domain.VoteStatus;
 import com.ject.vs.user.domain.ImageColor;
 import com.ject.vs.user.domain.User;
 import com.ject.vs.user.port.in.UserQueryUseCase;
-import com.ject.vs.vote.domain.VoteOption;
 import com.ject.vs.vote.domain.VoteOptionCode;
 import com.ject.vs.vote.port.in.VoteParticipationQueryUseCase;
 import com.ject.vs.vote.port.in.VoteQueryUseCase;
@@ -61,9 +60,6 @@ class ChatServiceTest {
     @Mock
     private UserQueryUseCase userQueryUseCase;
 
-    @Mock
-    private VoteOption selectedOption;
-
     @Nested
     class sendMessage {
 
@@ -98,8 +94,7 @@ class ChatServiceTest {
             given(sender.getNickname()).willReturn("테스트유저");
             given(sender.getImageColor()).willReturn(ImageColor.GREEN);
             given(userQueryUseCase.getUser(2L)).willReturn(sender);
-            given(voteQueryUseCase.getSelectedOption(1L, 2L)).willReturn(selectedOption);
-            given(selectedOption.getCode()).willReturn(VoteOptionCode.A);
+            given(voteQueryUseCase.findSelectedOptionCode(1L, 2L)).willReturn(Optional.of(VoteOptionCode.A));
 
             // when
             MessageResult result = chatService.sendMessage(new SendMessageCommand(1L, 2L, "hello"));
@@ -206,14 +201,14 @@ class ChatServiceTest {
             given(sender.getNickname()).willReturn("");
             given(sender.getImageColor()).willReturn(ImageColor.GREEN);
             given(userQueryUseCase.getUser(2L)).willReturn(sender);
-            given(voteQueryUseCase.getSelectedOption(1L, 2L)).willReturn(selectedOption);
-            given(selectedOption.getCode()).willReturn(null);
+            given(voteQueryUseCase.findSelectedOptionCode(1L, 2L)).willReturn(Optional.empty());
 
             // when
             MessagePageResult result = chatService.getMessages(1L, 2L, null, 30);
 
             // then
             assertThat(result.messages()).hasSize(1);
+            assertThat(result.messages().getFirst().senderVoteOption()).isNull();
             assertThat(result.hasNext()).isFalse();
             verify(chatMessageRepository).findAllByVoteIdOrderByIdDesc(eq(1L), any(PageRequest.class));
         }
@@ -228,8 +223,7 @@ class ChatServiceTest {
             given(sender.getNickname()).willReturn("");
             given(sender.getImageColor()).willReturn(ImageColor.GREEN);
             given(userQueryUseCase.getUser(2L)).willReturn(sender);
-            given(voteQueryUseCase.getSelectedOption(1L, 2L)).willReturn(selectedOption);
-            given(selectedOption.getCode()).willReturn(null);
+            given(voteQueryUseCase.findSelectedOptionCode(1L, 2L)).willReturn(Optional.of(VoteOptionCode.B));
 
             // when
             MessagePageResult result = chatService.getMessages(1L, 2L, 100L, 30);


### PR DESCRIPTION
## Summary

투표 참여를 취소한 사용자의 기존 채팅 메시지에서 `senderVoteOption`이 더 이상 `A`/`B`로 내려가지 않고 **null**로 반환됩니다.

## Changes

- `VoteQueryUseCase.findSelectedOptionCode()` 추가 — 현재 참여 상태가 없으면 empty
- `ChatService` 메시지 조회/전송, `ChatMessageEventListener` WebSocket 브로드캐스트에서 위 API 사용

## Test plan

- [x] `ChatServiceTest`, `ChatMessageEventListenerTest` 통과
- [ ] 투표 → 채팅 전송 → 동일 옵션 재클릭(취소) → 메시지 목록 재조회 시 본인 메시지 `senderVoteOption: null` 확인