### PR TITLE
feat: 몰입형 투표 startVoteId 지원 및 Amplitude 행동 로그 연동

### DIFF
--- a/src/main/java/com/ject/vs/analytics/AmplitudeClient.java
+++ b/src/main/java/com/ject/vs/analytics/AmplitudeClient.java
@@ -1,0 +1,143 @@
+package com.ject.vs.analytics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 행동 로그를 Amplitude로도 전송하는 어댑터.
+ *
+ * <p>RDB(analytics_events) 적재·GA4 전송과 별개로, PM·디자이너가 Amplitude 대시보드에서
+ * 같은 이벤트(퍼널/리텐션 등)를 볼 수 있게 한다. 서버 사이드라 SDK가 아니라
+ * <a href="https://amplitude.com/docs/apis/analytics/http-v2">HTTP V2 API</a>(HTTP POST)로 전송한다.
+ *
+ * <p>설계 원칙({@link GoogleAnalyticsClient}와 동일):
+ * <ul>
+ *   <li><b>비즈니스에 영향 없음</b> — 모든 예외를 삼키고, 미설정 시 no-op.</li>
+ *   <li><b>요청 지연 없음</b> — 외부 HTTP라 {@code @Async}로 분리(fire-and-forget).
+ *       호출 스레드에서 필요한 값을 모두 인자로 받으므로 비동기 스레드에 요청 컨텍스트가 없어도 안전하다.</li>
+ * </ul>
+ */
+@Component
+public class AmplitudeClient {
+
+    /** 전송 실패 경고 등 내부 진단용 로거(파일 어펜더는 "analytics" 로거명 공유). */
+    private static final Logger log = LoggerFactory.getLogger("analytics");
+
+    /** Amplitude는 user_id / device_id가 최소 5자 이상이어야 이벤트를 수락한다. */
+    private static final int MIN_ID_LENGTH = 5;
+
+    private final AmplitudeProperties properties;
+    private final RestClient restClient;
+
+    public AmplitudeClient(AmplitudeProperties properties, RestClient.Builder builder) {
+        this.properties = properties;
+        // 외부망 지연이 비동기 스레드를 오래 점유하지 않도록 짧은 타임아웃을 둔다.
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout((int) Duration.ofSeconds(2).toMillis());
+        factory.setReadTimeout((int) Duration.ofSeconds(2).toMillis());
+        this.restClient = builder.requestFactory(factory).build();
+    }
+
+    @Async("analyticsExecutor")
+    public void send(String eventName, Long userId, String anonymousId, boolean member,
+                     String platform, Map<String, Object> properties) {
+        if (!this.properties.isConfigured()) {
+            return;
+        }
+        try {
+            Map<String, Object> payload = buildPayload(eventName, userId, anonymousId, member, platform, properties);
+
+            restClient.post()
+                    .uri(this.properties.endpoint())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(payload)
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            log.warn("Amplitude forwarding failed for '{}': {}", eventName, e.getMessage());
+        }
+    }
+
+    /**
+     * Amplitude HTTP V2 요청 본문을 만든다. (전송 없이 순수 변환 — 테스트 가능)
+     *
+     * <pre>{@code
+     * { "api_key": "...", "events": [ { "event_type": "...", "user_id": "...", "device_id": "...", ... } ] }
+     * }</pre>
+     */
+    Map<String, Object> buildPayload(String eventName, Long userId, String anonymousId, boolean member,
+                                     String platform, Map<String, Object> properties) {
+        Map<String, Object> event = new LinkedHashMap<>();
+        event.put("event_type", eventName);
+
+        // 회원이면 안정적인 user_id를, 비회원 쿠키가 있으면 device_id를 같이 실어
+        // 가입 전후 흐름을 한 사용자로 잇는다(Amplitude의 identity 병합).
+        if (userId != null) {
+            event.put("user_id", "uid." + userId);
+        }
+        String deviceId = resolveDeviceId(anonymousId, userId);
+        if (deviceId != null) {
+            event.put("device_id", deviceId);
+        }
+        if (platform != null) {
+            event.put("platform", platform);
+        }
+        event.put("event_properties", buildEventProperties(member, properties));
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("api_key", this.properties.apiKey());
+        payload.put("events", List.of(event));
+        return payload;
+    }
+
+    private Map<String, Object> buildEventProperties(boolean member, Map<String, Object> properties) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("is_member", member);
+        if (properties != null) {
+            properties.forEach((key, value) -> {
+                Object sanitized = sanitize(value);
+                if (sanitized != null) {
+                    result.put(key, sanitized);
+                }
+            });
+        }
+        return result;
+    }
+
+    /** null은 제외, 숫자/불리언은 그대로, 그 외는 문자열로. */
+    private Object sanitize(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number || value instanceof Boolean) {
+            return value;
+        }
+        return value.toString();
+    }
+
+    /**
+     * device_id를 정한다: 익명 쿠키(5자 이상) → 회원 id 파생값 → 랜덤 UUID 순.
+     * Amplitude는 user_id/device_id 중 하나가 5자 이상이어야 하므로, 둘 다 비는 경우를 막는다.
+     */
+    private String resolveDeviceId(String anonymousId, Long userId) {
+        if (anonymousId != null && anonymousId.length() >= MIN_ID_LENGTH) {
+            return anonymousId;
+        }
+        if (userId != null) {
+            // 회원은 user_id("uid.N")가 이미 5자 이상이므로 device_id는 굳이 채우지 않는다.
+            return null;
+        }
+        return UUID.randomUUID().toString();
+    }
+}

--- a/src/main/java/com/ject/vs/analytics/AmplitudeProperties.java
+++ b/src/main/java/com/ject/vs/analytics/AmplitudeProperties.java
@@ -1,0 +1,32 @@
+package com.ject.vs.analytics;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Amplitude HTTP V2 API 전송 설정.
+ *
+ * <p>서버 사이드에서 Amplitude로 이벤트를 보내려면 Amplitude 프로젝트의
+ * <b>API Key</b>(Settings → Projects → 해당 프로젝트의 API Key)만 있으면 된다.
+ * GA4와 달리 별도 secret은 필요 없다.
+ *
+ * <p>미설정(또는 {@code enabled=false})이면 {@link AmplitudeClient}가 no-op이 되어
+ * 로컬·테스트 환경에서 외부 호출이 발생하지 않는다. (GA4 토글과 동일한 철학)
+ */
+@ConfigurationProperties(prefix = "amplitude")
+public record AmplitudeProperties(
+        boolean enabled,
+        String apiKey,
+        String endpoint
+) {
+    public AmplitudeProperties {
+        if (endpoint == null || endpoint.isBlank()) {
+            // EU 데이터 거주가 필요하면 https://api.eu.amplitude.com/2/httpapi 로 override
+            endpoint = "https://api2.amplitude.com/2/httpapi";
+        }
+    }
+
+    /** enabled이면서 API Key가 채워졌을 때만 실제 전송한다. */
+    public boolean isConfigured() {
+        return enabled && apiKey != null && !apiKey.isBlank();
+    }
+}

--- a/src/main/java/com/ject/vs/analytics/AnalyticsEventLogger.java
+++ b/src/main/java/com/ject/vs/analytics/AnalyticsEventLogger.java
@@ -45,6 +45,7 @@ public class AnalyticsEventLogger {
     private final Clock clock;
     private final AnalyticsEventRepository analyticsEventRepository;
     private final GoogleAnalyticsClient googleAnalytics;
+    private final AmplitudeClient amplitude;
 
     public void log(AnalyticsEvent event) {
         try {
@@ -71,9 +72,10 @@ public class AnalyticsEventLogger {
                     Instant.now(clock),
                     properties));
 
-            // 같은 이벤트를 GA4로도 전송(PM·디자이너 대시보드용). 비동기 fire-and-forget이라
-            // 실패/지연이 위 RDB 적재나 요청 처리에 영향을 주지 않는다. 미설정이면 no-op.
+            // 같은 이벤트를 GA4·Amplitude로도 전송(PM·디자이너 대시보드용). 비동기 fire-and-forget이라
+            // 실패/지연이 위 RDB 적재나 요청 처리에 영향을 주지 않는다. 미설정이면 각각 no-op.
             googleAnalytics.send(event.name(), userId, anonymousId, member, platform, event.properties());
+            amplitude.send(event.name(), userId, anonymousId, member, platform, event.properties());
         } catch (Exception e) {
             // 로깅 실패가 요청 처리에 영향을 주지 않도록 흡수
             AnalyticsEventLogger.log.warn("analytics event logging failed for '{}': {}", event.name(), e.getMessage());

--- a/src/main/java/com/ject/vs/vote/adapter/web/ImmersiveVoteController.java
+++ b/src/main/java/com/ject/vs/vote/adapter/web/ImmersiveVoteController.java
@@ -106,14 +106,15 @@ public class ImmersiveVoteController {
         return response;
     }
 
-    @Operation(summary = "랜덤 다음 투표 조회", description = "excludeIds를 제외한 진행 중인 투표를 랜덤으로 조회합니다. 모든 투표 소진 시 빈 배열 반환 → 클라이언트에서 excludeIds 초기화 후 재요청 (무한 순환)")
+    @Operation(summary = "랜덤 다음 투표 조회", description = "excludeIds를 제외한 진행 중인 투표를 랜덤으로 조회합니다. 모든 투표 소진 시 빈 배열 반환 → 클라이언트에서 excludeIds 초기화 후 재요청 (무한 순환). startVoteId를 지정하면 진행 중인 해당 투표가 맨 앞에 배치되고 나머지가 랜덤으로 채워집니다.")
     @PostMapping("/next")
     public ImmersiveNextResponse getNextRandom(
             @RequestBody @Valid ImmersiveNextRequest request,
             @AuthenticationPrincipal Long userId,
             @Parameter(hidden = true) @AnonymousId String anonymousId) {
         return ImmersiveNextResponse.from(
-                immersiveVoteQueryUseCase.getNextRandom(request.excludeIds(), request.size(), userId, anonymousId)
+                immersiveVoteQueryUseCase.getNextRandom(
+                        request.excludeIds(), request.startVoteId(), request.size(), userId, anonymousId)
         );
     }
 }

--- a/src/main/java/com/ject/vs/vote/adapter/web/dto/ImmersiveNextRequest.java
+++ b/src/main/java/com/ject/vs/vote/adapter/web/dto/ImmersiveNextRequest.java
@@ -8,6 +8,8 @@ import java.util.List;
 public record ImmersiveNextRequest(
         List<Long> excludeIds,
 
+        Long startVoteId,
+
         @Min(1)
         @Max(50)
         Integer size

--- a/src/main/java/com/ject/vs/vote/port/ImmersiveVoteQueryService.java
+++ b/src/main/java/com/ject/vs/vote/port/ImmersiveVoteQueryService.java
@@ -90,20 +90,37 @@ public class ImmersiveVoteQueryService implements ImmersiveVoteQueryUseCase {
     }
 
     @Override
-    public ImmersiveNextResult getNextRandom(List<Long> excludeIds, int size, Long userId, String anonymousId) {
+    public ImmersiveNextResult getNextRandom(List<Long> excludeIds, Long startVoteId, int size, Long userId, String anonymousId) {
         Instant now = Instant.now(clock);
-        PageRequest pageable = PageRequest.of(0, size);
 
-        Slice<Vote> slice;
-        if (excludeIds == null || excludeIds.isEmpty()) {
-            slice = voteRepository.findRandom(now, pageable);
-        } else {
-            slice = voteRepository.findRandomExcluding(now, excludeIds, pageable);
+        List<Long> exclude = excludeIds == null ? new ArrayList<>() : new ArrayList<>(excludeIds);
+
+        // startVoteId가 지정되면 진행 중인 해당 투표를 맨 앞에 배치하고 나머지를 랜덤으로 채운다.
+        Vote startVote = null;
+        if (startVoteId != null && !exclude.contains(startVoteId)) {
+            Vote candidate = voteRepository.findById(startVoteId).orElse(null);
+            if (candidate != null && !candidate.isEnded(clock)) {
+                startVote = candidate;
+                exclude.add(startVoteId);
+            }
         }
 
-        List<ImmersiveFeedItem> items = slice.getContent().stream()
-                .map(v -> toFeedItem(v, userId, anonymousId))
-                .toList();
+        int remaining = startVote != null ? size - 1 : size;
+
+        List<ImmersiveFeedItem> items = new ArrayList<>();
+        if (startVote != null) {
+            items.add(toFeedItem(startVote, userId, anonymousId));
+        }
+
+        if (remaining > 0) {
+            PageRequest pageable = PageRequest.of(0, remaining);
+            Slice<Vote> slice = exclude.isEmpty()
+                    ? voteRepository.findRandom(now, pageable)
+                    : voteRepository.findRandomExcluding(now, exclude, pageable);
+            slice.getContent().stream()
+                    .map(v -> toFeedItem(v, userId, anonymousId))
+                    .forEach(items::add);
+        }
 
         return new ImmersiveNextResult(items);
     }

--- a/src/main/java/com/ject/vs/vote/port/in/ImmersiveVoteQueryUseCase.java
+++ b/src/main/java/com/ject/vs/vote/port/in/ImmersiveVoteQueryUseCase.java
@@ -14,8 +14,9 @@ public interface ImmersiveVoteQueryUseCase {
 
     /**
      * 랜덤 다음 투표 조회 (excludeIds 제외, 무한 순환)
+     * startVoteId가 지정되면 진행 중인 해당 투표를 맨 앞에 배치하고 나머지를 랜덤으로 채운다.
      */
-    ImmersiveNextResult getNextRandom(List<Long> excludeIds, int size, Long userId, String anonymousId);
+    ImmersiveNextResult getNextRandom(List<Long> excludeIds, Long startVoteId, int size, Long userId, String anonymousId);
 
     record ImmersiveFeedResult(List<ImmersiveFeedItem> items, Long nextCursor, boolean hasNext) {
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,14 @@ google:
     api-secret: ${GA_API_SECRET:}
     endpoint: ${GA_ENDPOINT:https://www.google-analytics.com/mp/collect}
 
+# Amplitude HTTP V2 API (행동 로그를 Amplitude 대시보드로도 전송 — PM/디자이너용)
+# enabled=true + API Key가 있어야 실제 전송. 없으면 no-op(RDB 적재는 그대로).
+# API Key는 Amplitude 콘솔에서 발급: Settings → Projects → 해당 프로젝트의 API Key
+amplitude:
+  enabled: ${AMPLITUDE_ENABLED:false}
+  api-key: ${AMPLITUDE_API_KEY:}
+  endpoint: ${AMPLITUDE_ENDPOINT:https://api2.amplitude.com/2/httpapi}
+
 gemini:
   project-id: ${GEMINI_PROJECT_ID:}
   # 서울(asia-northeast3)은 Gemini 모델 미지원 → us-central1 사용. GEMINI_LOCATION으로 override 가능

--- a/src/unitTest/java/com/ject/vs/analytics/AmplitudeClientTest.java
+++ b/src/unitTest/java/com/ject/vs/analytics/AmplitudeClientTest.java
@@ -1,0 +1,109 @@
+package com.ject.vs.analytics;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Amplitude HTTP V2 페이로드 변환 규칙 검증(전송 없이 순수 변환만).
+ */
+class AmplitudeClientTest {
+
+    private AmplitudeClient client() {
+        AmplitudeProperties props = new AmplitudeProperties(true, "test-key", null);
+        return new AmplitudeClient(props, RestClient.builder());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void api_key와_event_type가_담긴다() {
+        Map<String, Object> payload = client().buildPayload(
+                "landing_visited", null, "anon-uuid", false, "web", Map.of());
+
+        assertThat(payload.get("api_key")).isEqualTo("test-key");
+        Map<String, Object> event = ((List<Map<String, Object>>) payload.get("events")).get(0);
+        assertThat(event.get("event_type")).isEqualTo("landing_visited");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void 비회원은_익명쿠키를_device_id로_쓰고_user_id는_빠진다() {
+        Map<String, Object> event = firstEvent(client().buildPayload(
+                "landing_visited", null, "anon-uuid", false, "web", Map.of()));
+
+        assertThat(event).doesNotContainKey("user_id");
+        assertThat(event.get("device_id")).isEqualTo("anon-uuid");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void 회원은_uid_접두사_user_id를_쓰고_익명쿠키가_없으면_device_id는_생략된다() {
+        Map<String, Object> event = firstEvent(client().buildPayload(
+                "signup_completed", 42L, null, true, "web", Map.of()));
+
+        assertThat(event.get("user_id")).isEqualTo("uid.42");
+        assertThat(event).doesNotContainKey("device_id");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void 익명쿠키와_user_id가_모두_있으면_둘_다_실어_identity를_잇는다() {
+        Map<String, Object> event = firstEvent(client().buildPayload(
+                "signup_completed", 42L, "anon-uuid", true, "web", Map.of()));
+
+        assertThat(event.get("user_id")).isEqualTo("uid.42");
+        assertThat(event.get("device_id")).isEqualTo("anon-uuid");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void 비회원이고_익명쿠키도_없으면_5자_이상의_랜덤_device_id가_생성된다() {
+        Map<String, Object> event = firstEvent(client().buildPayload(
+                "landing_visited", null, null, false, "web", Map.of()));
+
+        assertThat(event).doesNotContainKey("user_id");
+        assertThat((String) event.get("device_id")).hasSizeGreaterThanOrEqualTo(5);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void is_member와_이벤트_속성이_event_properties에_합쳐진다() {
+        Map<String, Object> props = new LinkedHashMap<>();
+        props.put("vote_id", 123);
+        props.put("vote_status", "ONGOING");
+
+        Map<String, Object> event = firstEvent(client().buildPayload(
+                "vote_detail_viewed", 42L, "anon", true, "ios", props));
+
+        assertThat(event.get("platform")).isEqualTo("ios");
+        Map<String, Object> eventProperties = (Map<String, Object>) event.get("event_properties");
+        assertThat(eventProperties)
+                .containsEntry("is_member", true)
+                .containsEntry("vote_id", 123)
+                .containsEntry("vote_status", "ONGOING");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void null_속성은_event_properties에서_제외된다() {
+        Map<String, Object> props = new LinkedHashMap<>();
+        props.put("nullable", null);
+        props.put("kept", "value");
+
+        Map<String, Object> event = firstEvent(client().buildPayload(
+                "some_event", 1L, "anon", true, "web", props));
+
+        Map<String, Object> eventProperties = (Map<String, Object>) event.get("event_properties");
+        assertThat(eventProperties).doesNotContainKey("nullable").containsEntry("kept", "value");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> firstEvent(Map<String, Object> payload) {
+        return ((List<Map<String, Object>>) payload.get("events")).get(0);
+    }
+}

--- a/src/unitTest/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
+++ b/src/unitTest/java/com/ject/vs/vote/port/ImmersiveVoteQueryServiceTest.java
@@ -4,6 +4,7 @@ import com.ject.vs.chat.domain.ChatMessageRepository;
 import com.ject.vs.vote.domain.*;
 import com.ject.vs.vote.port.in.ImmersiveVoteQueryUseCase.ImmersiveFeedResult;
 import com.ject.vs.vote.port.in.ImmersiveVoteQueryUseCase.ImmersiveLiveResult;
+import com.ject.vs.vote.port.in.ImmersiveVoteQueryUseCase.ImmersiveNextResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -181,6 +182,77 @@ class ImmersiveVoteQueryServiceTest {
             ImmersiveFeedResult result = service.getFeed(null, null, 10, null, null);
 
             assertThat(result.items().get(0).mySelectedOptionId()).isNull();
+        }
+    }
+
+    @Nested
+    class getNextRandom {
+
+        @BeforeEach
+        void setUp() {
+            given(clock.instant()).willReturn(FIXED_CLOCK.instant());
+        }
+
+        @Test
+        void startVoteId_지정시_진행중인_해당_투표가_맨앞에_배치된다() {
+            Vote startVote = Vote.create("시작투표", null, "t", "img.png", Duration.ofHours(24), FIXED_CLOCK);
+            Vote other = makeVote(Duration.ofHours(24));
+            given(voteRepository.findById(5L)).willReturn(Optional.of(startVote));
+            given(voteRepository.findRandomExcluding(any(), eq(List.of(5L)), any()))
+                    .willReturn(new SliceImpl<>(List.of(other), PageRequest.of(0, 9), false));
+            given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
+            given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());
+            given(voteParticipationRepository.countByVoteId(any())).willReturn(0L);
+
+            ImmersiveNextResult result = service.getNextRandom(List.of(), 5L, 10, null, null);
+
+            assertThat(result.items()).hasSize(2);
+            assertThat(result.items().get(0).title()).isEqualTo("시작투표");
+        }
+
+        @Test
+        void startVoteId_없으면_기존_랜덤_조회() {
+            Vote vote = makeVote(Duration.ofHours(24));
+            given(voteRepository.findRandom(any(), any()))
+                    .willReturn(new SliceImpl<>(List.of(vote), PageRequest.of(0, 10), false));
+            given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
+            given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());
+            given(voteParticipationRepository.countByVoteId(any())).willReturn(0L);
+
+            ImmersiveNextResult result = service.getNextRandom(null, null, 10, null, null);
+
+            assertThat(result.items()).hasSize(1);
+        }
+
+        @Test
+        void startVoteId가_excludeIds에_있으면_무시하고_랜덤_조회() {
+            Vote vote = makeVote(Duration.ofHours(24));
+            given(voteRepository.findRandomExcluding(any(), eq(List.of(5L)), any()))
+                    .willReturn(new SliceImpl<>(List.of(vote), PageRequest.of(0, 10), false));
+            given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
+            given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());
+            given(voteParticipationRepository.countByVoteId(any())).willReturn(0L);
+
+            ImmersiveNextResult result = service.getNextRandom(List.of(5L), 5L, 10, null, null);
+
+            assertThat(result.items()).hasSize(1);
+        }
+
+        @Test
+        void startVoteId가_종료된_투표면_무시하고_랜덤_조회() {
+            Vote endedVote = mock(Vote.class);
+            given(endedVote.isEnded(any())).willReturn(true);
+            Vote vote = makeVote(Duration.ofHours(24));
+            given(voteRepository.findById(5L)).willReturn(Optional.of(endedVote));
+            given(voteRepository.findRandom(any(), any()))
+                    .willReturn(new SliceImpl<>(List.of(vote), PageRequest.of(0, 10), false));
+            given(voteOptionRepository.findByVoteIdOrderByPosition(any())).willReturn(List.of());
+            given(emojiReactionRepository.countByEmojiForVote(any())).willReturn(List.of());
+            given(voteParticipationRepository.countByVoteId(any())).willReturn(0L);
+
+            ImmersiveNextResult result = service.getNextRandom(List.of(), 5L, 10, null, null);
+
+            assertThat(result.items()).hasSize(1);
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- closes #

## 🔍 작업 내용
몰입형 투표 피드에서 특정 투표로 바로 이동할 수 있도록 `POST /api/immersive-votes/next`에 `startVoteId`를 추가하고, 행동 로그를 Amplitude 대시보드로도 전송하는 연동을 추가했습니다.

## 📝 변경 사항
**몰입형 투표 startVoteId 지원**
- `ImmersiveNextRequest`에 `startVoteId` 필드 추가
- `startVoteId` 지정 시 진행 중인 해당 투표를 피드 맨 앞에 배치하고 나머지를 랜덤으로 채움
- 종료/없는 투표거나 `excludeIds`에 이미 포함된 경우 무시하고 기존 랜덤 동작 유지
- Swagger 설명 갱신 및 단위 테스트 추가

**Amplitude 애널리틱스 연동**
- RDB 적재와 별개로 Amplitude HTTP V2 API로 이벤트 전송
- `amplitude.enabled=true` + API Key가 있을 때만 동작하며, 없으면 no-op (RDB 적재는 그대로)
- `AmplitudeClient`, `AmplitudeProperties` 추가 및 `application.yml` 설정 추가

## 💬 리뷰어에게
- `startVoteId`는 보통 첫 요청에만 전달되며, 이후 순환 요청에서는 `excludeIds`에 쌓여 자동으로 무시됩니다. 무한 순환 동작에는 영향이 없습니다.
- Amplitude는 기본 비활성(`enabled=false`) 상태이며, 환경변수(`AMPLITUDE_ENABLED`, `AMPLITUDE_API_KEY`) 설정 시에만 실제 전송됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 행동 로그가 Amplitude로도 전송되도록 지원이 추가되었습니다.
  * 다음 투표를 조회할 때 특정 투표를 맨 앞에 고정해 보여주는 기능이 추가되었습니다.
  * Amplitude 전송 설정(활성화, API 키, 엔드포인트)이 추가되었습니다.

* **Bug Fixes**
  * 다음 투표 조회에서 순환 재요청 흐름이 더 자연스럽게 동작하도록 개선되었습니다.
  * Amplitude 전송 시 익명/회원 식별 정보와 이벤트 속성 처리 방식이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->