### PR TITLE
feat: VoteDuration에 HOURS_96(96시간) 추가

### DIFF
--- a/src/main/java/com/ject/vs/vote/domain/VoteDuration.java
+++ b/src/main/java/com/ject/vs/vote/domain/VoteDuration.java
@@ -16,7 +16,8 @@ public enum VoteDuration {
     HOURS_12(Duration.ofHours(12)),
     HOURS_24(Duration.ofHours(24)),
     HOURS_48(Duration.ofHours(48)),
-    HOURS_72(Duration.ofHours(72));
+    HOURS_72(Duration.ofHours(72)),
+    HOURS_96(Duration.ofHours(96));
 
     private final Duration value;
 


### PR DESCRIPTION
## 📌 관련 이슈
- closes #

## 🔍 작업 내용
투표 생성 시 선택 가능한 기간에 96시간(4일) 옵션을 추가합니다.

## 📝 변경 사항
- `VoteDuration` enum에 `HOURS_96`(Duration.ofHours(96)) 추가

## 💬 리뷰어에게
- 기존 `HOURS_48` 추가와 동일한 추가(additive) 변경입니다.
- DB 마이그레이션 불필요(투표는 `duration` 컬럼이 아니라 `end_at`만 저장).
- `fromHours()`·기존 enum 값·`VoteDurationTest`에 영향 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 투표 기간 선택 항목에 96시간 옵션이 추가되었습니다.
  * 이제 72시간을 넘어 더 긴 투표 기간을 설정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->