### PR TITLE
feat: 인앱 브라우저 구글 로그인 외부 브라우저 우회

### DIFF
--- a/src/main/java/com/ject/vs/config/InAppBrowserDetector.java
+++ b/src/main/java/com/ject/vs/config/InAppBrowserDetector.java
@@ -1,0 +1,50 @@
+package com.ject.vs.config;
+
+import java.util.regex.Pattern;
+
+/**
+ * User-Agent로 인앱 브라우저(WebView) 여부와 모바일 OS를 판별한다.
+ *
+ * <p>구글은 보안 정책상 WebView(인앱 브라우저)에서의 OAuth 로그인을 차단(disallowed_useragent, 403)하므로,
+ * 인앱 브라우저로 진입한 로그인 요청은 외부 브라우저로 우회시켜야 한다.
+ * 자세한 우회 처리는 {@link InAppBrowserRedirectFilter} 참고.
+ */
+public final class InAppBrowserDetector {
+
+    private InAppBrowserDetector() {
+    }
+
+    /**
+     * 대표적인 인앱 브라우저 UA 시그니처.
+     * <ul>
+     *     <li>{@code ; wv)} : 안드로이드 WebView 공통 마커(거의 모든 안드로이드 인앱 브라우저가 포함)</li>
+     *     <li>iOS는 WebView 공통 마커가 없어 앱별 시그니처로 판별(Instagram/Threads/카카오톡/라인/네이버 등)</li>
+     * </ul>
+     */
+    private static final Pattern IN_APP_PATTERN = Pattern.compile(
+            "; wv\\)"                                   // Android WebView 공통
+                    + "|FBAN|FBAV|FB_IAB"               // Facebook/Messenger
+                    + "|Instagram|Barcelona|Threads"    // Instagram, Threads(=Barcelona)
+                    + "|KAKAOTALK"                       // 카카오톡
+                    + "|Line/|NAVER|DaumApps|BAND"      // 라인, 네이버, 다음, 밴드
+                    + "|everytimeApp|Snapchat|Twitter|Pinterest",
+            Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern ANDROID_PATTERN = Pattern.compile("Android", Pattern.CASE_INSENSITIVE);
+    private static final Pattern IOS_PATTERN = Pattern.compile("iPhone|iPad|iPod", Pattern.CASE_INSENSITIVE);
+
+    public static boolean isInAppBrowser(String userAgent) {
+        if (userAgent == null || userAgent.isBlank()) {
+            return false;
+        }
+        return IN_APP_PATTERN.matcher(userAgent).find();
+    }
+
+    public static boolean isAndroid(String userAgent) {
+        return userAgent != null && ANDROID_PATTERN.matcher(userAgent).find();
+    }
+
+    public static boolean isIos(String userAgent) {
+        return userAgent != null && IOS_PATTERN.matcher(userAgent).find();
+    }
+}

--- a/src/main/java/com/ject/vs/config/InAppBrowserRedirectFilter.java
+++ b/src/main/java/com/ject/vs/config/InAppBrowserRedirectFilter.java
@@ -1,0 +1,150 @@
+package com.ject.vs.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * 인앱 브라우저(WebView)에서 들어온 소셜 로그인 진입 요청({@code /oauth2/authorization/**})을
+ * 외부 브라우저로 우회시킨다.
+ *
+ * <p>구글은 WebView에서의 OAuth 로그인을 차단(disallowed_useragent, 403)하므로,
+ * 인앱 브라우저로 로그인 진입 시 구글로 리다이렉트하지 않고:
+ * <ul>
+ *     <li>안드로이드: {@code intent://} 스킴으로 크롬을 강제로 띄운다.</li>
+ *     <li>iOS: WebView에서 사파리를 강제 실행할 방법이 없어, "외부 브라우저로 열기" 안내 페이지를 보여준다.</li>
+ * </ul>
+ * 외부 브라우저는 원래의 로그인 진입 URL을 그대로 다시 열어 OAuth 흐름을 새 세션에서 재시작한다.
+ *
+ * <p>Spring Security의 {@code OAuth2AuthorizationRequestRedirectFilter} 앞에 등록되어,
+ * 구글로 리다이렉트가 일어나기 전에 동작한다.
+ */
+@Slf4j
+public class InAppBrowserRedirectFilter extends OncePerRequestFilter {
+
+    private static final String OAUTH_AUTHORIZATION_PREFIX = "/oauth2/authorization/";
+    private static final String CHROME_PACKAGE = "com.android.chrome";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String uri = request.getRequestURI();
+        String userAgent = request.getHeader(HttpHeaders.USER_AGENT);
+
+        if (!uri.startsWith(OAUTH_AUTHORIZATION_PREFIX) || !InAppBrowserDetector.isInAppBrowser(userAgent)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String targetUrl = buildExternalUrl(request);
+        log.info("인앱 브라우저 로그인 우회: uri={}, android={}, ios={}",
+                uri, InAppBrowserDetector.isAndroid(userAgent), InAppBrowserDetector.isIos(userAgent));
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("text/html;charset=UTF-8");
+        response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+
+        String html = InAppBrowserDetector.isAndroid(userAgent)
+                ? androidIntentPage(targetUrl)
+                : iosGuidePage(targetUrl);
+        response.getWriter().write(html);
+    }
+
+    /** 포워딩 헤더(FRAMEWORK 전략)를 반영한 외부 접근 URL(scheme/host 포함)을 복원한다. */
+    private String buildExternalUrl(HttpServletRequest request) {
+        StringBuilder url = new StringBuilder(request.getRequestURL());
+        String queryString = request.getQueryString();
+        if (queryString != null && !queryString.isBlank()) {
+            url.append('?').append(queryString);
+        }
+        return url.toString();
+    }
+
+    /** 안드로이드: intent:// 스킴으로 크롬을 강제 실행한다. 크롬 미설치 시 마켓 폴백. */
+    private String androidIntentPage(String targetUrl) {
+        String hostPathQuery = targetUrl.replaceFirst("^https?://", "");
+        String intentUrl = "intent://" + hostPathQuery
+                + "#Intent;scheme=https;package=" + CHROME_PACKAGE + ";"
+                + "S.browser_fallback_url=" + targetUrl + ";end";
+        String safeIntentUrl = escapeJs(intentUrl);
+
+        return """
+                <!doctype html>
+                <html lang="ko">
+                <head>
+                  <meta charset="utf-8">
+                  <meta name="viewport" content="width=device-width, initial-scale=1">
+                  <title>외부 브라우저로 이동</title>
+                </head>
+                <body style="font-family:-apple-system,'Apple SD Gothic Neo',sans-serif;text-align:center;padding:40px 24px;color:#222;">
+                  <p style="font-size:16px;line-height:1.6;">크롬으로 이동 중입니다…<br>자동으로 열리지 않으면 아래 버튼을 눌러주세요.</p>
+                  <a href="%s" style="display:inline-block;margin-top:16px;padding:14px 24px;background:#1a73e8;color:#fff;border-radius:10px;text-decoration:none;font-size:16px;">크롬으로 열기</a>
+                  <script>location.href = "%s";</script>
+                </body>
+                </html>
+                """.formatted(escapeHtmlAttr(intentUrl), safeIntentUrl);
+    }
+
+    /** iOS: 사파리를 강제 실행할 수 없으므로 안내 페이지 + 주소 복사 버튼을 제공한다. */
+    private String iosGuidePage(String targetUrl) {
+        return """
+                <!doctype html>
+                <html lang="ko">
+                <head>
+                  <meta charset="utf-8">
+                  <meta name="viewport" content="width=device-width, initial-scale=1">
+                  <title>외부 브라우저에서 로그인</title>
+                </head>
+                <body style="font-family:-apple-system,'Apple SD Gothic Neo',sans-serif;padding:40px 24px;color:#222;max-width:480px;margin:0 auto;">
+                  <h2 style="font-size:20px;">외부 브라우저에서 로그인해 주세요</h2>
+                  <p style="font-size:15px;line-height:1.7;color:#444;">
+                    보안 정책상 인앱 브라우저에서는 구글 로그인이 제한됩니다.<br>
+                    아래 순서로 <b>Safari</b>에서 열어 로그인해 주세요.
+                  </p>
+                  <ol style="font-size:15px;line-height:1.9;color:#444;padding-left:20px;">
+                    <li>화면 우측 상단 또는 하단의 <b>···</b> · 공유 버튼을 누르세요.</li>
+                    <li><b>Safari로 열기</b>(기본 브라우저로 열기)를 선택하세요.</li>
+                  </ol>
+                  <div style="margin-top:20px;padding:14px;background:#f5f5f7;border-radius:10px;font-size:13px;word-break:break-all;color:#555;">%s</div>
+                  <button onclick="copyUrl()" style="display:block;width:100%%;margin-top:16px;padding:14px;background:#1a73e8;color:#fff;border:0;border-radius:10px;font-size:16px;">주소 복사하기</button>
+                  <script>
+                    var url = "%s";
+                    function copyUrl() {
+                      if (navigator.clipboard) {
+                        navigator.clipboard.writeText(url).then(showCopied, fallbackCopy);
+                      } else {
+                        fallbackCopy();
+                      }
+                    }
+                    function fallbackCopy() {
+                      var ta = document.createElement('textarea');
+                      ta.value = url; document.body.appendChild(ta); ta.select();
+                      try { document.execCommand('copy'); showCopied(); } catch (e) {}
+                      document.body.removeChild(ta);
+                    }
+                    function showCopied() { alert('주소가 복사되었습니다. Safari 주소창에 붙여넣어 주세요.'); }
+                  </script>
+                </body>
+                </html>
+                """.formatted(escapeHtml(targetUrl), escapeJs(targetUrl));
+    }
+
+    private String escapeHtml(String value) {
+        return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+
+    private String escapeHtmlAttr(String value) {
+        return escapeHtml(value).replace("\"", "&quot;");
+    }
+
+    private String escapeJs(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/src/main/java/com/ject/vs/config/SecurityConfig.java
+++ b/src/main/java/com/ject/vs/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
@@ -50,7 +51,9 @@ public class SecurityConfig {
                             response.getWriter().write("{\"code\":\"AUTH_001\",\"message\":\"인증이 필요합니다.\"}");
                         })
                 )
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                // 인앱 브라우저(WebView) 로그인 진입은 구글로 리다이렉트되기 전에 외부 브라우저로 우회시킨다.
+                .addFilterBefore(new InAppBrowserRedirectFilter(), OAuth2AuthorizationRequestRedirectFilter.class);
 
         return http.build();
     }

--- a/src/unitTest/java/com/ject/vs/config/InAppBrowserDetectorTest.java
+++ b/src/unitTest/java/com/ject/vs/config/InAppBrowserDetectorTest.java
@@ -1,0 +1,58 @@
+package com.ject.vs.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 인앱 브라우저(WebView) UA 판별 규칙 검증.
+ */
+class InAppBrowserDetectorTest {
+
+    // 실제 인앱 브라우저 UA 샘플
+    private static final String THREADS_IOS =
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 "
+                    + "(KHTML, like Gecko) Mobile/15E148 Instagram 320.0.0.0 (iPhone; iOS 17_0; en_US; Barcelona)";
+    private static final String INSTAGRAM_ANDROID =
+            "Mozilla/5.0 (Linux; Android 13; SM-S908N; wv) AppleWebKit/537.36 (KHTML, like Gecko) "
+                    + "Version/4.0 Chrome/120.0.0.0 Mobile Safari/537.36 Instagram 320.0.0.0 Android";
+    private static final String KAKAOTALK_ANDROID =
+            "Mozilla/5.0 (Linux; Android 12; wv) AppleWebKit/537.36 (KHTML, like Gecko) "
+                    + "Version/4.0 Chrome/120.0.0.0 Mobile Safari/537.36 KAKAOTALK 10.0.0";
+
+    // 정상 브라우저 UA 샘플
+    private static final String CHROME_ANDROID =
+            "Mozilla/5.0 (Linux; Android 13; SM-S908N) AppleWebKit/537.36 (KHTML, like Gecko) "
+                    + "Chrome/120.0.0.0 Mobile Safari/537.36";
+    private static final String SAFARI_IOS =
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 "
+                    + "(KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+
+    @Test
+    void 인앱_브라우저_UA는_감지된다() {
+        assertThat(InAppBrowserDetector.isInAppBrowser(THREADS_IOS)).isTrue();
+        assertThat(InAppBrowserDetector.isInAppBrowser(INSTAGRAM_ANDROID)).isTrue();
+        assertThat(InAppBrowserDetector.isInAppBrowser(KAKAOTALK_ANDROID)).isTrue();
+    }
+
+    @Test
+    void 일반_크롬과_사파리는_인앱으로_보지_않는다() {
+        assertThat(InAppBrowserDetector.isInAppBrowser(CHROME_ANDROID)).isFalse();
+        assertThat(InAppBrowserDetector.isInAppBrowser(SAFARI_IOS)).isFalse();
+    }
+
+    @Test
+    void UA가_없으면_인앱이_아니다() {
+        assertThat(InAppBrowserDetector.isInAppBrowser(null)).isFalse();
+        assertThat(InAppBrowserDetector.isInAppBrowser("")).isFalse();
+    }
+
+    @Test
+    void 안드로이드와_iOS를_구분한다() {
+        assertThat(InAppBrowserDetector.isAndroid(INSTAGRAM_ANDROID)).isTrue();
+        assertThat(InAppBrowserDetector.isIos(INSTAGRAM_ANDROID)).isFalse();
+
+        assertThat(InAppBrowserDetector.isIos(THREADS_IOS)).isTrue();
+        assertThat(InAppBrowserDetector.isAndroid(THREADS_IOS)).isFalse();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
  - closes #

  ## 🔍 작업 내용
  스레드 등 인앱 브라우저(WebView)에서 구글 로그인 시 403(`disallowed_useragent`)으로 막히는 문제를 해결했습니다.
  구글이 보안 정책상 WebView에서의 OAuth 로그인을 차단하기 때문에, 인앱 브라우저로 로그인 진입 시 외부 브라우저로 우회시킵니다.

  ## 📝 변경 사항
  - `InAppBrowserDetector` 추가: User-Agent로 인앱 브라우저 / Android / iOS 판별
    - 안드로이드 WebView 공통 마커(`; wv)`) + Threads(Barcelona)/Instagram/Facebook/카카오톡/라인/네이버/다음/밴드 등 앱 시그니처 감지
  - `InAppBrowserRedirectFilter` 추가: `/oauth2/authorization/**` 진입 요청을 가로채 외부 브라우저로 우회
    - 안드로이드: `intent://` 스킴으로 크롬 강제 실행 (크롬 미설치 시 `fallback_url`로 폴백)
    - iOS: 사파리 강제 실행이 불가능해 "외부 브라우저로 열기" 안내 페이지 + 주소 복사 제공
    - 외부 브라우저에서 같은 URL로 OAuth 흐름을 새 세션에서 재시작
  - `SecurityConfig`: `OAuth2AuthorizationRequestRedirectFilter` 앞에 필터 등록 (구글 리다이렉트 전에 동작)
  - `InAppBrowserDetectorTest` 추가: UA 판별 로직 검증

  ## 💬 리뷰어에게
  - iOS는 WebView에서 사파리를 코드로 강제 실행할 방법이 없어 안내 페이지가 한계입니다(구글 정책상 불가피한 표준 방식). 안드로이드는 자동으로 크롬이
  열립니다.
  - 필터를 `@Component` 빈이 아니라 `SecurityConfig`에서 직접 `new`로 생성했습니다. `OncePerRequestFilter`를 빈으로 등록하면 전체 서블릿 체인에도   
  중복 등록되기 때문에 시큐리티 체인에만 적용되도록 했습니다.
  - 감지 대상 앱을 추가/조정하려면 `InAppBrowserDetector`의 `IN_APP_PATTERN` 한 곳만 수정하면 됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 인앱 브라우저(WebView) 환경에서 소셜 로그인이 외부 브라우저로 자동 우회되도록 개선
  * Android에서는 Chrome을 통한 로그인 진행, iOS에서는 Safari를 통한 로그인 안내 제공

* **Tests**
  * 인앱 브라우저 감지 및 OS 판별 기능에 대한 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->