### PR TITLE
fix: 투표 종료 푸시 알림 누락 방지

### DIFF
--- a/src/main/java/com/ject/vs/notification/adapter/out/fcm/FcmSenderAdapter.java
+++ b/src/main/java/com/ject/vs/notification/adapter/out/fcm/FcmSenderAdapter.java
@@ -3,6 +3,7 @@ package com.ject.vs.notification.adapter.out.fcm;
 import com.google.firebase.messaging.*;
 import com.ject.vs.notification.port.out.FcmPayload;
 import com.ject.vs.notification.port.out.PushSenderPort;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -18,6 +19,11 @@ import java.util.List;
 public class FcmSenderAdapter implements PushSenderPort {
 
     private final FirebaseMessaging firebaseMessaging;
+
+    @PostConstruct
+    void logActivation() {
+        log.info("Push sender: FCM enabled (FcmSenderAdapter active)");
+    }
 
     @Override
     public List<String> sendMulticast(List<String> tokens, FcmPayload payload) {
@@ -50,8 +56,10 @@ public class FcmSenderAdapter implements PushSenderPort {
             SendResponse r = responses.get(i);
             if (!r.isSuccessful()) {
                 MessagingErrorCode code = r.getException().getMessagingErrorCode();
-                if (code == MessagingErrorCode.UNREGISTERED
-                        || code == MessagingErrorCode.INVALID_ARGUMENT) {
+                // UNREGISTERED만 "확실히 죽은 토큰"으로 보고 삭제한다.
+                // INVALID_ARGUMENT는 페이로드 형식 문제로도 발생할 수 있어, 이를 만료로 간주하면
+                // 멀쩡한 토큰까지 한꺼번에 지워져 이후 발송이 영구히 막힐 수 있다.
+                if (code == MessagingErrorCode.UNREGISTERED) {
                     expired.add(tokens.get(i));
                 } else {
                     log.warn("FCM send failed token={} code={}", tokens.get(i), code);

--- a/src/main/java/com/ject/vs/notification/adapter/out/fcm/NoOpPushSenderAdapter.java
+++ b/src/main/java/com/ject/vs/notification/adapter/out/fcm/NoOpPushSenderAdapter.java
@@ -2,6 +2,7 @@ package com.ject.vs.notification.adapter.out.fcm;
 
 import com.ject.vs.notification.port.out.FcmPayload;
 import com.ject.vs.notification.port.out.PushSenderPort;
+import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
@@ -12,6 +13,14 @@ import java.util.List;
 @ConditionalOnExpression("'${firebase.service-account-path:}' == ''")
 @Slf4j
 public class NoOpPushSenderAdapter implements PushSenderPort {
+
+    @PostConstruct
+    void logActivation() {
+        // firebase.service-account-path가 비어 있어 FCM이 비활성화된 상태.
+        // 운영에서 푸시가 전혀 안 갈 때 이 로그로 원인을 즉시 식별할 수 있도록 WARN으로 남긴다.
+        log.warn("Push sender: FCM DISABLED (NoOpPushSenderAdapter active) — "
+                + "firebase.service-account-path 미설정. 푸시 알림이 발송되지 않습니다.");
+    }
 
     @Override
     public List<String> sendMulticast(List<String> tokens, FcmPayload payload) {

--- a/src/main/java/com/ject/vs/notification/event/PushNotificationSender.java
+++ b/src/main/java/com/ject/vs/notification/event/PushNotificationSender.java
@@ -8,10 +8,11 @@ import com.ject.vs.notification.port.out.FcmPayload;
 import com.ject.vs.notification.port.out.PushSenderPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.Clock;
 import java.util.ArrayList;
@@ -29,9 +30,15 @@ public class PushNotificationSender {
     private final PushSenderPort pushSender;
     private final Clock clock;
 
-    @EventListener
-    @Async("notificationExecutor")
-    @Transactional
+    // 알림 row를 만든 트랜잭션이 커밋된 뒤에 발송한다.
+    // 평범한 @EventListener + @Async 조합은 발행 트랜잭션 커밋 전에 별도 스레드/트랜잭션에서
+    // findAllById가 실행돼 빈 결과를 받고 발송이 통째로 누락되는 race가 있었다.
+    // - @Async는 함께 쓸 수 없다(@TransactionalEventListener와 동시 사용 시 Spring이 거부).
+    //   발행 스레드(투표 종료는 notif- 비동기 풀 스레드)에서 커밋 직후 동기로 실행되므로 문제없다.
+    // - 커밋 이후 단계라 기존 트랜잭션이 없으므로 REQUIRES_NEW로 markSent/토큰 삭제를 새 트랜잭션에 커밋한다.
+    // - fallbackExecution=true: 혹시 트랜잭션 밖에서 발행돼도 발송되도록 한다.
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void on(NotificationCreatedEvent event) {
         List<Long> notificationIds = event.notificationIds();
         if (notificationIds.isEmpty()) return;


### PR DESCRIPTION
## 📌 관련 이슈
- closes #이슈번호

## 🔍 작업 내용
투표 종료 시 푸시 알림이 발송되지 않는 문제를 수정했습니다.
알림 생성 트랜잭션이 커밋되기 전에 비동기 발송 리스너가 실행돼 빈 결과를 읽고 발송이 통째로 누락되는 race condition이 원인이었습니다.

## 📝 변경 사항
- PushNotificationSender: @EventListener + @Async → @TransactionalEventListener(AFTER_COMMIT) + REQUIRES_NEW 로 변경. 알림 생성 트랜잭션이 커밋된 뒤 발송하도록 해 race로 인한 발송 누락 제거
- FcmSenderAdapter: INVALID_ARGUMENT를 만료 토큰으로 간주해 삭제하던 로직 제거 (UNREGISTERED만 삭제). 페이로드 형식 오류 시 정상 토큰까지 대량 삭제돼 영구 미발송되는 사고 방지
- 진단성: FCM 활성(FcmSenderAdapter) / 비활성(NoOpPushSenderAdapter) 여부를 기동 로그로 식별 가능하게 추가

## 💬 리뷰어에게
- @TransactionalEventListener + @Async는 Spring이 동시 사용을 막아 @Async를 제거했습니다. 발송은 발행 스레드(투표 종료는 notif- 비동기 풀 스레드)에서 커밋 직후 동기 실행됩니다. AdminPushService(관리자 테스트 푸시)만 요청 스레드에서 동기 발송되는데, 빈도가 낮아 허용 가능하다고 판단했습니다
- INVALID_ARGUMENT 토큰 삭제 제거가 적절한지(UNREGISTERED만 삭제) 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 푸시 알림 발송 시 토큰 처리 로직을 개선하여 불필요한 토큰 삭제를 방지했습니다.

* **Chores**
  * 알림 시스템 활성화 상태를 로그로 기록하도록 개선했습니다.
  * 푸시 알림 발송의 트랜잭션 처리를 개선하여 데이터 일관성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->