### PR TITLE
feat: 투표 종료 후속 처리 멱등성 개선

### DIFF
--- a/src/integrationTest/java/com/ject/vs/vote/domain/VoteRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/com/ject/vs/vote/domain/VoteRepositoryIntegrationTest.java
@@ -199,17 +199,35 @@ class VoteRepositoryIntegrationTest {
         }
 
         @Test
-        @DisplayName("findExpiredOngoing은 현재 시각 기준 종료된 투표를 반환한다")
-        void findExpiredOngoing은_종료된_투표를_반환한다() {
+        @DisplayName("findUnprocessedExpired는 미처리·종료된 투표만 반환한다")
+        void findUnprocessedExpired는_미처리_종료_투표만_반환한다() {
             // given
             Instant queryTime = BASE_TIME.plus(Duration.ofHours(2));
 
             // when
-            List<Vote> expiredVotes = voteRepository.findExpiredOngoing(queryTime);
+            List<Vote> expiredVotes = voteRepository.findUnprocessedExpired(queryTime);
 
             // then
             assertThat(expiredVotes).hasSize(1);
             assertThat(expiredVotes.get(0).getTitle()).isEqualTo("종료된 투표");
+        }
+
+        @Test
+        @DisplayName("findUnprocessedExpired는 endedProcessedAt이 있는 투표를 제외한다")
+        void findUnprocessedExpired는_이미_처리된_투표를_제외한다() {
+            // given
+            Instant queryTime = BASE_TIME.plus(Duration.ofHours(2));
+            Vote foundExpired = voteRepository.findById(expiredVote.getId()).orElseThrow();
+            foundExpired.markEndedProcessed(FIXED_CLOCK);
+            voteRepository.save(foundExpired);
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            List<Vote> expiredVotes = voteRepository.findUnprocessedExpired(queryTime);
+
+            // then
+            assertThat(expiredVotes).isEmpty();
         }
 
         @Test

--- a/src/main/java/com/ject/vs/vote/domain/Vote.java
+++ b/src/main/java/com/ject/vs/vote/domain/Vote.java
@@ -35,6 +35,8 @@ public class Vote extends BaseTimeEntity {
     @Column(nullable = false)
     private Instant endAt;
 
+    private Instant endedProcessedAt;
+
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "vote_id", insertable = false, updatable = false)
     private List<VoteOption> options = new ArrayList<>();
@@ -117,5 +119,14 @@ public class Vote extends BaseTimeEntity {
 
     public boolean hasAiInsight() {
         return aiInsightHeadline != null && aiInsightBody != null;
+    }
+
+    public boolean isEndedProcessed() {
+        return endedProcessedAt != null;
+    }
+
+    public void markEndedProcessed(Clock clock) {
+        if (endedProcessedAt != null) return;
+        this.endedProcessedAt = Instant.now(clock);
     }
 }

--- a/src/main/java/com/ject/vs/vote/domain/VoteRepository.java
+++ b/src/main/java/com/ject/vs/vote/domain/VoteRepository.java
@@ -13,8 +13,12 @@ import java.util.List;
 
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 
-    @Query("SELECT v FROM Vote v WHERE v.endAt < :now")
-    List<Vote> findExpiredOngoing(@Param("now") Instant now);
+    @Query("""
+        SELECT v FROM Vote v
+         WHERE v.endAt < :now
+           AND v.endedProcessedAt IS NULL
+        """)
+    List<Vote> findUnprocessedExpired(@Param("now") Instant now);
 
     List<Vote> findAllByIdIn(List<Long> ids);
 

--- a/src/main/java/com/ject/vs/vote/scheduler/VoteCloseScheduler.java
+++ b/src/main/java/com/ject/vs/vote/scheduler/VoteCloseScheduler.java
@@ -26,12 +26,14 @@ public class VoteCloseScheduler {
     @Scheduled(cron = "0 * * * * *")
     @Transactional
     public void closeExpiredVotes() {
-        List<Vote> expired = voteRepository.findExpiredOngoing(Instant.now(clock));
+        Instant now = Instant.now(clock);
+        List<Vote> expired = voteRepository.findUnprocessedExpired(now);
         for (Vote vote : expired) {
+            vote.markEndedProcessed(clock);
             eventPublisher.publishEvent(new VoteEndedEvent(vote.getId()));
         }
         if (!expired.isEmpty()) {
-            log.info("Closed {} expired votes", expired.size());
+            log.info("Processed {} newly expired votes", expired.size());
         }
     }
 }

--- a/src/main/resources/db/migration/V13__vote_ended_processed_and_notification_unique.sql
+++ b/src/main/resources/db/migration/V13__vote_ended_processed_and_notification_unique.sql
@@ -8,22 +8,3 @@ UPDATE vote
    SET ended_processed_at = end_at
  WHERE end_at < CURRENT_TIMESTAMP
    AND ended_processed_at IS NULL;
-
--- 동일 투표·사용자·타입 알림 중복 방지 (race condition 안전망)
-DELETE FROM notification
- WHERE id IN (
-    SELECT duplicates.id
-      FROM (
-        SELECT n1.id AS id
-          FROM notification n1
-          INNER JOIN notification n2
-                  ON n1.vote_id = n2.vote_id
-                 AND n1.user_id = n2.user_id
-                 AND n1.type = n2.type
-                 AND n1.id > n2.id
-         WHERE n1.vote_id IS NOT NULL
-      ) duplicates
- );
-
-ALTER TABLE notification
-    ADD CONSTRAINT uq_notification_vote_user_type UNIQUE (vote_id, user_id, type);

--- a/src/main/resources/db/migration/V13__vote_ended_processed_and_notification_unique.sql
+++ b/src/main/resources/db/migration/V13__vote_ended_processed_and_notification_unique.sql
@@ -1,25 +1,29 @@
 -- 투표 종료 후속 처리(알림 등)를 한 번만 트리거하기 위한 마커
 ALTER TABLE vote ADD COLUMN ended_processed_at TIMESTAMP WITH TIME ZONE;
 
-CREATE INDEX idx_vote_unprocessed_expired
-    ON vote (end_at)
-    WHERE ended_processed_at IS NULL;
+CREATE INDEX idx_vote_ended_processed_end_at ON vote (ended_processed_at, end_at);
 
 -- 배포 시점에 이미 종료된 투표는 재처리하지 않음
 UPDATE vote
    SET ended_processed_at = end_at
- WHERE end_at < now()
+ WHERE end_at < CURRENT_TIMESTAMP
    AND ended_processed_at IS NULL;
 
 -- 동일 투표·사용자·타입 알림 중복 방지 (race condition 안전망)
-DELETE FROM notification n1
- USING notification n2
- WHERE n1.id > n2.id
-   AND n1.vote_id IS NOT NULL
-   AND n1.vote_id = n2.vote_id
-   AND n1.user_id = n2.user_id
-   AND n1.type = n2.type;
+DELETE FROM notification
+ WHERE id IN (
+    SELECT duplicates.id
+      FROM (
+        SELECT n1.id AS id
+          FROM notification n1
+          INNER JOIN notification n2
+                  ON n1.vote_id = n2.vote_id
+                 AND n1.user_id = n2.user_id
+                 AND n1.type = n2.type
+                 AND n1.id > n2.id
+         WHERE n1.vote_id IS NOT NULL
+      ) duplicates
+ );
 
-CREATE UNIQUE INDEX uq_notification_vote_user_type
-    ON notification (vote_id, user_id, type)
-    WHERE vote_id IS NOT NULL;
+ALTER TABLE notification
+    ADD CONSTRAINT uq_notification_vote_user_type UNIQUE (vote_id, user_id, type);

--- a/src/main/resources/db/migration/V13__vote_ended_processed_and_notification_unique.sql
+++ b/src/main/resources/db/migration/V13__vote_ended_processed_and_notification_unique.sql
@@ -1,0 +1,25 @@
+-- 투표 종료 후속 처리(알림 등)를 한 번만 트리거하기 위한 마커
+ALTER TABLE vote ADD COLUMN ended_processed_at TIMESTAMP WITH TIME ZONE;
+
+CREATE INDEX idx_vote_unprocessed_expired
+    ON vote (end_at)
+    WHERE ended_processed_at IS NULL;
+
+-- 배포 시점에 이미 종료된 투표는 재처리하지 않음
+UPDATE vote
+   SET ended_processed_at = end_at
+ WHERE end_at < now()
+   AND ended_processed_at IS NULL;
+
+-- 동일 투표·사용자·타입 알림 중복 방지 (race condition 안전망)
+DELETE FROM notification n1
+ USING notification n2
+ WHERE n1.id > n2.id
+   AND n1.vote_id IS NOT NULL
+   AND n1.vote_id = n2.vote_id
+   AND n1.user_id = n2.user_id
+   AND n1.type = n2.type;
+
+CREATE UNIQUE INDEX uq_notification_vote_user_type
+    ON notification (vote_id, user_id, type)
+    WHERE vote_id IS NOT NULL;

--- a/src/unitTest/java/com/ject/vs/notification/event/VoteEndedNotificationHandlerTest.java
+++ b/src/unitTest/java/com/ject/vs/notification/event/VoteEndedNotificationHandlerTest.java
@@ -1,0 +1,216 @@
+package com.ject.vs.notification.event;
+
+import com.ject.vs.notification.domain.Notification;
+import com.ject.vs.notification.domain.NotificationRepository;
+import com.ject.vs.notification.domain.NotificationType;
+import com.ject.vs.notification.port.in.NotificationCommandUseCase;
+import com.ject.vs.notification.port.in.NotificationCommandUseCase.NotificationCreateCommand;
+import com.ject.vs.notification.port.out.VoteQueryPort;
+import com.ject.vs.vote.domain.Vote;
+import com.ject.vs.vote.domain.VoteParticipationRepository;
+import com.ject.vs.vote.event.VoteEndedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class VoteEndedNotificationHandlerTest {
+
+    @InjectMocks
+    private VoteEndedNotificationHandler handler;
+
+    @Mock
+    private VoteQueryPort voteQueryPort;
+
+    @Mock
+    private VoteParticipationRepository voteParticipationRepository;
+
+    @Mock
+    private NotificationCommandUseCase notificationCommandUseCase;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private Clock clock;
+
+    private static final Long VOTE_ID = 100L;
+    private static final Instant FIXED_INSTANT = Instant.parse("2024-01-15T10:00:00Z");
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(clock.instant()).thenReturn(FIXED_INSTANT);
+        lenient().when(clock.getZone()).thenReturn(ZONE_ID);
+    }
+
+    private Vote createVote() {
+        Vote vote = Vote.create("테스트 투표", null, "thumb.png", null,
+                Duration.ofHours(1), clock);
+        ReflectionTestUtils.setField(vote, "id", VOTE_ID);
+        return vote;
+    }
+
+    private Notification createNotificationWithId(Long id, Long userId) {
+        Notification notification = Notification.ofVoteEnded(
+                userId, VOTE_ID, "테스트 투표", "thumb.png", clock);
+        ReflectionTestUtils.setField(notification, "id", id);
+        return notification;
+    }
+
+    @Nested
+    @DisplayName("on (VoteEndedEvent 핸들러)")
+    class OnVoteEnded {
+
+        @Test
+        @DisplayName("참여자가 없으면 알림을 생성하지 않는다")
+        void does_nothing_when_no_participants() {
+            Vote vote = createVote();
+            given(voteQueryPort.getById(VOTE_ID)).willReturn(vote);
+            given(voteParticipationRepository.findAllUserIdsByVoteId(VOTE_ID)).willReturn(List.of());
+
+            handler.on(new VoteEndedEvent(VOTE_ID));
+
+            verify(notificationCommandUseCase, never()).createBatch(anyList());
+            verify(eventPublisher, never()).publishEvent(any());
+        }
+
+        @Test
+        @DisplayName("참여자에게 알림을 생성하고 NotificationCreatedEvent를 발행한다")
+        void creates_notifications_and_publishes_event() {
+            Vote vote = createVote();
+            given(voteQueryPort.getById(VOTE_ID)).willReturn(vote);
+            given(voteParticipationRepository.findAllUserIdsByVoteId(VOTE_ID))
+                    .willReturn(List.of(1L, 2L));
+            given(notificationRepository.findUserIdsByVoteIdAndType(VOTE_ID, NotificationType.VOTE_ENDED))
+                    .willReturn(List.of());
+
+            Notification n1 = createNotificationWithId(10L, 1L);
+            Notification n2 = createNotificationWithId(20L, 2L);
+            given(notificationCommandUseCase.createBatch(anyList())).willReturn(List.of(n1, n2));
+
+            handler.on(new VoteEndedEvent(VOTE_ID));
+
+            ArgumentCaptor<NotificationCreatedEvent> eventCaptor =
+                    ArgumentCaptor.forClass(NotificationCreatedEvent.class);
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+            assertThat(eventCaptor.getValue().notificationIds()).containsExactly(10L, 20L);
+        }
+
+        @Test
+        @DisplayName("알림 생성 시 VOTE_ENDED 타입과 투표 정보가 포함된다")
+        void creates_commands_with_vote_info() {
+            Vote vote = createVote();
+            given(voteQueryPort.getById(VOTE_ID)).willReturn(vote);
+            given(voteParticipationRepository.findAllUserIdsByVoteId(VOTE_ID))
+                    .willReturn(List.of(1L));
+            given(notificationRepository.findUserIdsByVoteIdAndType(VOTE_ID, NotificationType.VOTE_ENDED))
+                    .willReturn(List.of());
+
+            Notification n1 = createNotificationWithId(10L, 1L);
+            given(notificationCommandUseCase.createBatch(anyList())).willReturn(List.of(n1));
+
+            handler.on(new VoteEndedEvent(VOTE_ID));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<NotificationCreateCommand>> commandCaptor =
+                    ArgumentCaptor.forClass(List.class);
+            verify(notificationCommandUseCase).createBatch(commandCaptor.capture());
+
+            NotificationCreateCommand command = commandCaptor.getValue().getFirst();
+            assertThat(command.userId()).isEqualTo(1L);
+            assertThat(command.type()).isEqualTo(NotificationType.VOTE_ENDED);
+            assertThat(command.voteId()).isEqualTo(VOTE_ID);
+            assertThat(command.title()).isEqualTo("테스트 투표");
+            assertThat(command.body()).isEqualTo("투표 결과가 공개됐어요");
+            assertThat(command.thumbnailUrl()).isEqualTo("thumb.png");
+        }
+
+        @Test
+        @DisplayName("이미 알림을 받은 참여자는 제외한다")
+        void excludes_already_notified_participants() {
+            Vote vote = createVote();
+            given(voteQueryPort.getById(VOTE_ID)).willReturn(vote);
+            given(voteParticipationRepository.findAllUserIdsByVoteId(VOTE_ID))
+                    .willReturn(List.of(1L, 2L, 3L));
+            given(notificationRepository.findUserIdsByVoteIdAndType(VOTE_ID, NotificationType.VOTE_ENDED))
+                    .willReturn(List.of(2L));
+
+            Notification n1 = createNotificationWithId(10L, 1L);
+            Notification n3 = createNotificationWithId(30L, 3L);
+            given(notificationCommandUseCase.createBatch(anyList())).willReturn(List.of(n1, n3));
+
+            handler.on(new VoteEndedEvent(VOTE_ID));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<NotificationCreateCommand>> commandCaptor =
+                    ArgumentCaptor.forClass(List.class);
+            verify(notificationCommandUseCase).createBatch(commandCaptor.capture());
+
+            List<Long> targetUserIds = commandCaptor.getValue().stream()
+                    .map(NotificationCreateCommand::userId)
+                    .toList();
+            assertThat(targetUserIds).containsExactly(1L, 3L);
+        }
+
+        @Test
+        @DisplayName("모든 참여자가 이미 알림을 받았으면 이벤트를 발행하지 않는다")
+        void does_not_publish_event_when_all_already_notified() {
+            Vote vote = createVote();
+            given(voteQueryPort.getById(VOTE_ID)).willReturn(vote);
+            given(voteParticipationRepository.findAllUserIdsByVoteId(VOTE_ID))
+                    .willReturn(List.of(1L, 2L));
+            given(notificationRepository.findUserIdsByVoteIdAndType(VOTE_ID, NotificationType.VOTE_ENDED))
+                    .willReturn(List.of(1L, 2L));
+
+            handler.on(new VoteEndedEvent(VOTE_ID));
+
+            verify(notificationCommandUseCase, never()).createBatch(anyList());
+            verify(eventPublisher, never()).publishEvent(any());
+        }
+
+        @Test
+        @DisplayName("createBatch 결과가 비어 있으면 빈 NotificationCreatedEvent를 발행한다")
+        void publishes_empty_event_when_create_batch_returns_empty() {
+            Vote vote = createVote();
+            given(voteQueryPort.getById(VOTE_ID)).willReturn(vote);
+            given(voteParticipationRepository.findAllUserIdsByVoteId(VOTE_ID))
+                    .willReturn(List.of(1L));
+            given(notificationRepository.findUserIdsByVoteIdAndType(VOTE_ID, NotificationType.VOTE_ENDED))
+                    .willReturn(List.of());
+            given(notificationCommandUseCase.createBatch(anyList())).willReturn(List.of());
+
+            handler.on(new VoteEndedEvent(VOTE_ID));
+
+            ArgumentCaptor<NotificationCreatedEvent> eventCaptor =
+                    ArgumentCaptor.forClass(NotificationCreatedEvent.class);
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+            assertThat(eventCaptor.getValue().notificationIds()).isEmpty();
+        }
+    }
+}

--- a/src/unitTest/java/com/ject/vs/vote/domain/VoteTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/domain/VoteTest.java
@@ -91,6 +91,33 @@ class VoteTest {
     }
 
     @Nested
+    class markEndedProcessed {
+
+        @Test
+        void 최초_호출_시_처리_시각이_기록된다() {
+            Vote vote = Vote.create("제목", null, "thumb", null,
+                    Duration.ofHours(24), FIXED_CLOCK);
+
+            vote.markEndedProcessed(FIXED_CLOCK);
+
+            assertThat(vote.isEndedProcessed()).isTrue();
+            assertThat(vote.getEndedProcessedAt()).isEqualTo(Instant.parse("2025-01-01T00:00:00Z"));
+        }
+
+        @Test
+        void 이미_처리된_투표는_재호출해도_시각이_변경되지_않는다() {
+            Vote vote = Vote.create("제목", null, "thumb", null,
+                    Duration.ofHours(24), FIXED_CLOCK);
+            vote.markEndedProcessed(FIXED_CLOCK);
+
+            Clock later = Clock.fixed(Instant.parse("2025-01-02T00:00:00Z"), ZoneOffset.UTC);
+            vote.markEndedProcessed(later);
+
+            assertThat(vote.getEndedProcessedAt()).isEqualTo(Instant.parse("2025-01-01T00:00:00Z"));
+        }
+    }
+
+    @Nested
     class cacheAiInsight {
 
         @Test

--- a/src/unitTest/java/com/ject/vs/vote/scheduler/VoteCloseSchedulerTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/scheduler/VoteCloseSchedulerTest.java
@@ -51,14 +51,16 @@ class VoteCloseSchedulerTest {
     class closeExpiredVotes {
 
         @Test
-        void 만료된_투표가_있으면_markEnded_호출하고_이벤트_발행() {
+        void 미처리_만료_투표가_있으면_처리_마킹하고_이벤트_발행() {
             Vote expired = makeExpiredVote();
-            given(clock.instant()).willReturn(Instant.parse("2025-01-01T02:00:00Z"));
-            given(voteRepository.findExpiredOngoing(any())).willReturn(List.of(expired));
+            Instant now = Instant.parse("2025-01-01T02:00:00Z");
+            given(clock.instant()).willReturn(now);
+            given(voteRepository.findUnprocessedExpired(now)).willReturn(List.of(expired));
 
             scheduler.closeExpiredVotes();
 
             assertThat(expired.getStatus()).isEqualTo(VoteStatus.ENDED);
+            assertThat(expired.isEndedProcessed()).isTrue();
 
             ArgumentCaptor<VoteEndedEvent> captor = ArgumentCaptor.forClass(VoteEndedEvent.class);
             verify(eventPublisher).publishEvent(captor.capture());
@@ -66,9 +68,10 @@ class VoteCloseSchedulerTest {
         }
 
         @Test
-        void 만료된_투표_없으면_이벤트_미발행() {
-            given(clock.instant()).willReturn(Instant.parse("2025-01-01T02:00:00Z"));
-            given(voteRepository.findExpiredOngoing(any())).willReturn(List.of());
+        void 미처리_만료_투표_없으면_이벤트_미발행() {
+            Instant now = Instant.parse("2025-01-01T02:00:00Z");
+            given(clock.instant()).willReturn(now);
+            given(voteRepository.findUnprocessedExpired(now)).willReturn(List.of());
 
             scheduler.closeExpiredVotes();
 
@@ -76,28 +79,31 @@ class VoteCloseSchedulerTest {
         }
 
         @Test
-        void 만료된_투표_여러개이면_각각_이벤트_발행() {
+        void 미처리_만료_투표_여러개이면_각각_처리_마킹하고_이벤트_발행() {
             Vote v1 = makeExpiredVote();
             Vote v2 = makeExpiredVote();
-            given(clock.instant()).willReturn(Instant.parse("2025-01-01T02:00:00Z"));
-            given(voteRepository.findExpiredOngoing(any())).willReturn(List.of(v1, v2));
+            Instant now = Instant.parse("2025-01-01T02:00:00Z");
+            given(clock.instant()).willReturn(now);
+            given(voteRepository.findUnprocessedExpired(now)).willReturn(List.of(v1, v2));
 
             scheduler.closeExpiredVotes();
 
             assertThat(v1.getStatus()).isEqualTo(VoteStatus.ENDED);
             assertThat(v2.getStatus()).isEqualTo(VoteStatus.ENDED);
+            assertThat(v1.isEndedProcessed()).isTrue();
+            assertThat(v2.isEndedProcessed()).isTrue();
             verify(eventPublisher, times(2)).publishEvent(any(VoteEndedEvent.class));
         }
 
         @Test
-        void findExpiredOngoing에_현재_시각_전달() {
+        void findUnprocessedExpired에_현재_시각_전달() {
             Instant now = Instant.parse("2025-06-01T12:00:00Z");
             given(clock.instant()).willReturn(now);
-            given(voteRepository.findExpiredOngoing(now)).willReturn(List.of());
+            given(voteRepository.findUnprocessedExpired(now)).willReturn(List.of());
 
             scheduler.closeExpiredVotes();
 
-            verify(voteRepository).findExpiredOngoing(now);
+            verify(voteRepository).findUnprocessedExpired(now);
         }
     }
 }


### PR DESCRIPTION
## Summary

종료된 투표에 대해 매 분 `VoteEndedEvent`가 반복 발행되며, 알림 핸들러가 `notification` 테이블을 역조회하던 비효율을 개선합니다.

스케줄러 단계에서 `ended_processed_at` 마커로 투표당 후속 처리를 한 번만 트리거합니다.

## Changes

### 1. 스케줄러 멱등성 (`vote.ended_processed_at`)
- `VoteCloseScheduler`가 `endAt < now AND ended_processed_at IS NULL`인 투표만 조회
- 이벤트 발행 전 `markEndedProcessed()`로 처리 완료 마킹 → **투표당 1회만** 후속 처리 트리거
- 배포 시 이미 종료된 투표는 마이그레이션에서 `ended_processed_at = end_at`으로 backfill

### 2. 마이그레이션 (SQL 표준 / H2 CI 호환)
- `V13__vote_ended_processed_and_notification_unique.sql`
- PostgreSQL partial index, `DELETE USING` 등 DB 전용 문법 없이 작성
- `notification` 중복 DELETE / UNIQUE 제약은 **포함하지 않음**
  - 스케줄러 마커로 중복 트리거가 방지되므로 불필요
  - 기존 `VoteEndedNotificationHandler`의 `findUserIdsByVoteIdAndType` 조회가 애플리케이션 레벨 방어 역할

### 3. 테스트
- `VoteCloseSchedulerTest`: 처리 마킹 + `findUnprocessedExpired` 검증
- `VoteTest`: `markEndedProcessed` 멱등성 검증
- `VoteRepositoryIntegrationTest`: 미처리 투표만 조회 검증
- `VoteEndedNotificationHandlerTest`: 투표 종료 알림 핸들러 단위 테스트 추가

## Before / After

| | Before | After |
|---|---|---|
| 스케줄러 | 매 분 종료 투표 전체 조회 | 미처리 종료 투표만 1회 조회 |
| 핸들러 | 매 분 notification 역조회 | 투표당 1회만 실행 |
| 중복 방지 | 핸들러 애플리케이션 필터 | 스케줄러 `ended_processed_at` 마커 + 핸들러 필터 |

## Test plan

- [x] `./gradlew unitTest --tests "com.ject.vs.vote.scheduler.VoteCloseSchedulerTest"`
- [x] `./gradlew unitTest --tests "com.ject.vs.vote.domain.VoteTest"`
- [x] `./gradlew unitTest --tests "com.ject.vs.notification.event.VoteEndedNotificationHandlerTest"`
- [x] `./gradlew integrationTest --tests "com.ject.vs.vote.domain.VoteRepositoryIntegrationTest"` (H2 Flyway 포함)