### PR TITLE
fix: 투표 종료 알림 body 정리 및 투표 기간 분 단위 옵션 추가

### DIFF
--- a/src/main/java/com/ject/vs/notification/domain/Notification.java
+++ b/src/main/java/com/ject/vs/notification/domain/Notification.java
@@ -39,7 +39,7 @@ public class Notification extends BaseEntity {
         n.type = NotificationType.VOTE_ENDED;
         n.voteId = voteId;
         n.title = "투표 결과가 공개됐어요";
-        n.body = "[" + voteTitle + "] 결과 보러가기";
+        n.body = voteTitle;
         n.thumbnailUrl = thumbnailUrl;
         n.isRead = false;
         n.createdAt = Instant.now(clock);

--- a/src/main/java/com/ject/vs/vote/domain/VoteDuration.java
+++ b/src/main/java/com/ject/vs/vote/domain/VoteDuration.java
@@ -10,6 +10,9 @@ import java.util.Arrays;
 @Getter
 @RequiredArgsConstructor
 public enum VoteDuration {
+    MINUTES_7(Duration.ofMinutes(7)),
+    MINUTES_10(Duration.ofMinutes(10)),
+    MINUTES_15(Duration.ofMinutes(15)),
     HOURS_12(Duration.ofHours(12)),
     HOURS_24(Duration.ofHours(24)),
     HOURS_72(Duration.ofHours(72));

--- a/src/unitTest/java/com/ject/vs/notification/adapter/web/NotificationControllerTest.java
+++ b/src/unitTest/java/com/ject/vs/notification/adapter/web/NotificationControllerTest.java
@@ -80,7 +80,7 @@ class NotificationControllerTest {
         void returns_notification_list() throws Exception {
             NotificationView view = new NotificationView(
                     1L, NotificationType.VOTE_ENDED, 100L,
-                    "투표 결과가 공개됐어요", "[테스트 투표] 결과 보러가기",
+                    "투표 결과가 공개됐어요", "테스트 투표",
                     "https://example.com/thumb.jpg", false, Instant.now());
             NotificationPageResult result = new NotificationPageResult(List.of(view), null, false);
 


### PR DESCRIPTION
## 📌 관련 이슈
- closes #

## 🔍 작업 내용
- 프론트 UI 시안 반영 요청에 따라 투표 종료 알림의 `body` 값을 순수 투표 제목만 내려주도록 수정했습니다.
- 투표 생성 시 선택할 수 있는 기간 옵션에 분 단위(7/10/15분)를 추가했습니다.

## 📝 변경 사항
- 알림 `body` 형식 변경
  - AS-IS: `"[투표 제목] 결과 보러가기"`
  - TO-BE: `"투표 제목"` (대괄호 및 ' 결과 보러가기' 문구 제거)
- 변경된 응답 형식에 맞춰 알림 컨트롤러 테스트 더미 데이터 정리
- `VoteDuration`에 분 단위 옵션 추가 (`MINUTES_7`, `MINUTES_10`, `MINUTES_15`)

## 💬 리뷰어에게
- 알림 `title`("투표 결과가 공개됐어요")은 별개 필드라 변경 범위에서 제외했습니다. 함께 조정이 필요한지 확인 부탁드립니다.
- 분 단위 옵션이 짧은 편이라, 스케줄러/알림 발송 주기 등 기간 의존 로직에 영향이 없는지 봐주시면 좋겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 더 짧은 투표 기간 옵션 추가 (7분, 10분, 15분)
  * 투표 종료 알림 메시지 형식 간소화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->